### PR TITLE
Fix dashboard for vouchers without offers

### DIFF
--- a/oscar/apps/dashboard/vouchers/views.py
+++ b/oscar/apps/dashboard/vouchers/views.py
@@ -137,18 +137,22 @@ class VoucherUpdateView(FormView):
 
     def get_initial(self):
         voucher = self.get_voucher()
-        offer = voucher.offers.all()[0]
-        benefit = offer.benefit
-        return {
+        kwargs = {
             'name': voucher.name,
             'code': voucher.code,
             'start_date': voucher.start_date,
             'end_date': voucher.end_date,
             'usage': voucher.usage,
-            'benefit_type': benefit.type,
-            'benefit_range': benefit.range,
-            'benefit_value': benefit.value,
         }
+        if voucher.offers.count():
+            offer = voucher.offers.all()[0]
+            benefit = offer.benefit
+            kwargs.update({
+                'benefit_type': benefit.type,
+                'benefit_range': benefit.range,
+                'benefit_value': benefit.value,
+            })
+        return kwargs
 
     def form_valid(self, form):
         voucher = self.get_voucher()


### PR DESCRIPTION
Updating a voucher in the dashboard was not possible with a voucher that has no offers. This makes editing these vouchers impossible.

I worked around it by skipping the initial settings for offer related initial values when no offers are available. 
