### PR TITLE
Permissions for generating reports in dashboard

### DIFF
--- a/oscar/apps/order/reports.py
+++ b/oscar/apps/order/reports.py
@@ -58,4 +58,4 @@ class OrderReportGenerator(ReportGenerator):
         return self.formatter.generate_response(orders, **additional_data)
 
     def is_available_to(self, user):
-        return user.is_staff and user.has_perm('order.can_view')
+        return user.is_staff


### PR DESCRIPTION
Should oscar use so specific permissions as has_perm('order.can_view') instead of just is_staff? I think a project should create additional restrictions depending on their needs.

Report generators other than OrderReportGenerator use simply is_staff anyway.
