### PR TITLE
Installation issue for MacOSX Lion (Python 2.7.1)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 include *.rst
 recursive-include oscar/templates *.txt *.html
 recursive-include oscar/apps *.json
+recursive-include oscar/fixtures *.json
+recursive-include oscar/static *

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(name='django-oscar',
       license='BSD',
       platforms=['linux'],
       packages=find_packages(exclude=["*.tests"]),
+      include_package_data = True,
       install_requires=[
           'django>=1.3',
           'PIL',


### PR DESCRIPTION
MANIFEST.in
- now includes oscar static files
- add oscar/fixtures : in pip install case, the user does not see the distribution archive

setup.py
- adds `include_package_data = True` to the setup class (seems required for Python 2.7.1 on MacOSX 10.7 to copy files listed in the MANIFEST.in)
