### PR TITLE
used basket from request to make it work with promotion tag

### DIFF
--- a/oscar/templates/oscar/catalogue/partials/add_to_basket_form.html
+++ b/oscar/templates/oscar/catalogue/partials/add_to_basket_form.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% if product.stockrecord and product.stockrecord.is_available_to_buy %}
-    {% basket_form basket product as basket_form %}
+    {% basket_form request.basket product as basket_form %}
     <form action="{% url basket:add %}" method="post" class="form-stacked">
         {% csrf_token %}
         {% include "partials/form_fields.html" with form=basket_form %}

--- a/oscar/templates/oscar/catalogue/partials/add_to_basket_form_compact.html
+++ b/oscar/templates/oscar/catalogue/partials/add_to_basket_form_compact.html
@@ -1,7 +1,7 @@
 {% load basket_tags %}
 {% load i18n %}
 
-{% basket_form basket product as basket_form single %}
+{% basket_form request.basket product as basket_form single %}
 <form action="{% url basket:add %}" method="post">
     {% csrf_token %}
     {{ basket_form.as_p }}


### PR DESCRIPTION
This is related to pull request #250. It adds the `request.basket` to the templates that create the add to basket HTML. This ensures that it works within the promotions as well where the basket is not provided directly in the context.
