### PR TITLE
Reformatting confirm delete to be more in line with same functionality i...

### DIFF
--- a/oscar/templates/customer/address-delete.html
+++ b/oscar/templates/customer/address-delete.html
@@ -30,13 +30,15 @@ Delete address? | {{ block.super }}
 {% endblock header %}
 
 {% block content %}
-<form action="." method="post" class="form-horizontal">
-    {% csrf_token %}
-    {% include "partials/form_fields.html" with form=form %}
-    <div class="form-actions">
-        <input type="submit" value="Delete address" class="btn btn-danger btn-large"/>
-    </div>
-</form>
+<form action="." method="post">
+	{% csrf_token %}
+	<p>Are you sure you want to delete this address?</p>
+	{{ object.summary }}
 
+	{% include "partials/form_fields.html" with form=form %}
+    	<div class="form-actions">
+		<button type="submit" value="Delete address" class="btn btn-danger btn-large">Delete</button> <a href="{% url customer:address-list %}">Cancel</a>
+	</div>
+</form>
 {% endblock content %}
 


### PR DESCRIPTION
...n checkout. Basically ignore my last pull request, this is an extension of it. Is there a reason these two delete screens use different templates?
