### PR TITLE
make add basket success url work with absolute HTTP_REFERER urls

### DIFF
--- a/oscar/apps/basket/views.py
+++ b/oscar/apps/basket/views.py
@@ -1,3 +1,4 @@
+from urlparse import urlparse
 from django.contrib import messages
 from django.core.urlresolvers import reverse, resolve
 from django.db.models import get_model
@@ -165,7 +166,7 @@ class BasketAddView(FormView):
         if url:
             # We only allow internal URLs so we see if the url resolves
             try:
-                resolve(url)
+                resolve(urlparse(url).path)
             except Http404:
                 url = None
         if url is None:


### PR DESCRIPTION
The URL in `HTTP_REFERER` is an absolute URL and always fails in `resolve` which expects a relative URL. The [Django docs](https://docs.djangoproject.com/en/dev/topics/http/urls/#resolve) suggest using `urlparse` to split the URL into its parts. The example is at the very end of the `resolve` section and has a mistake in it because the parsed result cannot be accessed using index 2. 

I have added `urlparse` to get the actual path from the absolute URL. I hope this is a sensible solution.
