### PR TITLE
Fix for docs in getting_started section

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -97,7 +97,7 @@ Alter your ``frobshop/urls.py`` to include Oscar's URLs::
     from django.conf.urls import patterns, include, url
     from oscar.app import shop
 
-    urlpatterns = ('',
+    urlpatterns = patterns('',
         (r'', include(shop.urls))
     )
 


### PR DESCRIPTION
It's my first pull request ever, so don't be so rught on me if i make some silly mistake :)

I found missing 'patterns' in URL section, so fix it.
