### PR TITLE
Allow "Add to basket" form override on product listing view (without need to override entire product.html)

### DIFF
--- a/oscar/templates/catalogue/partials/add_to_basket_form_compact.html
+++ b/oscar/templates/catalogue/partials/add_to_basket_form_compact.html
@@ -1,0 +1,8 @@
+{% load basket_tags %}
+
+{% basket_form basket product as basket_form single %}
+<form action="{% url basket:add %}" method="post">
+    {% csrf_token %}
+    {{ basket_form.as_p }}
+    <input type="submit" class="btn btn-primary" value="Add to basket" />
+</form>

--- a/oscar/templates/catalogue/partials/product.html
+++ b/oscar/templates/catalogue/partials/product.html
@@ -1,5 +1,4 @@
 {% load currency_filters %}
-{% load basket_tags %}
 {% load thumbnail %}
 
 <article class="product_pod">
@@ -39,11 +38,6 @@
             <p class="app-ico avaliability outofstock">Not available</p>
         {% endif %}
 
-        {% basket_form basket product as basket_form single %}
-        <form action="{% url basket:add %}" method="post">
-            {% csrf_token %}
-            {{ basket_form.as_p }}
-            <input type="submit" class="btn btn-primary" value="Add to basket" />
-        </form>
-    </div>
+        {% include "catalogue/partials/add_to_basket_form_compact.html" %}
+   </div>
 </article>


### PR DESCRIPTION
The templates/catalogue/partials/product.html now includes the external add_to_basket_form_compact.html partial, to allow override of only that part of the product listing display by Oscar implementations.
