### PR TITLE
Fix absolute benefit

### DIFF
--- a/oscar/apps/offer/models.py
+++ b/oscar/apps/offer/models.py
@@ -22,14 +22,14 @@ class ConditionalOffer(models.Model):
     description = models.TextField(blank=True, null=True)
 
     # Offers come in a few different types:
-    # (a) Offers that are available to all customers on the site.  Eg a 
+    # (a) Offers that are available to all customers on the site.  Eg a
     #     3-for-2 offer.
     # (b) Offers that are linked to a voucher, and only become available once
     #     that voucher has been applied to the basket
     # (c) Offers that are linked to a user.  Eg, all students get 10% off.  The code
     #     to apply this offer needs to be coded
-    # (d) Session offers - these are temporarily available to a user after some trigger 
-    #     event.  Eg, users coming from some affiliate site get 10% off.     
+    # (d) Session offers - these are temporarily available to a user after some trigger
+    #     event.  Eg, users coming from some affiliate site get 10% off.
     TYPE_CHOICES = (
         (SITE, "Site offer - available to all users"),
         (VOUCHER, "Voucher offer - only available after entering the appropriate voucher code"),
@@ -42,7 +42,7 @@ class ConditionalOffer(models.Model):
     benefit = models.ForeignKey('offer.Benefit')
 
     # Range of availability.  Note that if this is a voucher offer, then these
-    # dates are ignored and only the dates from the voucher are used to determine 
+    # dates are ignored and only the dates from the voucher are used to determine
     # availability.
     start_date = models.DateField(blank=True, null=True)
     end_date = models.DateField(blank=True, null=True)
@@ -52,7 +52,7 @@ class ConditionalOffer(models.Model):
 
     # We track some information on usage
     total_discount = models.DecimalField(decimal_places=2, max_digits=12, default=Decimal('0.00'))
-    
+
     date_created = models.DateTimeField(auto_now_add=True)
 
     objects = models.Manager()
@@ -65,22 +65,22 @@ class ConditionalOffer(models.Model):
 
     class Meta:
         ordering = ['-priority']
-        
+
     def __unicode__(self):
-        return self.name    
+        return self.name
 
     def clean(self):
         if self.start_date and self.end_date and self.start_date > self.end_date:
             raise exceptions.ValidationError('End date should be later than start date')
-        
+
     def is_active(self, test_date=None):
         if not test_date:
             test_date = datetime.date.today()
         return self.start_date <= test_date and test_date < self.end_date
-    
+
     def is_condition_satisfied(self, basket):
         return self._proxy_condition().is_satisfied(basket)
-        
+
     def apply_benefit(self, basket):
         u"""
         Applies the benefit to the given basket and returns the discount.
@@ -88,13 +88,13 @@ class ConditionalOffer(models.Model):
         if not self.is_condition_satisfied(basket):
             return Decimal('0.00')
         return self._proxy_benefit().apply(basket, self._proxy_condition())
-        
+
     def set_voucher(self, voucher):
         self._voucher = voucher
-        
+
     def get_voucher(self):
-        return self._voucher        
-        
+        return self._voucher
+
     def _proxy_condition(self):
         u"""
         Returns the appropriate proxy model for the condition
@@ -109,7 +109,7 @@ class ConditionalOffer(models.Model):
         elif self.condition.type == self.condition.COVERAGE:
             return CoverageCondition(**field_dict)
         return self.condition
-    
+
     def _proxy_benefit(self):
         u"""
         Returns the appropriate proxy model for the condition
@@ -126,7 +126,7 @@ class ConditionalOffer(models.Model):
         elif self.benefit.type == self.benefit.FIXED_PRICE:
             return FixedPriceBenefit(**field_dict)
         return self.benefit
-        
+
 
 class Condition(models.Model):
     COUNT, VALUE, COVERAGE = ("Count", "Value", "Coverage")
@@ -145,10 +145,10 @@ class Condition(models.Model):
         elif self.type == self.COVERAGE:
             return u"Basket includes %d distinct products from %s" % (self.value, unicode(self.range).lower())
         return u"Basket includes %d value from %s" % (self.value, unicode(self.range).lower())
-    
+
     def consume_items(self, basket, lines=None):
         return ()
-    
+
     def is_satisfied(self, basket):
         """
         Determines whether a given basket meets this condition.  This is
@@ -156,7 +156,7 @@ class Condition(models.Model):
         responsible for implementing it correctly.
         """
         return False
-    
+
 
 class Benefit(models.Model):
     PERCENTAGE, FIXED, MULTIBUY, FIXED_PRICE = ("Percentage", "Absolute", "Multibuy", "Fixed price")
@@ -173,11 +173,11 @@ class Benefit(models.Model):
 
     price_field = 'price_incl_tax'
 
-    # If this is not set, then there is no upper limit on how many products 
+    # If this is not set, then there is no upper limit on how many products
     # can be discounted by this benefit.
     max_affected_items = models.PositiveIntegerField(blank=True, null=True, help_text="""Set this
         to prevent the discount consuming all items within the range that are in the basket.""")
-    
+
     def __unicode__(self):
         if self.type == self.PERCENTAGE:
             desc = u"%s%% discount on %s" % (self.value, unicode(self.range).lower())
@@ -192,10 +192,10 @@ class Benefit(models.Model):
         elif self.max_affected_items > 1:
             desc += u" (max %d items)" % self.max_affected_items
         return desc
-    
+
     def apply(self, basket, condition=None):
         return Decimal('0.00')
-    
+
     def clean(self):
         if self.value is None:
             if not self.type:
@@ -234,14 +234,14 @@ class Range(models.Model):
     excluded_products = models.ManyToManyField('catalogue.Product', related_name='excludes', blank=True)
     classes = models.ManyToManyField('catalogue.ProductClass', related_name='classes', blank=True)
     included_categories = models.ManyToManyField('catalogue.Category', related_name='includes', blank=True)
-    
+
     __included_product_ids = None
     __excluded_product_ids = None
     __class_ids = None
 
     def __unicode__(self):
-        return self.name    
-        
+        return self.name
+
     def contains_product(self, product):
         """
         Check whether the passed product is part of this range
@@ -258,33 +258,33 @@ class Range(models.Model):
         if self.includes_all_products:
             return True
         if product.product_class_id in self._class_ids():
-            return True   
+            return True
         included_product_ids = self._included_product_ids()
         if product.id in included_product_ids:
             return True
-        test_categories = self.included_categories.all() 
+        test_categories = self.included_categories.all()
         if test_categories:
             for category in product.categories.all():
                 for test_category in test_categories:
                     if category == test_category or category.is_descendant_of(test_category):
                         return True
         return False
-    
+
     def _included_product_ids(self):
         if None == self.__included_product_ids:
             self.__included_product_ids = [row['id'] for row in self.included_products.values('id')]
         return self.__included_product_ids
-    
+
     def _excluded_product_ids(self):
         if None == self.__excluded_product_ids:
             self.__excluded_product_ids = [row['id'] for row in self.excluded_products.values('id')]
         return self.__excluded_product_ids
-    
+
     def _class_ids(self):
         if None == self.__class_ids:
             self.__class_ids = [row['id'] for row in self.classes.values('id')]
         return self.__class_ids
-        
+
 
 class CountCondition(Condition):
     """
@@ -305,7 +305,7 @@ class CountCondition(Condition):
             if num_matches >= self.value:
                 return True
         return False
-    
+
     def consume_items(self, basket, lines=None, value=None):
         """
         Marks items within the basket lines as consumed so they
@@ -323,8 +323,8 @@ class CountCondition(Condition):
             if len(consumed_products) == value:
                 break
         return consumed_products
-        
-        
+
+
 class CoverageCondition(Condition):
     """
     An offer condition dependent on the NUMBER of matching items from the basket.
@@ -346,7 +346,7 @@ class CoverageCondition(Condition):
             if len(covered_ids) >= self.value:
                 return True
         return False
-    
+
     def consume_items(self, basket, lines=None, value=None):
         """
         Marks items within the basket lines as consumed so they
@@ -364,7 +364,7 @@ class CoverageCondition(Condition):
             if len(consumed_products) >= value:
                 break
         return consumed_products
-    
+
     def get_value_of_satisfying_items(self, basket):
         covered_ids = []
         value = Decimal('0.00')
@@ -375,8 +375,8 @@ class CoverageCondition(Condition):
             if len(covered_ids) >= self.value:
                 return value
         return value
-        
-        
+
+
 class ValueCondition(Condition):
     """
     An offer condition dependent on the VALUE of matching items from the basket.
@@ -397,12 +397,12 @@ class ValueCondition(Condition):
             if value_of_matches >= self.value:
                 return True
         return False
-    
+
     def consume_items(self, basket, lines=None, value=None):
         """
         Marks items within the basket lines as consumed so they
         can't be reused in other offers.
-        
+
         We allow lines to be passed in as sometimes we want them sorted
         in a specific order.
         """
@@ -417,11 +417,11 @@ class ValueCondition(Condition):
                 if not price:
                     continue
                 quantity_to_consume = min(line.quantity_without_discount,
-                                          int(((value - value_of_matches)/price).quantize(Decimal(1),
+                                          int(((value - value_of_matches) / price).quantize(Decimal(1),
                                                                                               ROUND_UP)))
                 value_of_matches += price * quantity_to_consume
                 line.consume(quantity_to_consume)
-                consumed_products.extend((line.product,)*int(quantity_to_consume))
+                consumed_products.extend((line.product,) * int(quantity_to_consume))
             if value_of_matches >= value:
                 break
         return consumed_products
@@ -442,20 +442,20 @@ class PercentageDiscountBenefit(Benefit):
         discount = Decimal('0.00')
         affected_items = 0
         max_affected_items = self._effective_max_affected_items()
-        
+
         for line in basket.all_lines():
             if affected_items >= max_affected_items:
                 break
             product = line.product
             if self.range.contains_product(product) and product.has_stockrecord:
                 price = getattr(product.stockrecord, self.price_field)
-                quantity = min(line.quantity_without_discount, 
+                quantity = min(line.quantity_without_discount,
                                max_affected_items - affected_items)
-                line_discount = self.round(self.value/100 * price * int(quantity))
+                line_discount = self.round(self.value / 100 * price * int(quantity))
                 line.discount(line_discount, quantity)
                 affected_items += quantity
                 discount += line_discount
-                
+
         if discount > 0 and condition:
             condition.consume_items(basket)
         return discount
@@ -473,7 +473,7 @@ class AbsoluteDiscountBenefit(Benefit):
         discount = Decimal('0.00')
         affected_items = 0
         max_affected_items = self._effective_max_affected_items()
-        
+
         for line in basket.all_lines():
             if affected_items >= max_affected_items:
                 break
@@ -484,32 +484,33 @@ class AbsoluteDiscountBenefit(Benefit):
                     # Avoid zero price products
                     continue
                 remaining_discount = self.value - discount
-                quantity_affected = int(min(line.quantity_without_discount, 
+                quantity_affected = int(min(line.quantity_without_discount,
                                         max_affected_items - affected_items,
                                         math.ceil(remaining_discount / price)))
-                
+
                 # Update line with discounts
                 line_discount = self.round(min(remaining_discount, quantity_affected * price))
-                line.discount(line_discount, quantity_affected)
-                
+                if not condition:
+                    line.discount(line_discount, quantity_affected)
+
                 # Update loop vars
                 affected_items += quantity_affected
                 remaining_discount -= line_discount
                 discount += line_discount
         if discount > 0 and condition:
             condition.consume_items(basket)
-            
+
         return discount
 
 
 class FixedPriceBenefit(Benefit):
     """
-    An offer benefit that gives the items in the condition for a 
+    An offer benefit that gives the items in the condition for a
     fixed price.  This is useful for "bundle" offers.
-    
+
     Note that we ignore the benefit range here and only give a fixed price
     for the products in the condition range.
-    
+
     The condition should be a count condition
     """
     class Meta:
@@ -523,22 +524,22 @@ class FixedPriceBenefit(Benefit):
         for line in basket.all_lines():
             product = line.product
             if condition.range.contains_product(product) and line.quantity_without_discount > 0:
-                # Line is available - determine quantity to consume and 
+                # Line is available - determine quantity to consume and
                 # record the total of the consumed products
                 if isinstance(condition, CoverageCondition):
                     quantity = 1
                 else:
                     quantity = min(line.quantity_without_discount, num_permitted - num_covered)
                 num_covered += quantity
-                product_total += quantity*line.unit_price_incl_tax
+                product_total += quantity * line.unit_price_incl_tax
                 covered_lines.append((line, quantity))
             if num_covered >= num_permitted:
                 break
         discount = max(product_total - self.value, Decimal('0.00'))
-        
+
         if not discount:
             return discount
-        
+
         # Apply discount weighted by original value of line
         discount_applied = Decimal('0.00')
         last_line = covered_lines[-1][0]
@@ -551,13 +552,13 @@ class FixedPriceBenefit(Benefit):
                 line_discount = self.round(discount * (line.unit_price_incl_tax * quantity) / product_total)
             line.discount(line_discount, quantity)
             discount_applied += line_discount
-        return discount 
-        
+        return discount
+
         # Apply discount weighted by original value of line
         for line, quantity in covered_lines:
-            line_discount = self.round(discount * (line.unit_price_incl_tax * quantity) / product_total)  
+            line_discount = self.round(discount * (line.unit_price_incl_tax * quantity) / product_total)
             line.discount(line_discount.quantize(Decimal('.01')), quantity)
-        return discount 
+        return discount
 
 
 class MultibuyDiscountBenefit(Benefit):

--- a/oscar/apps/offer/tests.py
+++ b/oscar/apps/offer/tests.py
@@ -37,40 +37,40 @@ class WholeSiteRangeWithGlobalBlacklistTest(TestCase):
 
 
 class WholeSiteRangeTest(TestCase):
-    
+
     def setUp(self):
         self.range = Range.objects.create(name="All products", includes_all_products=True)
         self.prod = create_product()
-    
+
     def test_all_products_range(self):
         self.assertTrue(self.range.contains_product(self.prod))
-        
+
     def test_all_products_range_with_exception(self):
         self.range.excluded_products.add(self.prod)
         self.assertFalse(self.range.contains_product(self.prod))
-        
+
     def test_whitelisting(self):
         self.range.included_products.add(self.prod)
         self.assertTrue(self.range.contains_product(self.prod))
-        
+
     def test_blacklisting(self):
         self.range.excluded_products.add(self.prod)
         self.assertFalse(self.range.contains_product(self.prod))
-        
+
 
 class PartialRangeTest(TestCase):
-    
+
     def setUp(self):
         self.range = Range.objects.create(name="All products", includes_all_products=False)
         self.prod = create_product()
 
     def test_empty_list(self):
         self.assertFalse(self.range.contains_product(self.prod))
-        
+
     def test_included_classes(self):
         self.range.classes.add(self.prod.product_class)
         self.assertTrue(self.range.contains_product(self.prod))
-        
+
     def test_included_class_with_exception(self):
         self.range.classes.add(self.prod.product_class)
         self.range.excluded_products.add(self.prod)
@@ -84,18 +84,18 @@ class OfferTest(TestCase):
 
 
 class CountConditionTest(OfferTest):
-    
+
     def setUp(self):
         super(CountConditionTest, self).setUp()
         self.cond = CountCondition(range=self.range, type="Count", value=2)
-    
+
     def test_empty_basket_fails_condition(self):
         self.assertFalse(self.cond.is_satisfied(self.basket))
-        
+
     def test_matching_quantity_basket_passes_condition(self):
         self.basket.add_product(create_product(), 2)
         self.assertTrue(self.cond.is_satisfied(self.basket))
-        
+
     def test_greater_quantity_basket_passes_condition(self):
         self.basket.add_product(create_product(), 3)
         self.assertTrue(self.cond.is_satisfied(self.basket))
@@ -104,12 +104,12 @@ class CountConditionTest(OfferTest):
         self.basket.add_product(create_product(), 3)
         self.cond.consume_items(self.basket)
         self.assertEquals(1, self.basket.all_lines()[0].quantity_without_discount)
-        
+
     def test_is_satisfied_accounts_for_consumed_items(self):
         self.basket.add_product(create_product(), 3)
         self.cond.consume_items(self.basket)
         self.assertFalse(self.cond.is_satisfied(self.basket))
-        
+
     def test_count_condition_is_applied_multpile_times(self):
         benefit = AbsoluteDiscountBenefit(range=self.range, type="Absolute", value=Decimal('10.00'))
         for i in range(10):
@@ -119,33 +119,33 @@ class CountConditionTest(OfferTest):
 
         first_discount = benefit.apply(self.basket, condition=condition)
         self.assertEquals(Decimal('10.00'), first_discount)
-        
+
         second_discount = benefit.apply(self.basket, condition=condition)
         self.assertEquals(Decimal('10.00'), second_discount)
 
-    
+
 class ValueConditionTest(OfferTest):
     def setUp(self):
         super(ValueConditionTest, self).setUp()
         self.cond = ValueCondition(range=self.range, type="Value", value=Decimal('10.00'))
         self.item = create_product(price=Decimal('5.00'))
         self.expensive_item = create_product(price=Decimal('15.00'))
-    
+
     def test_empty_basket_fails_condition(self):
         self.assertFalse(self.cond.is_satisfied(self.basket))
-        
+
     def test_less_value_basket_fails_condition(self):
         self.basket.add_product(self.item, 1)
-        self.assertFalse(self.cond.is_satisfied(self.basket))    
-        
+        self.assertFalse(self.cond.is_satisfied(self.basket))
+
     def test_matching_basket_passes_condition(self):
         self.basket.add_product(self.item, 2)
-        self.assertTrue(self.cond.is_satisfied(self.basket))   
-        
+        self.assertTrue(self.cond.is_satisfied(self.basket))
+
     def test_greater_than_basket_passes_condition(self):
         self.basket.add_product(self.item, 3)
-        self.assertTrue(self.cond.is_satisfied(self.basket)) 
-        
+        self.assertTrue(self.cond.is_satisfied(self.basket))
+
     def test_consumption(self):
         self.basket.add_product(self.item, 3)
         self.cond.consume_items(self.basket)
@@ -155,71 +155,71 @@ class ValueConditionTest(OfferTest):
         self.basket.add_product(self.expensive_item, 1)
         self.cond.consume_items(self.basket)
         self.assertEquals(0, self.basket.all_lines()[0].quantity_without_discount)
-        
+
     def test_is_consumed_respects_quantity_consumed(self):
         self.basket.add_product(self.expensive_item, 1)
         self.assertTrue(self.cond.is_satisfied(self.basket))
         self.cond.consume_items(self.basket)
         self.assertFalse(self.cond.is_satisfied(self.basket))
 
-      
+
 class CoverageConditionTest(TestCase):
-    
+
     def setUp(self):
         self.products = [create_product(Decimal('5.00')), create_product(Decimal('10.00'))]
         self.range = Range.objects.create(name="Some products")
         for product in self.products:
             self.range.included_products.add(product)
             self.range.included_products.add(product)
-            
+
         self.basket = Basket.objects.create()
         self.cond = CoverageCondition(range=self.range, type="Coverage", value=2)
-    
+
     def test_empty_basket_fails(self):
         self.assertFalse(self.cond.is_satisfied(self.basket))
-        
+
     def test_single_item_fails(self):
         self.basket.add_product(self.products[0])
         self.assertFalse(self.cond.is_satisfied(self.basket))
-        
+
     def test_duplicate_item_fails(self):
         self.basket.add_product(self.products[0])
         self.basket.add_product(self.products[0])
-        self.assertFalse(self.cond.is_satisfied(self.basket))  
-        
+        self.assertFalse(self.cond.is_satisfied(self.basket))
+
     def test_covering_items_pass(self):
         self.basket.add_product(self.products[0])
         self.basket.add_product(self.products[1])
         self.assertTrue(self.cond.is_satisfied(self.basket))
-        
+
     def test_covering_items_are_consumed(self):
         self.basket.add_product(self.products[0])
         self.basket.add_product(self.products[1])
         self.cond.consume_items(self.basket)
         self.assertEquals(0, self.basket.num_items_without_discount)
-        
+
     def test_consumed_items_checks_affected_items(self):
         # Create new offer
         range = Range.objects.create(name="All products", includes_all_products=True)
         cond = CoverageCondition(range=range, type="Coverage", value=2)
-        
+
         # Get 4 distinct products in the basket
         self.products.extend([create_product(Decimal('15.00')), create_product(Decimal('20.00'))])
 
-        for product in self.products:        
+        for product in self.products:
             self.basket.add_product(product)
-        
-        self.assertTrue(cond.is_satisfied(self.basket))    
+
+        self.assertTrue(cond.is_satisfied(self.basket))
         cond.consume_items(self.basket)
-        self.assertEquals(2, self.basket.num_items_without_discount) 
-        
-        self.assertTrue(cond.is_satisfied(self.basket))    
+        self.assertEquals(2, self.basket.num_items_without_discount)
+
+        self.assertTrue(cond.is_satisfied(self.basket))
         cond.consume_items(self.basket)
-        self.assertEquals(0, self.basket.num_items_without_discount) 
-        
-        
+        self.assertEquals(0, self.basket.num_items_without_discount)
+
+
 class PercentageDiscountBenefitTest(OfferTest):
-    
+
     def setUp(self):
         super(PercentageDiscountBenefitTest, self).setUp()
         self.benefit = PercentageDiscountBenefit(range=self.range, type="Percentage", value=Decimal('15.00'))
@@ -232,38 +232,38 @@ class PercentageDiscountBenefitTest(OfferTest):
         super(PercentageDiscountBenefitTest, self).tearDown()
         if self.original_offer_rounding_function is not None:
             settings.OSCAR_OFFER_ROUNDING_FUNCTION = self.original_offer_rounding_function
-    
+
     def test_no_discount_for_empty_basket(self):
         self.assertEquals(Decimal('0.00'), self.benefit.apply(self.basket))
-        
+
     def test_discount_for_single_item_basket(self):
         self.basket.add_product(self.item, 1)
         self.assertEquals(Decimal('0.15') * Decimal('5.00'), self.benefit.apply(self.basket))
-        
+
     def test_discount_for_multi_item_basket(self):
         self.basket.add_product(self.item, 3)
         self.assertEquals(Decimal('3') * Decimal('0.15') * Decimal('5.00'), self.benefit.apply(self.basket))
-        
+
     def test_discount_for_multi_item_basket_with_max_affected_items_set(self):
         self.basket.add_product(self.item, 3)
         self.benefit.max_affected_items = 1
         self.assertEquals(Decimal('0.15') * Decimal('5.00'), self.benefit.apply(self.basket))
-        
+
     def test_discount_can_only_be_applied_once(self):
         self.basket.add_product(self.item, 3)
-        first_discount = self.benefit.apply(self.basket)
+        self.benefit.apply(self.basket)
         second_discount = self.benefit.apply(self.basket)
         self.assertEquals(Decimal('0.00'), second_discount)
-        
+
     def test_discount_can_be_applied_several_times_when_max_is_set(self):
         self.basket.add_product(self.item, 3)
         self.benefit.max_affected_items = 1
         for i in range(1, 4):
             self.assertTrue(self.benefit.apply(self.basket) > 0)
-        
-        
+
+
 class AbsoluteDiscountBenefitTest(OfferTest):
-    
+
     def setUp(self):
         super(AbsoluteDiscountBenefitTest, self).setUp()
         self.benefit = AbsoluteDiscountBenefit(range=self.range, type="Absolute", value=Decimal('10.00'))
@@ -276,18 +276,18 @@ class AbsoluteDiscountBenefitTest(OfferTest):
         super(AbsoluteDiscountBenefitTest, self).tearDown()
         if self.original_offer_rounding_function is not None:
             settings.OSCAR_OFFER_ROUNDING_FUNCTION = self.original_offer_rounding_function
-    
+
     def test_no_discount_for_empty_basket(self):
         self.assertEquals(Decimal('0.00'), self.benefit.apply(self.basket))
-        
+
     def test_discount_for_single_item_basket(self):
         self.basket.add_product(self.item, 1)
         self.assertEquals(Decimal('5.00'), self.benefit.apply(self.basket))
-        
+
     def test_discount_for_multi_item_basket(self):
         self.basket.add_product(self.item, 3)
         self.assertEquals(Decimal('10.00'), self.benefit.apply(self.basket))
-        
+
     def test_discount_for_multi_item_basket_with_max_affected_items_set(self):
         self.basket.add_product(self.item, 3)
         self.benefit.max_affected_items = 1
@@ -298,51 +298,67 @@ class AbsoluteDiscountBenefitTest(OfferTest):
         self.basket.add_product(self.item, 3)
         first_discount = self.benefit.apply(self.basket)
         self.assertEquals(Decimal('10.00'), first_discount)
-        
+
         second_discount = self.benefit.apply(self.basket)
         self.assertEquals(Decimal('5.00'), second_discount)
-        
-        
+
+    def test_absolute_does_not_consume_twice(self):
+        product = create_product(Decimal('25000'))
+        rng = Range.objects.create(name='Dummy')
+        rng.included_products.add(product)
+        condition = ValueCondition(range=rng, type='Value', value=Decimal('5000'))
+        basket = Basket.objects.create()
+        basket.add_product(product, 5)
+        benefit = AbsoluteDiscountBenefit(range=rng, type='Absolute', value=Decimal('100'))
+        self.assertTrue(condition.is_satisfied(basket))
+        self.assertEquals(Decimal('100'), benefit.apply(basket, condition))
+        self.assertEquals(Decimal('100'), benefit.apply(basket, condition))
+        self.assertEquals(Decimal('100'), benefit.apply(basket, condition))
+        self.assertEquals(Decimal('100'), benefit.apply(basket, condition))
+        self.assertEquals(Decimal('100'), benefit.apply(basket, condition))
+        self.assertEquals(Decimal('0'), benefit.apply(basket, condition))
+
+
 class MultibuyDiscountBenefitTest(OfferTest):
-    
+
     def setUp(self):
         super(MultibuyDiscountBenefitTest, self).setUp()
         self.benefit = MultibuyDiscountBenefit(range=self.range, type="Multibuy", value=1)
         self.item = create_product(price=Decimal('5.00'))
-    
+
     def test_no_discount_for_empty_basket(self):
         self.assertEquals(Decimal('0.00'), self.benefit.apply(self.basket))
-        
+
     def test_discount_for_single_item_basket(self):
         self.basket.add_product(self.item, 1)
-        self.assertEquals(Decimal('5.00'), self.benefit.apply(self.basket)) 
-        
+        self.assertEquals(Decimal('5.00'), self.benefit.apply(self.basket))
+
     def test_discount_for_multi_item_basket(self):
         self.basket.add_product(self.item, 3)
-        self.assertEquals(Decimal('5.00'), self.benefit.apply(self.basket))   
-        
+        self.assertEquals(Decimal('5.00'), self.benefit.apply(self.basket))
+
     def test_discount_does_not_consume_item_if_in_condition_range(self):
         self.basket.add_product(self.item, 1)
         first_discount = self.benefit.apply(self.basket)
         self.assertEquals(Decimal('5.00'), first_discount)
         second_discount = self.benefit.apply(self.basket)
         self.assertEquals(Decimal('5.00'), second_discount)
-        
+
     def test_product_does_consume_item_if_not_in_condition_range(self):
         # Set up condition using a different range from benefit
         range = Range.objects.create(name="Small range")
         other_product = create_product(price=Decimal('15.00'))
         range.included_products.add(other_product)
         cond = ValueCondition(range=range, type="Value", value=Decimal('10.00'))
-        
+
         self.basket.add_product(self.item, 1)
         self.benefit.apply(self.basket, cond)
         line = self.basket.all_lines()[0]
         self.assertEqual(line.quantity_without_discount, 0)
-        
+
     def test_condition_consumes_most_expensive_lines_first(self):
         for i in range(10, 0, -1):
-            product = create_product(price=Decimal(i), title='%i'%i, upc='upc_%i' % i)
+            product = create_product(price=Decimal(i), title='%i' % i, upc='upc_%i' % i)
             self.basket.add_product(product, 1)
 
         condition = CountCondition(range=self.range, type="Count", value=2)
@@ -374,10 +390,10 @@ class MultibuyDiscountBenefitTest(OfferTest):
 
         # end of items (one not discounted item in basket)
         self.assertFalse(condition.is_satisfied(self.basket))
-        
+
     def test_condition_consumes_most_expensive_lines_first_when_products_are_repeated(self):
         for i in range(5, 0, -1):
-            product = create_product(price=Decimal(i), title='%i'%i, upc='upc_%i' % i)
+            product = create_product(price=Decimal(i), title='%i' % i, upc='upc_%i' % i)
             self.basket.add_product(product, 2)
 
         condition = CountCondition(range=self.range, type="Count", value=2)
@@ -410,38 +426,38 @@ class MultibuyDiscountBenefitTest(OfferTest):
 
         # end of items (one not discounted item in basket)
         self.assertFalse(condition.is_satisfied(self.basket))
-    
+
     def test_products_with_no_stockrecord_are_handled_ok(self):
         self.basket.add_product(self.item, 3)
         self.basket.add_product(create_product())
         condition = CountCondition(range=self.range, type="Count", value=3)
         self.benefit.apply(self.basket, condition)
-        
+
 
 class FixedPriceBenefitTest(OfferTest):
-    
+
     def setUp(self):
         super(FixedPriceBenefitTest, self).setUp()
         self.benefit = FixedPriceBenefit(range=self.range, type="FixedPrice", value=Decimal('10.00'))
-        
+
     def test_correct_discount_for_count_condition(self):
-        products = [create_product(Decimal('7.00')), 
+        products = [create_product(Decimal('7.00')),
                     create_product(Decimal('8.00')),
                     create_product(Decimal('12.00'))]
-        
+
         # Create range that includes the products
         range = Range.objects.create(name="Dummy range")
         for product in products:
             range.included_products.add(product)
         condition = CountCondition(range=range, type="Count", value=3)
-            
-        # Create basket that satisfies condition but with one extra product    
+
+        # Create basket that satisfies condition but with one extra product
         basket = Basket.objects.create()
         [basket.add_product(p, 2) for p in products]
-        
+
         benefit = FixedPriceBenefit(range=range, type="FixedPrice", value=Decimal('20.00'))
         self.assertEquals(Decimal('2.00'), benefit.apply(basket, condition))
-        self.assertEquals(Decimal('12.00'), benefit.apply(basket, condition)) 
+        self.assertEquals(Decimal('12.00'), benefit.apply(basket, condition))
         self.assertEquals(Decimal('0.00'), benefit.apply(basket, condition))
 
     def test_correct_discount_is_returned(self):
@@ -450,86 +466,82 @@ class FixedPriceBenefitTest(OfferTest):
         for product in products:
             range.included_products.add(product)
             range.included_products.add(product)
-            
+
         basket = Basket.objects.create()
         [basket.add_product(p) for p in products]
-        
+
         condition = CoverageCondition(range=range, type="Coverage", value=2)
         discount = self.benefit.apply(basket, condition)
-        self.assertEquals(Decimal('2.00'), discount)   
-        
+        self.assertEquals(Decimal('2.00'), discount)
+
     def test_no_discount_is_returned_when_value_is_greater_than_product_total(self):
         products = [create_product(Decimal('4.00')), create_product(Decimal('4.00'))]
         range = Range.objects.create(name="Dummy range")
         for product in products:
             range.included_products.add(product)
             range.included_products.add(product)
-            
+
         basket = Basket.objects.create()
         [basket.add_product(p) for p in products]
-        
+
         condition = CoverageCondition(range=range, type="Coverage", value=2)
         discount = self.benefit.apply(basket, condition)
-        self.assertEquals(Decimal('0.00'), discount) 
-        
+        self.assertEquals(Decimal('0.00'), discount)
+
     def test_discount_when_more_products_than_required(self):
-        products = [create_product(Decimal('4.00')), 
+        products = [create_product(Decimal('4.00')),
                     create_product(Decimal('8.00')),
                     create_product(Decimal('12.00'))]
-        
+
         # Create range that includes the products
         range = Range.objects.create(name="Dummy range")
         for product in products:
             range.included_products.add(product)
         condition = CoverageCondition(range=range, type="Coverage", value=3)
-            
-        # Create basket that satisfies condition but with one extra product    
+
+        # Create basket that satisfies condition but with one extra product
         basket = Basket.objects.create()
         [basket.add_product(p) for p in products]
         basket.add_product(products[0])
-        
+
         benefit = FixedPriceBenefit(range=range, type="FixedPrice", value=Decimal('20.00'))
         discount = benefit.apply(basket, condition)
-        self.assertEquals(Decimal('4.00'), discount) 
-        
+        self.assertEquals(Decimal('4.00'), discount)
+
     def test_discount_when_applied_twice(self):
-        products = [create_product(Decimal('4.00')), 
+        products = [create_product(Decimal('4.00')),
                     create_product(Decimal('8.00')),
                     create_product(Decimal('12.00'))]
-        
+
         # Create range that includes the products
         range = Range.objects.create(name="Dummy range")
         for product in products:
             range.included_products.add(product)
         condition = CoverageCondition(range=range, type="Coverage", value=3)
-            
-        # Create basket that satisfies condition but with one extra product    
+
+        # Create basket that satisfies condition but with one extra product
         basket = Basket.objects.create()
         [basket.add_product(p, 2) for p in products]
-        
+
         benefit = FixedPriceBenefit(range=range, type="FixedPrice", value=Decimal('20.00'))
         first_discount = benefit.apply(basket, condition)
-        self.assertEquals(Decimal('4.00'), first_discount) 
+        self.assertEquals(Decimal('4.00'), first_discount)
         second_discount = benefit.apply(basket, condition)
-        self.assertEquals(Decimal('4.00'), second_discount) 
-        
-    
+        self.assertEquals(Decimal('4.00'), second_discount)
+
+
 class ConditionalOfferTest(TestCase):
-   
+
     def test_is_active(self):
         start = datetime.date(2011, 01, 01)
         test = datetime.date(2011, 01, 10)
         end = datetime.date(2011, 02, 01)
         offer = ConditionalOffer(start_date=start, end_date=end)
         self.assertTrue(offer.is_active(test))
-       
+
     def test_is_inactive(self):
         start = datetime.date(2011, 01, 01)
         test = datetime.date(2011, 03, 10)
         end = datetime.date(2011, 02, 01)
         offer = ConditionalOffer(start_date=start, end_date=end)
         self.assertFalse(offer.is_active(test))
-        
-
-    
-   


### PR DESCRIPTION
There is currently no communication between conditions and benefits. As the absolute benefit does not use product ranges, it should never consume affected products as the underlying condition already does so. Otherwise it results in the condition being applied every other time.
