### PR TITLE
Just an empty class

### DIFF
--- a/oscar/apps/partner/exceptions.py
+++ b/oscar/apps/partner/exceptions.py
@@ -1,2 +1,5 @@
 class ImportException(Exception):
     pass
+
+class CatalogueImportException(Exception):
+    pass


### PR DESCRIPTION
Lack of this class was causing following error while trying to import sample data: 

(oscar)owad@owad:~/workspace/django-oscar/examples/vanilla$ ./manage.py import_catalogue ../sample-data/books.csv 
Traceback (most recent call last):
  File "./manage.py", line 11, in <module>
    execute_manager(settings)
  File "/home/owad/.virtualenvs/oscar/lib/python2.6/site-packages/django/core/management/**init**.py", line 438, in execute_manager
    utility.execute()
  File "/home/owad/.virtualenvs/oscar/lib/python2.6/site-packages/django/core/management/**init**.py", line 379, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/owad/.virtualenvs/oscar/lib/python2.6/site-packages/django/core/management/**init**.py", line 261, in fetch_command
    klass = load_command_class(app_name, subcommand)
  File "/home/owad/.virtualenvs/oscar/lib/python2.6/site-packages/django/core/management/**init**.py", line 67, in load_command_class
    module = import_module('%s.management.commands.%s' % (app_name, name))
  File "/home/owad/.virtualenvs/oscar/lib/python2.6/site-packages/django/utils/importlib.py", line 35, in import_module
    **import**(name)
  File "/home/owad/workspace/django-oscar/oscar/apps/partner/management/commands/import_catalogue.py", line 9, in <module>
    import_module('partner.exceptions', ['CatalogueImportException'], locals())
  File "/home/owad/workspace/django-oscar/oscar/core/loading.py", line 42, in import_module
    return _import_classes_from_module("oscar.apps.%s" % module_label, classes, namespace)
  File "/home/owad/workspace/django-oscar/oscar/core/loading.py", line 80, in _import_classes_from_module
    namespace[classname] = getattr(imported_module, classname)
AttributeError: 'module' object has no attribute 'CatalogueImportException'
