### PR TITLE
Fix customer order history view

### DIFF
--- a/oscar/apps/customer/forms.py
+++ b/oscar/apps/customer/forms.py
@@ -109,7 +109,7 @@ class SearchByDateRangeForm(forms.Form):
         return super(SearchByDateRangeForm, self).clean()
 
     def description(self):
-        if not self.is_bound:
+        if not self.is_bound or not self.is_valid():
             return 'All orders'
         date_from = self.cleaned_data['date_from']
         date_to = self.cleaned_data['date_to']

--- a/oscar/apps/customer/views.py
+++ b/oscar/apps/customer/views.py
@@ -289,7 +289,8 @@ class OrderHistoryView(ListView):
         if 'date_from' in request.GET:
             self.form = SearchByDateRangeForm(self.request.GET)
             if not self.form.is_valid():
-                ctx = self.get_context_data()
+                self.object_list = self.get_queryset()
+                ctx = self.get_context_data(object_list=self.object_list)
                 return self.render_to_response(ctx)
         else:
             self.form = SearchByDateRangeForm()
@@ -297,7 +298,7 @@ class OrderHistoryView(ListView):
 
     def get_queryset(self):
         qs = self.model._default_manager.filter(user=self.request.user)
-        if self.form.is_bound:
+        if self.form.is_bound and self.form.is_valid():
             qs = qs.filter(**self.form.get_filters())
         return qs
 


### PR DESCRIPTION
We get an error when the filtering form is not valid in the customer order history view - need to pass additional argument for the get_context_data method.
