### PR TITLE
moved getting categories into queryset method for easier overwriting

### DIFF
--- a/oscar/templatetags/category_tags.py
+++ b/oscar/templatetags/category_tags.py
@@ -38,11 +38,14 @@ class CategoryTreeNode(template.Node):
                     self._build_tree(node[1], category, data, depth+1)
                 root.append(node)
         return root
-        
+
+    def get_category_queryset(self, depth):
+        return Category.objects.filter(depth__lte=depth)
+
     def render(self, context):
         depth = int(self.depth_var.resolve(context))
-        categories = Category.objects.filter(depth__lte=depth)
-        
+        categories = self.get_category_queryset(depth)
+
         category_buckets = [[] for i in range(depth)]
         
         for c in categories:


### PR DESCRIPTION
I just finished some work on adding a visibility flag to the `Category` model and had to create a custom `category_tree` template tag to make the templates use the correct queryset of categories. I realised that it would be a little bit more DRY if I could just overwrite a method in `CategoryTreeNode` returning the queryset instead of copying the whole `render` method. 

It would be great if this update could go into Oscar to make it a bit simpler and DRYer to overwrite the node.
