### PR TITLE
Mini cleanup in test for flatpages

### DIFF
--- a/oscar/apps/dashboard/pages/tests.py
+++ b/oscar/apps/dashboard/pages/tests.py
@@ -16,10 +16,8 @@ class PageViewTests(ClientTestCase):
     def setUp(self):
         self.flatpage_1 = FlatPage.objects.create(title='title1', url='/url1/',
                                       content='some content')
-        self.flatpage_1.save()
         self.flatpage_2 = FlatPage.objects.create(title='title2', url='/url2/',
                                       content='other content')
-        self.flatpage_2.save()
 
         super(PageViewTests, self).setUp()
 


### PR DESCRIPTION
As I was a bit too quick in updating my last pull request I did not take your response to 

   https://github.com/tangentlabs/django-oscar/pull/121#r562173

into account. I just removed the two `save()` calls that are now redundant with the `objects.create()` calls in place. Just had the feeling this should be cleaned up :)
