### PR TITLE
Fix product form validation when the parent field is excluded

### DIFF
--- a/oscar/apps/dashboard/catalogue/forms.py
+++ b/oscar/apps/dashboard/catalogue/forms.py
@@ -189,7 +189,7 @@ class ProductForm(forms.ModelForm):
         data = self.cleaned_data
         if 'parent' not in data and not data['title']:
             raise forms.ValidationError(_("This field is required"))
-        elif data['parent'] is None and not data['title']:
+        elif 'parent' in data and data['parent'] is None and not data['title']:
             raise forms.ValidationError(_("Parent products must have a title"))
         return data
 


### PR DESCRIPTION
Some projects may want to exclude the parent field from the product update form - need to fix the form validation in this case so that they can call the super clean.
