### PR TITLE
Add support to change redirect after adding item to the basket using POST variable

### DIFF
--- a/oscar/apps/basket/views.py
+++ b/oscar/apps/basket/views.py
@@ -141,8 +141,8 @@ class BasketAddView(FormView):
         return kwargs
 
     def get_success_url(self):
-        if self.request.POST.get('redirect'):
-            return self.request.POST.get('redirect')
+        if self.request.POST.get('next'):
+            return self.request.POST.get('next')
         return self.request.META.get('HTTP_REFERER', reverse('basket:summary'))
 
     def form_valid(self, form):


### PR DESCRIPTION
Currently the `BasketAddView` by default redirects to the referrer page (in real terms appears to be a page reload) with no option to change. 

To avoid having to extend the entire view just to change the redirect - this simple commit adds ability to change redirect by introducing a `redirect` variable to the `POST`.
