### PR TITLE
load subapplications from the import_module function

### DIFF
--- a/oscar/core/loading.py
+++ b/oscar/core/loading.py
@@ -30,10 +30,10 @@ def import_module(module_label, classes=[], namespace=None):
     
     # Arguments will be things like 'product.models' and so we
     # we take the first component to find within the INSTALLED_APPS list.
-    app_name = module_label.split(".")[0]
+    app_name = module_label.rsplit(".", 1)[0] 
     for installed_app in settings.INSTALLED_APPS:
         base_package = installed_app.split(".")[0]
-        module_name = installed_app.split(".").pop()
+        module_name = installed_app.split(".", 2).pop() # strip oscar.apps
         try: 
             # We search the second component of the installed apps
             if app_name == module_name:


### PR DESCRIPTION
A couple of simple changes in 2 lines in the import_module function to enable imports like this:

import_module("rest.order.handlers", [...])

Before it was trying to load "rest" app in INSTALLED_APPS and not finding it because it was not matching to "rest.order". 
I think it makes sense to be able to load apps which are inside a package. "rest" in this case is not an app but just a container for other 3 apps, "order", "product" and "stock".

Another solution could be not rely on this change and make these apps separate packages, call them "rest-order", "rest-product", "rest-stock"... what's your opinion?
