### PR TITLE
Removing 'basket' for the array of raw_id_fields

### DIFF
--- a/oscar/apps/order/admin.py
+++ b/oscar/apps/order/admin.py
@@ -7,7 +7,7 @@ import_module('order.models', ['Order', 'OrderNote', 'CommunicationEvent',
                                         'PaymentEvent', 'PaymentEventType', 'LineAttribute', 'OrderDiscount'], locals())
 
 class OrderAdmin(admin.ModelAdmin):
-    raw_id_fields = ['basket','user','billing_address','shipping_address', ]
+    raw_id_fields = ['user','billing_address','shipping_address', ]
     list_display = ('number', 'total_incl_tax', 'site', 'user', 'billing_address', 'date_placed')
     readonly_fields = ('number', 'total_incl_tax', 'total_excl_tax', 'shipping_incl_tax', 'shipping_excl_tax')
 


### PR DESCRIPTION
Looks like a recent merge changed the basket foreign key in the abstract order model to a simple int field.  This broke the order admin as 'basket' was in the raw_id_fields list.

This pull request removes 'basket' from raw_id_fields.
