### PR TITLE
Add missing save m2m

### DIFF
--- a/oscar/apps/dashboard/catalogue/forms.py
+++ b/oscar/apps/dashboard/catalogue/forms.py
@@ -170,7 +170,8 @@ class ProductForm(forms.ModelForm):
         if not object.upc:
             object.upc = None
         object.save()
-        self.save_m2m()
+        if hasattr(self, 'save_m2m'):
+            self.save_m2m()
         return object
 
     def save_attributes(self, object):


### PR DESCRIPTION
Suppose we have:

class Product(oscar.apps.catalogue.abstract_models.AbstractProduct):
    tags = django.db.models.ManyToManyField('Tag')

class Tag(django.db.models.Model):
    pass

This will cause oscar.apps.dashboard.catalog.forms.ProductForm display mulit select box for selecting tags for a product. But the tags won't be saved due to commit=False passed to to forms save method. This fixes it by calling save_m2m is such field exists for the form.
