### PR TITLE
Filter auto promotions using the browsable product manager

### DIFF
--- a/oscar/apps/dashboard/catalogue/forms.py
+++ b/oscar/apps/dashboard/catalogue/forms.py
@@ -112,8 +112,7 @@ class ProductForm(forms.ModelForm):
 
     def save(self, commit=True):
         object = super(ProductForm, self).save(commit)
-        if commit:
-            self.save_attributes(object)
+        self.save_attributes(object)
         return object
 
     def save_attributes(self, object):


### PR DESCRIPTION
The auto-generated promotions was using Product.objects. This resulted in them showing non-canonical products in an odd way.  This patch switches the auto-generated promotions to using Product.browsable
