### PR TITLE
Removing the promotions block. The reason for this is that it's already ...

### DIFF
--- a/oscar/templates/catalogue/browse.html
+++ b/oscar/templates/catalogue/browse.html
@@ -49,11 +49,7 @@
     {% if category.description %}
     	<p>{{ category.description }}</p>
     {% endif %}
-    <div id="promotions">
-    	{% for promotion in promotions_page %}
-    	{% render_promotion promotion %}
-    	{% endfor %}
-    </div>
+
     {% if products.count %}
 		<section>
 			<div class="mod">


### PR DESCRIPTION
...on this page - as defined in layout 2 col, which it extends. Not only does this mean a duplicate div id but any content block added to this page was appearing twice - once above and once below the page content.
