### PR TITLE
updated breadcrumbs on product list pages

### DIFF
--- a/oscar/templates/oscar/catalogue/browse.html
+++ b/oscar/templates/oscar/catalogue/browse.html
@@ -14,12 +14,20 @@
 {% block breadcrumbs %}
 <ul class="breadcrumb">
     <li>
-	<a href="{% url promotions:home %}">{% trans "Home" %}</a>
+        <a href="{% url promotions:home %}">{% trans "Home" %}</a>
         <span class="divider">/</span>
     </li>
-    <li class="active"><a href=".">{{ summary }}</a></li>
+    {% for c in category.get_ancestors|slice:":-1" %}
+    <li>
+        <a href="{{ c.get_absolute_url }}">{{ c.name }}</a>
+        <span class="divider">/</span>
+    </li>
+    {% endfor %}
+    <li class="active">
+        <a href=".">{{ category.name }}</a>
+    </li>
 </ul>
-{% endblock %}
+{% endblock breadcrumbs %}
 
 {% block column_left %}
     <div class="side_categories" style="padding: 8px 0;">


### PR DESCRIPTION
The breadcrumbs in the product list page using the `browse.html`
template only shows the leaf category selected but not the whole
path in the hierachy. This means when selecting a parent
category on a product page, the user will loose track of where
in the tree they actually were. Talking to Gareth we updated
the template with the fix included here and thought it might
be good to provide it to Oscar.

This is only a suggestion. Please feel free to close it if you
don't agree with it.
