### PR TITLE
creating product now checks for unique UPC

### DIFF
--- a/oscar/apps/dashboard/catalogue/forms.py
+++ b/oscar/apps/dashboard/catalogue/forms.py
@@ -195,6 +195,16 @@ class ProductForm(forms.ModelForm):
             value = self.cleaned_data['attr_%s' % attribute.code]
             attribute.save_value(object, value)
 
+    def clean_upc(self):
+        upc = self.cleaned_data['upc']
+        try:
+            Product.objects.get(upc=upc)
+            raise forms.ValidationError(
+                _("A product with UPC '%s' already exists") % upc)
+        except Product.DoesNotExist:
+            pass
+        return upc
+
     def clean(self):
         data = self.cleaned_data
         if 'parent' not in data and not data['title']:


### PR DESCRIPTION
Attempting to create a new product with a UPC that already exists
raises an `IntegrityError` instead of handling the `ProductForm`
as an invalid form with an appropriate `ValidationError`.

I fixed that by adding a `clean_upc` validation method to the
form by checking for an existing product by UPC. I am not sure if
that is the most efficient way to validate this. If there's a
better alternative, I am happy to change it...and learn something
:)

**Note:** I switched the functional tests in `product_tests.py`
to use `WebTest` while I was at it.
