### PR TITLE
Check whether forms are valid in the category formset clean method

### DIFF
--- a/oscar/apps/dashboard/catalogue/forms.py
+++ b/oscar/apps/dashboard/catalogue/forms.py
@@ -216,8 +216,9 @@ class ProductCategoryFormSet(BaseInlineFormSet):
         num_categories = 0
         for i in range(0, self.total_form_count()):
             form = self.forms[i]
-            if form.cleaned_data.get('category', None) and \
-               form.cleaned_data.get('DELETE', False) != True:
+            if (hasattr(form, 'cleaned_data') 
+                    and form.cleaned_data.get('category', None) 
+                    and form.cleaned_data.get('DELETE', False) != True):
                 num_categories += 1
         return num_categories
 


### PR DESCRIPTION
Currently if a form in the dahsboard product-category formset is not valid, we get an attribute error in the get_num_categories method.

We can just check whether the attribute is there, if it's ok that we're counting only valid category choices for the total category count.
