### PR TITLE
removed leftover code fragment from oscar package __init__.py

### DIFF
--- a/oscar/__init__.py
+++ b/oscar/__init__.py
@@ -76,9 +76,3 @@ def get_core_apps(overrides=None):
     for app_label in OSCAR_CORE_APPS:
         apps.append(get_app_label(app_label, overrides))
     return apps
-
-
-
-
-
-    return OSCAR_CORE_APPS


### PR DESCRIPTION
I just found a little line of code that seems like it should have been removed during a rewrite of the `get_core_apps` method. I cleaned it up but didn't want to mix it up with some other commit. Hope that's alright. 
