### PR TITLE
Return ProductAttributeValue even if it's None

### DIFF
--- a/oscar/apps/catalogue/abstract_models.py
+++ b/oscar/apps/catalogue/abstract_models.py
@@ -350,8 +350,7 @@ class ProductAttributesContainer(object):
                 if v.attribute.code == name:
                     result = v.value
             self.initialised = True
-            if result:
-                return result
+            return result
         raise AttributeError((_(u"%(obj)s has no attribute named " \
                                        u"'%(attr)s'") % \
                                      {'obj': self.product.product_class, 'attr': name}))


### PR DESCRIPTION
Up to now every first usage of `ProductAttributesContainer` raised `AttributeError` if desired attribute value evaluated to `False` while casting to `bool`.
