### PR TITLE
UPC validation is now working correcly

### DIFF
--- a/oscar/apps/dashboard/catalogue/forms.py
+++ b/oscar/apps/dashboard/catalogue/forms.py
@@ -79,7 +79,6 @@ class StockRecordForm(forms.ModelForm):
             del self.fields['num_in_stock']
             del self.fields['low_stock_threshold']
 
-
     class Meta:
         model = StockRecord
         exclude = ('product', 'num_allocated', 'price_currency')
@@ -195,24 +194,16 @@ class ProductForm(forms.ModelForm):
             value = self.cleaned_data['attr_%s' % attribute.code]
             attribute.save_value(object, value)
 
-    def clean_upc(self):
-        upc = self.cleaned_data['upc']
-        try:
-            Product.objects.get(upc=upc)
-        except Product.DoesNotExist:
-            pass
-        else:
-            raise forms.ValidationError(
-                _("A product with UPC '%s' already exists") % upc)
-        return upc
-
     def clean(self):
         data = self.cleaned_data
         if 'parent' not in data and not data['title']:
             raise forms.ValidationError(_("This field is required"))
         elif 'parent' in data and data['parent'] is None and not data['title']:
             raise forms.ValidationError(_("Parent products must have a title"))
-        return data
+        # calling the clean() method of BaseForm here is required to apply checks
+        # for 'unique' field. This prevents e.g. the UPC field from raising 
+        # a DatabaseError.
+        return super(ProductForm, self).clean()
 
 
 class StockAlertSearchForm(forms.Form):

--- a/tests/functional/dashboard/product_tests.py
+++ b/tests/functional/dashboard/product_tests.py
@@ -98,8 +98,10 @@ class TestCreateGroupProduct(ProductWebTest):
                                upc="12345")
 
         self.assertEquals(Product.objects.count(), 1)
+        self.assertNotEquals(Product.objects.get(upc='12345').title,
+                             'Nice T-Shirt')
         self.assertContains(response,
-                            "A product with UPC &#39;12345&#39; already exists")
+                            "Product with this UPC already exists.")
 
 
 class TestCreateChildProduct(ProductWebTest):


### PR DESCRIPTION
The previous UPC validation in `ProductForm` broke updating the
a product. I realised this while digging around to fix the broken
`StockRecord` issue that broke the CI build.

The validation now uses Django's validation of `unique` fields
instead and works.

The `StockRecord` issue was related to creating a form in the
update view providing stock record data in POST with `partner`
empty. I corrected that and added a test case for it.

**Note** This fixes an issue caused by PR #312
