### PR TITLE
Fix error prefetching stockrecord-related models

### DIFF
--- a/oscar/apps/catalogue/views.py
+++ b/oscar/apps/catalogue/views.py
@@ -97,7 +97,9 @@ def get_product_base_queryset():
         'variants',
         'product_options',
         'product_class__options',
-        'stockrecord',
+        'stockrecord__product',
+        'stockrecord__product__product_class',
+        'stockrecord__partner',
         'images',
     ).all()
 


### PR DESCRIPTION
Trying to do a prefetch_selected() on models with a relationship
to StockRecord such as 'stockrecord__product' raises an exception
when no stock record exists for the product. Since especially
parent products don't need to have a stock record these prefetch
statements need to be removed.
