### PR TITLE
dashboard/order/search - search by name 

### DIFF
--- a/oscar/apps/dashboard/orders/views.py
+++ b/oscar/apps/dashboard/orders/views.py
@@ -78,7 +78,7 @@ class OrderListView(ListView, BulkEditMixin):
     current_view = 'dashboard:order-list'
 
     def get(self, request, *args, **kwargs):
-        if 'order_number' in request.GET and request.GET.get('response_format', None) == 'html':
+        if 'order_number' in request.GET and request.GET.get('response_format', 'html') == 'html':
             try:
                 order = Order.objects.get(number=request.GET['order_number'])
             except Order.DoesNotExist:


### PR DESCRIPTION
there are two issues addressed by this pull request:
1. Advanced search by customer name looks only in the user's fields for the name, thus all anonymous orders are ignored. I could not find a nice solution that will not have too many `| Q()` operations, but couldn't find one quickly... so this one at least is working. I've added one more check - if configuration allows anonymous orders, then search on the user addresses, if not - leave it as it was
2. on the advanced search form, there is a field specifying response format, unfortunately when you first submit a search form, with just an order_number set, it sets `response_format` field value to None, so when form is binded in the code, rendered radio group will have no default value). This change will make sure that 'html' output is always set as a default value.
