### PR TITLE
Check for existing email when updating profile

### DIFF
--- a/oscar/apps/customer/forms.py
+++ b/oscar/apps/customer/forms.py
@@ -10,6 +10,7 @@ from django.contrib.auth.models import User
 from django.contrib.auth import forms as auth_forms
 from django.conf import settings
 from django.core import validators
+from django.core.exceptions import ValidationError
 from django.utils.http import int_to_base36
 from django.contrib.sites.models import get_current_site
 from django.contrib.auth.tokens import default_token_generator
@@ -211,7 +212,33 @@ class SearchByDateRangeForm(forms.Form):
         return {}
 
 
-class UserForm(forms.ModelForm):
+class CleanEmailMixin(object):
+
+    def clean_email(self):
+        """
+        Make sure that the email address is aways unique as it is 
+        used instead of the username. This is necessary because the
+        unique-ness of email addresses is *not* enforced on the model
+        level in ``django.contrib.auth.models.User``.
+        """
+        email = self.cleaned_data['email']
+
+        try:
+            user = User.objects.get(email=email)
+        except User.DoesNotExist:
+            # this email address is unique so we don't have to worry
+            # about it
+            return email
+
+        if self.instance and self.instance.id != user.id:
+            raise ValidationError(
+                _("A user with this email address already exists")
+            )
+
+        return email
+
+
+class UserForm(forms.ModelForm, CleanEmailMixin):
 
     def __init__(self, user, *args, **kwargs):
         self.user = user
@@ -229,7 +256,7 @@ if hasattr(settings, 'AUTH_PROFILE_MODULE'):
 
     Profile = get_profile_class()
 
-    class UserAndProfileForm(forms.ModelForm):
+    class UserAndProfileForm(forms.ModelForm, CleanEmailMixin):
 
         first_name = forms.CharField(label=_('First name'), max_length=128)
         last_name = forms.CharField(label=_('Last name'), max_length=128)


### PR DESCRIPTION
A user in Oscar is identified by email address instead of the
username. This is, however, not set as a `unique` constraint
in the user model in `django.contrib.auth.models.User`. Checks
if an email already exists are carried out when a user registers
but are ignored when a registered user changes their
profile. This can lead to multiple users having the same email
address which should not happen.

I provide a failing test with a mixin that can be used in both
the `UserForm` and `UserAndProfileForm` to clean the email
field when validating the form. A `ValidationError` is raised
when a user with this email address already exists and is not
the currently edited instance (makes sure that profile updates
with unchanged email work still).

I am not sure if this is the best way of handling the validation.
Feedback is welcome.

_Note:_ It might also be worth considering to change to a custom
`User` model when Oscar starts using Django 1.5 as it now
supports swappable user models. It would allow for making the
email field truely unique.
