### PR TITLE
updated prefetch_related as suggested in pull request #238

### DIFF
--- a/oscar/apps/catalogue/views.py
+++ b/oscar/apps/catalogue/views.py
@@ -73,6 +73,8 @@ def get_product_base_queryset():
         'variants',
         'product_options',
         'product_class__options',
+        'stockrecord',
+        'stockrecord__partner',
         'images',
     ).all()
 


### PR DESCRIPTION
I updated the queryset to use `stockrecord` and
`stockrecord__partner` in the prefetch_related method parameters.
Testing it on the product list page for all products reduced the
amount of queries from 159 to 149.
