### PR TITLE
Add convenience wrapper for webtest (cleanup of #293)

### DIFF
--- a/oscar/test/__init__.py
+++ b/oscar/test/__init__.py
@@ -70,9 +70,27 @@ class ClientTestCase(TestCase):
 
 
 class WebTestCase(WebTest):
-    """
-    Custom version of WebTest that adds a few useful assertion methods
-    """
+    is_staff = False
+    is_anonymous = True
+    username = 'testuser'
+    email = 'testuser@buymore.com'
+    password = 'somefancypassword'
+
+    def setUp(self):
+        self.user = None
+        if not self.is_anonymous or self.is_staff:
+            self.user = User.objects.create_user(self.username, self.email,
+                                                 self.password)
+            self.user.is_staff = self.is_staff
+            self.user.save()
+
+    def get(self, url, **kwargs):
+        kwargs.setdefault('user', self.user)
+        return self.app.get(url, **kwargs)
+
+    def post(self, url, **kwargs):
+        kwargs.setdefault('user', self.user)
+        return self.app.post(url, **kwargs)
 
     def assertRedirectsTo(self, response, url_name):
         self.assertTrue(str(response.status_code).startswith('3'))


### PR DESCRIPTION
I just realised that I never created the new PR mentioned in #293. So here is the wrapper around the `WebTest` class that allows for easier user handling. 
