### PR TITLE
updated render_promotion template tag to provide copy of global context

### DIFF
--- a/oscar/templatetags/promotion_tags.py
+++ b/oscar/templatetags/promotion_tags.py
@@ -1,26 +1,33 @@
-from django.template import Library, Node, Variable, Context
-from django.template.loader import select_template
-from django.template import RequestContext
+from copy import copy
 
-     
+from django.template import Library, Node, Variable, TemplateSyntaxError
+from django.template.loader import select_template
+
+
 register = Library()
-     
-     
+
+
 class PromotionNode(Node):
     def __init__(self, promotion):
         self.promotion_var = Variable(promotion)
-    
+
     def render(self, context):
         promotion = self.promotion_var.resolve(context)
-        template = select_template([promotion.template_name(), 'promotions/default.html'])
-        args = {'promotion': promotion}
-        args.update(**promotion.template_context(request=context['request']))
-        ctx = RequestContext(context['request'], args)
+        template = select_template([promotion.template_name(),
+                                    'promotions/default.html'])
+        ctx = copy(context)
+        ctx['promotion'] = promotion
+        ctx.update(promotion.template_context(request=context['request']))
         return template.render(ctx)
- 
+
+
+@register.tag('render_promotion')
 def get_promotion_html(parser, token):
-    _, promotion = token.split_contents()
+    try:
+        __, promotion = token.split_contents()
+    except ValueError:
+        raise TemplateSyntaxError(
+            "%r expects promotion instance as required argument",
+            token.split_contents()[0]
+        )
     return PromotionNode(promotion)
-
-
-register.tag('render_promotion', get_promotion_html)

--- a/tests/unit/promotion_tests.py
+++ b/tests/unit/promotion_tests.py
@@ -1,5 +1,10 @@
-from django.test import TestCase
+import mock
 
+from django.test import TestCase
+from django.core.urlresolvers import reverse
+from django.template import Template, TemplateSyntaxError
+
+from oscar.test import ClientTestCase
 from oscar.apps.promotions import models
 
 
@@ -9,3 +14,29 @@ class PromotionTest(TestCase):
         promotion = models.Image.objects.create(name="dummy banner")
         self.assertEqual('promotions/image.html', promotion.template_name())
 
+
+class PromotionTemplateTagTest(ClientTestCase):
+    anonymous = True
+
+    def test_promotion_templatetag_argument_error(self):
+        self.assertRaises(
+            TemplateSyntaxError, Template,
+            '{% load promotion_tags %}{% render_promotion %}',
+        )
+
+    def test_promotion_templatetag(self):
+        response = self.client.get(reverse('catalogue:index'))
+        promotion = models.Image.objects.create(name="dummy banner")
+
+        template = Template(
+            '{% load promotion_tags %}'
+            '{% render_promotion promotion %}'
+        )
+        ctx = response.context[0]
+        ctx.update({
+            "promotion": promotion,
+            "basket": mock.Mock('FakeBasket')
+        })
+        template.render(ctx)
+        self.assertTrue('promotion' in ctx)
+        self.assertTrue('basket' in ctx)


### PR DESCRIPTION
I had an issue with the promotions automatically generating a list of products with the ability to add them to the basket. As the template tag `render_promotion` creates an empty `RequestContext` the basket instance is not available in the promotion's context. 

After talking to @a-musing-moose,  I thought it would be best to add the current (global) context to the promotion. I updated the template tag accordingly. It now creates a copy of the global context to prevent it from being cluttered with promotion specific variables. The promotion's context is then used to update this context copy. I also added some unit tests. 

I am not sure if this is the way the `render_promotion` tag should work but I assume that the basket is pretty likely to be used in a promotion that lists/shows products. Please let me know if you reject this change so I can put it into our project. 

Also, any feedback on doing it differently or better would be appreciated. 
