### PR TITLE
get_classes fix

### DIFF
--- a/oscar/apps/dashboard/catalogue/forms.py
+++ b/oscar/apps/dashboard/catalogue/forms.py
@@ -21,7 +21,62 @@ class StockRecordForm(forms.ModelForm):
         exclude = ('product', 'num_allocated', 'price_currency')
 
 
+def _attr_text_field(attribute):
+    return forms.CharField(label=attribute.name,
+                           required=attribute.required)
+
+def _attr_integer_field(attribute):
+    return forms.IntegerField(label=attribute.name,
+                              required=attribute.required)
+
+def _attr_boolean_field(attribute):
+    return forms.BooleanField(label=attribute.name,
+                              required=attribute.required)
+
+def _attr_float_field(attribute):
+    return forms.FloatField(label=attribute.name,
+                            required=attribute.required)
+
+def _attr_date_field(attribute):
+    return forms.DateField(label=attribute.name,
+                           required=attribute.required,
+                           widget=forms.widgets.SelectDateWidget)
+
+def _attr_option_field(attribute):
+    return forms.ModelChoiceField(
+        label=attribute.name,
+        required=attribute.required,
+        queryset=attribute.option_group.options.all())
+
+def _attr_multi_option_field(attribute):
+    return forms.ModelMultipleChoiceField(
+        label=attribute.name,
+        required=attribute.required,
+        queryset=attribute.option_group.options.all())
+
+def _attr_entity_field(attribute):
+    return forms.ModelChoiceField(
+        label=attribute.name,
+        required=attribute.required,
+        queryset=attribute.entity_type.entities.all())
+
+def _attr_numeric_field(attribute):
+    return forms.FloatField(label=attribute.name,
+                            required=attribute.required)
+
 class ProductForm(forms.ModelForm):
+
+    FIELD_FACTORIES = {
+        "text": _attr_text_field,
+        "integer": _attr_integer_field,
+        "boolean": _attr_boolean_field,
+        "float": _attr_float_field,
+        "date": _attr_date_field,
+        "option": _attr_option_field,
+        "multi_option" : _attr_multi_option_field,
+        "entity": _attr_entity_field,
+        "numeric" : _attr_numeric_field,
+    }
 
     def __init__(self, product_class, *args, **kwargs):
         self.product_class = product_class
@@ -42,60 +97,6 @@ class ProductForm(forms.ModelForm):
             else:
                 kwargs['initial']['attr_%s' % attribute.code] = value
 
-    def _attr_text_field(self, attribute):
-        return forms.CharField(label=attribute.name,
-                               required=attribute.required)
-
-    def _attr_integer_field(self, attribute):
-        return forms.IntegerField(label=attribute.name,
-                                  required=attribute.required)
-
-    def _attr_boolean_field(self, attribute):
-        return forms.BooleanField(label=attribute.name,
-                                  required=attribute.required)
-
-    def _attr_float_field(self, attribute):
-        return forms.FloatField(label=attribute.name,
-                                required=attribute.required)
-
-    def _attr_date_field(self, attribute):
-        return forms.DateField(label=attribute.name,
-                               required=attribute.required,
-                               widget=forms.widgets.SelectDateWidget)
-
-    def _attr_option_field(self, attribute):
-        return forms.ModelChoiceField(
-            label=attribute.name,
-            required=attribute.required,
-            queryset=attribute.option_group.options.all())
-
-    def _attr_multi_option_field(self, attribute):
-        return forms.ModelMultipleChoiceField(
-            label=attribute.name,
-            required=attribute.required,
-            queryset=attribute.option_group.options.all())
-
-    def _attr_entity_field(self, attribute):
-        return forms.ModelChoiceField(
-            label=attribute.name,
-            required=attribute.required,
-            queryset=attribute.entity_type.entities.all())
-
-    def _attr_numeric_field(self, attribute):
-        return forms.FloatField(label=attribute.name,
-                                required=attribute.required)
-
-    FIELD_FACTORIES = {
-        "text": _attr_text_field,
-        "integer": _attr_integer_field,
-        "boolean": _attr_boolean_field,
-        "float": _attr_float_field,
-        "date": _attr_date_field,
-        "option": _attr_option_field,
-        "multi_option" : _attr_multi_option_field,
-        "entity": _attr_entity_field,
-        "numeric" : _attr_numeric_field,
-    }
 
     def add_attribute_fields(self):
         for attribute in self.product_class.attributes.all():
@@ -103,7 +104,7 @@ class ProductForm(forms.ModelForm):
                     self.get_attribute_field(attribute)
 
     def get_attribute_field(self, attribute):
-        return self.FIELD_FACTORIES[attribute.type](self, attribute)
+        return self.FIELD_FACTORIES[attribute.type](attribute)
 
     class Meta:
         model = Product

--- a/oscar/core/loading.py
+++ b/oscar/core/loading.py
@@ -20,14 +20,14 @@ def get_class(module_label, classname):
 def get_classes(module_label, classnames):
     """
     For dynamically importing classes from a module.
-    
+
     Eg. calling get_classes('catalogue.models', ['Product']) will search
     INSTALLED_APPS for the relevant product app (default is
     'oscar.apps.catalogue') and then import the classes from there.  If the
     class can't be found in the overriding module, then we attempt to import it
-    from within oscar.  
-    
-    This is very similar to django.db.models.get_model although that is only 
+    from within oscar.
+
+    This is very similar to django.db.models.get_model although that is only
     for loading models while this method will load any class.
     """
     app_module_path = _get_app_module_path(module_label)
@@ -44,7 +44,7 @@ def get_classes(module_label, classnames):
     # App must be local - check if module is in local app (it could be in
     # oscar's)
     app_label = module_label.split('.')[0]
-    base_package = app_module_path.replace('.'+app_label, '')
+    base_package = app_module_path.rsplit('.'+app_label, 1)[0]
     local_app = "%s.%s" % (base_package, module_label)
     try:
         imported_local_module = __import__(local_app, fromlist=classnames)
@@ -74,7 +74,7 @@ def _pluck_classes(modules, classnames):
 
 
 def _get_app_module_path(module_label):
-    app_name = module_label.rsplit(".", 1)[0] 
+    app_name = module_label.rsplit(".", 1)[0]
     for installed_app in settings.INSTALLED_APPS:
         if installed_app.endswith(app_name):
             return installed_app
@@ -90,7 +90,7 @@ def import_module(module_label, classes, namespace=None):
         for classname, klass in zip(classes, klasses):
             namespace[classname] = klass
     else:
-        module = new_module("oscar.apps.%s" % module_label)   
+        module = new_module("oscar.apps.%s" % module_label)
         for classname, klass in zip(classes, klasses):
             setattr(module, classname, klass)
         return module


### PR DESCRIPTION
Didn't work with longer application paths like project_name.dashboard.catalogue.
Also changed attribute types to form fields mapping methods (they wasn't real methods - direct passing 'self' proofs that) into functions.
