### PR TITLE
fixed problem with select_related on products without stock records

### DIFF
--- a/oscar/apps/catalogue/views.py
+++ b/oscar/apps/catalogue/views.py
@@ -68,8 +68,6 @@ def get_product_base_queryset():
     """
     return product_model.browsable.select_related(
         'product_class',
-        'stockrecord',
-        'stockrecord__partner',
     ).prefetch_related(
         'reviews',
         'variants',


### PR DESCRIPTION
I realise that the `select_related` on the product - added to
reduce the amount SQL queries - does cause problems with products
that have no stock record. Especially, for product variants this
is a huge issue.
I have reverted this change as there is no easy way around it. A
possible solution might be to generate the JOIN directly by using
`join` on the products but this needs some more evaluation.
