### PR TITLE
Added additional_order_information template block to order details template

### DIFF
--- a/oscar/templates/oscar/dashboard/orders/order_detail.html
+++ b/oscar/templates/oscar/dashboard/orders/order_detail.html
@@ -76,6 +76,8 @@
                 <p>{{ order.status|default:"N/A" }}</p>
             </div>
         </div>
+        {% block additional_order_information %}
+        {% endblock additional_order_information %}
     </div>
 
 


### PR DESCRIPTION
Allow extending templates to add more to the order information list
(i.e. shipping details of the order) without having to copy the entire
existing info.

The order information section isn't self contained in a {% block %} 
adding more to this section would require having to extend the entire 
{% block dashboard_content %}
