### PR TITLE
Removing the gradient on the fixed navbar in the dashboard. The reason f...

### DIFF
--- a/oscar/static/oscar/less/dashboard.less
+++ b/oscar/static/oscar/less/dashboard.less
@@ -37,6 +37,7 @@ body {
 }
 .subnav {
   #gradient > .vertical(#f5f5f5, #eee);
+  filter: progid:DXImageTransform.Microsoft.gradient(enabled=false) !important;
   height:36px;
   width: 100%;
 }


### PR DESCRIPTION
...or this is that the js dropdowns (from bootstrap) don't work in any version of IE if they're positioned inside a fixed position element with a MS filter CSS rule providing a background gradient.

I'm quite amazed that apparently no one noticed until now that the dashboard dropdowns don't work at all in IE.
