### PR TITLE
decimal values passed as string now work (again)

### DIFF
--- a/oscar/templatetags/currency_filters.py
+++ b/oscar/templatetags/currency_filters.py
@@ -1,3 +1,5 @@
+from decimal import InvalidOperation, Decimal as D
+
 from django import template
 from django.conf import settings
 from babel.numbers import format_currency
@@ -18,4 +20,10 @@ def currency(value):
     locale = getattr(settings, 'OSCAR_CURRENCY_LOCALE', None)
     if locale:
         kwargs['locale'] = locale
+
+    try:
+        value = D(value)
+    except (TypeError, InvalidOperation):
+        return u""
+
     return format_currency(value, **kwargs)

--- a/tests/unit/currency_filters_tests.py
+++ b/tests/unit/currency_filters_tests.py
@@ -1,0 +1,31 @@
+﻿from decimal import Decimal as D
+
+from django.conf import settings
+from django.test import TestCase
+
+from oscar.templatetags.currency_filters import currency
+
+
+class TestCurrencyFilter(TestCase):
+
+    def test_formats_a_decimal_value_using_oscar_setting(self):
+        default = settings.OSCAR_DEFAULT_CURRENCY
+        settings.OSCAR_DEFAULT_CURRENCY = u'USD'
+
+        formatted = currency(D('23.54'))
+        self.assertEquals(formatted, u'US$23.54')
+
+        # rest to default for further testing
+        settings.OSCAR_DEFAULT_CURRENCY = default
+
+    def test_formats_a_decimal_value_using_oscar_default_setting(self):
+        formatted = currency(D('23.54'))
+        self.assertEquals(formatted, u'£23.54')
+
+    def test_formats_a_string_value_using_oscar_default_setting(self):
+        formatted = currency('23.54')
+        self.assertEquals(formatted, u'£23.54')
+
+    def test_formats_empty_string_as_empty_value(self):
+        formatted = currency('')
+        self.assertEquals(formatted, u'')


### PR DESCRIPTION
I am not a 100% sure that this is a fix for Oscar. I suggest this
change to be included because of the following reasons:
1. The previous implementation of the currency filter (pre-Babel)
   would return an empty string '' whenever an invalid type was
   passed in. It think it makes sense to be backwards compatible.
2. Applying the currency filter fails when passing in an empty
   string. This means that whenever the currency filter is applied
   it has to be ensured that it is not an empty value. Otherwise
   the filter raises an exception.
   This might cause additional issues due to the way the Djangoo
   templating system usually fails silently.

Please take a look at the suggested code in the commit and let me
know if this is a feasible addition/extension.
