### PR TITLE
Offers / Introduce statuses for offers

### DIFF
--- a/oscar/apps/offer/migrations/0016_auto__add_field_conditionaloffer_status.py
+++ b/oscar/apps/offer/migrations/0016_auto__add_field_conditionaloffer_status.py
@@ -1,0 +1,191 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'ConditionalOffer.status'
+        db.add_column('offer_conditionaloffer', 'status',
+                      self.gf('django.db.models.fields.CharField')(default='Open', max_length=64),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'ConditionalOffer.status'
+        db.delete_column('offer_conditionaloffer', 'status')
+
+
+    models = {
+        'catalogue.attributeentity': {
+            'Meta': {'object_name': 'AttributeEntity'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '255', 'blank': 'True'}),
+            'type': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'entities'", 'to': "orm['catalogue.AttributeEntityType']"})
+        },
+        'catalogue.attributeentitytype': {
+            'Meta': {'object_name': 'AttributeEntityType'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '255', 'blank': 'True'})
+        },
+        'catalogue.attributeoption': {
+            'Meta': {'object_name': 'AttributeOption'},
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'options'", 'to': "orm['catalogue.AttributeOptionGroup']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'option': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        'catalogue.attributeoptiongroup': {
+            'Meta': {'object_name': 'AttributeOptionGroup'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'})
+        },
+        'catalogue.category': {
+            'Meta': {'ordering': "['full_name']", 'object_name': 'Category'},
+            'depth': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'full_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'numchild': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'path': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '255'})
+        },
+        'catalogue.option': {
+            'Meta': {'object_name': 'Option'},
+            'code': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '128'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'type': ('django.db.models.fields.CharField', [], {'default': "'Required'", 'max_length': '128'})
+        },
+        'catalogue.product': {
+            'Meta': {'ordering': "['-date_created']", 'object_name': 'Product'},
+            'attributes': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['catalogue.ProductAttribute']", 'through': "orm['catalogue.ProductAttributeValue']", 'symmetrical': 'False'}),
+            'categories': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['catalogue.Category']", 'through': "orm['catalogue.ProductCategory']", 'symmetrical': 'False'}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'date_updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_discountable': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'variants'", 'null': 'True', 'to': "orm['catalogue.Product']"}),
+            'product_class': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['catalogue.ProductClass']", 'null': 'True'}),
+            'product_options': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['catalogue.Option']", 'symmetrical': 'False', 'blank': 'True'}),
+            'recommended_products': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['catalogue.Product']", 'symmetrical': 'False', 'through': "orm['catalogue.ProductRecommendation']", 'blank': 'True'}),
+            'related_products': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'relations'", 'blank': 'True', 'to': "orm['catalogue.Product']"}),
+            'score': ('django.db.models.fields.FloatField', [], {'default': '0.0', 'db_index': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '255'}),
+            'status': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'upc': ('django.db.models.fields.CharField', [], {'max_length': '64', 'unique': 'True', 'null': 'True', 'blank': 'True'})
+        },
+        'catalogue.productattribute': {
+            'Meta': {'ordering': "['code']", 'object_name': 'ProductAttribute'},
+            'code': ('django.db.models.fields.SlugField', [], {'max_length': '128'}),
+            'entity_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['catalogue.AttributeEntityType']", 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'option_group': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['catalogue.AttributeOptionGroup']", 'null': 'True', 'blank': 'True'}),
+            'product_class': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'attributes'", 'null': 'True', 'to': "orm['catalogue.ProductClass']"}),
+            'required': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'type': ('django.db.models.fields.CharField', [], {'default': "'text'", 'max_length': '20'})
+        },
+        'catalogue.productattributevalue': {
+            'Meta': {'object_name': 'ProductAttributeValue'},
+            'attribute': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['catalogue.ProductAttribute']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'attribute_values'", 'to': "orm['catalogue.Product']"}),
+            'value_boolean': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'value_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'value_entity': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['catalogue.AttributeEntity']", 'null': 'True', 'blank': 'True'}),
+            'value_float': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'value_integer': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'value_option': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['catalogue.AttributeOption']", 'null': 'True', 'blank': 'True'}),
+            'value_richtext': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'value_text': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'})
+        },
+        'catalogue.productcategory': {
+            'Meta': {'ordering': "['-is_canonical']", 'object_name': 'ProductCategory'},
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['catalogue.Category']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_canonical': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['catalogue.Product']"})
+        },
+        'catalogue.productclass': {
+            'Meta': {'ordering': "['name']", 'object_name': 'ProductClass'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'options': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['catalogue.Option']", 'symmetrical': 'False', 'blank': 'True'}),
+            'requires_shipping': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '128'}),
+            'track_stock': ('django.db.models.fields.BooleanField', [], {'default': 'True'})
+        },
+        'catalogue.productrecommendation': {
+            'Meta': {'object_name': 'ProductRecommendation'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'primary': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'primary_recommendations'", 'to': "orm['catalogue.Product']"}),
+            'ranking': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '0'}),
+            'recommendation': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['catalogue.Product']"})
+        },
+        'offer.benefit': {
+            'Meta': {'object_name': 'Benefit'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'max_affected_items': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'range': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['offer.Range']", 'null': 'True', 'blank': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'value': ('oscar.models.fields.PositiveDecimalField', [], {'null': 'True', 'max_digits': '12', 'decimal_places': '2', 'blank': 'True'})
+        },
+        'offer.condition': {
+            'Meta': {'object_name': 'Condition'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'proxy_class': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '255', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'range': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['offer.Range']", 'null': 'True', 'blank': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '128', 'null': 'True', 'blank': 'True'}),
+            'value': ('oscar.models.fields.PositiveDecimalField', [], {'null': 'True', 'max_digits': '12', 'decimal_places': '2', 'blank': 'True'})
+        },
+        'offer.conditionaloffer': {
+            'Meta': {'ordering': "['-priority']", 'object_name': 'ConditionalOffer'},
+            'benefit': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['offer.Benefit']"}),
+            'condition': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['offer.Condition']"}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'end_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'max_basket_applications': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'max_discount': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '12', 'decimal_places': '2', 'blank': 'True'}),
+            'max_global_applications': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'max_user_applications': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '128'}),
+            'num_applications': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'num_orders': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'offer_type': ('django.db.models.fields.CharField', [], {'default': "'Site'", 'max_length': '128'}),
+            'priority': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'redirect_url': ('oscar.models.fields.ExtendedURLField', [], {'max_length': '200', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '128', 'unique': 'True', 'null': 'True'}),
+            'start_date': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'Open'", 'max_length': '64'}),
+            'total_discount': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '12', 'decimal_places': '2'})
+        },
+        'offer.range': {
+            'Meta': {'object_name': 'Range'},
+            'classes': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'classes'", 'blank': 'True', 'to': "orm['catalogue.ProductClass']"}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'excluded_products': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'excludes'", 'blank': 'True', 'to': "orm['catalogue.Product']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'included_categories': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'includes'", 'blank': 'True', 'to': "orm['catalogue.Category']"}),
+            'included_products': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'includes'", 'blank': 'True', 'to': "orm['catalogue.Product']"}),
+            'includes_all_products': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '128'}),
+            'proxy_class': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '255', 'unique': 'True', 'null': 'True', 'blank': 'True'})
+        },
+        'offer.shippingbenefit': {
+            'Meta': {'object_name': 'ShippingBenefit', '_ormbases': ['offer.Benefit']},
+            'benefit_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': "orm['offer.Benefit']", 'unique': 'True', 'primary_key': 'True'})
+        }
+    }
+
+    complete_apps = ['offer']

--- a/oscar/apps/offer/utils.py
+++ b/oscar/apps/offer/utils.py
@@ -40,8 +40,6 @@ class Applicator(object):
     def get_basket_discounts(self, basket, offers):
         discounts = {}
         for offer in offers:
-            if not offer.is_active():
-                continue
             # For each offer, we keep trying to apply it until the
             # discount is 0
             applications = 0
@@ -86,9 +84,12 @@ class Applicator(object):
         Return site offers that are available to all users
         """
         date_based_offers = ConditionalOffer.active.filter(
-            offer_type=ConditionalOffer.SITE)
+            offer_type=ConditionalOffer.SITE,
+            status=ConditionalOffer.OPEN)
         nondate_based_offers = ConditionalOffer.objects.filter(
-            offer_type=ConditionalOffer.SITE, start_date=None, end_date=None)
+            offer_type=ConditionalOffer.SITE,
+            status=ConditionalOffer.OPEN,
+            start_date=None, end_date=None)
         return list(chain(date_based_offers, nondate_based_offers))
 
     def get_basket_offers(self, basket, user):

--- a/oscar/templates/oscar/dashboard/offers/offer_list.html
+++ b/oscar/templates/oscar/dashboard/offers/offer_list.html
@@ -50,6 +50,7 @@
                     <th>{% trans "Offer name" %}</th>
                     <th>{% trans "Status" %}</th>
                     <th>{% trans "Availability" %}</th>
+                    <th>{% trans "Is available?" %}</th>
                     <th>{% trans "Condition" %}</th>
                     <th>{% trans "Benefit" %}</th>
                     <th>{% trans "Applications" %}</th>
@@ -60,13 +61,24 @@
                 {% for offer in offers %}
                 <tr>
                     <td><a href="{{ offer.get_absolute_url }}">{{ offer.name }}</a></td>
-					<td>{% if offer.is_active %}
-						<span class="label label-success">{% trans "Active" %}</span>
+					<td>
+						{% if offer.is_open %}
+						<span class="label label-info">{% trans "Open" %}</span>
 						{% else %}
-						<span class="label">{% trans "Inactive" %}</span>
+							{% if offer.is_suspended %}
+							<span class="label label-important">{% trans "Suspended" %}</span>
+							{% else %}
+							<span class="label label-inverse">{% trans "Consumed" %}</span>
+							{% endif %}
 						{% endif %}
 					</td>
                     <td>{{ offer.availability_description }}</td>
+					<td>{% if offer.is_available %}
+						<span class="label label-success">{% trans "Yes" %}</span>
+						{% else %}
+						<span class="label label-important">{% trans "No" %}</span>
+						{% endif %}
+					</td>
                     <td>{{ offer.condition.description }}</td>
                     <td>{{ offer.benefit.description }}</td>
                     <td>{{ offer.num_applications }}</td>

--- a/oscar/templates/oscar/offer/detail.html
+++ b/oscar/templates/oscar/offer/detail.html
@@ -27,8 +27,8 @@
 
 {% block content %}
 
-	{% if not offer.is_active %}
-	<div class="alert alert-error">{% trans " This offer has expired " %}</div>
+	{% if not offer.is_available %}
+	<div class="alert alert-error">{% trans " This offer is no longer available." %}</div>
 	{% endif %}
 
     {% if offer.description %}

--- a/tests/integration/offer/status_tests.py
+++ b/tests/integration/offer/status_tests.py
@@ -1,0 +1,33 @@
+from decimal import Decimal as D
+
+from django.test import TestCase
+from django_dynamic_fixture import G
+
+from oscar.apps.offer import models
+
+
+class TestAnOfferChangesStatusWhen(TestCase):
+
+    def setUp(self):
+        condition, benefit = G(models.Condition), G(models.Benefit)
+        self.offer = models.ConditionalOffer(
+            offer_type=models.ConditionalOffer.SITE,
+            condition=condition, benefit=benefit)
+
+    def test_the_max_discount_is_exceeded(self):
+        self.offer.max_discount = D('10.00')
+        self.assertTrue(self.offer.is_open)
+
+        # Now bump the total discount and save to see if the status is
+        # automatically updated.
+        self.offer.total_discount += D('20.00')
+        self.offer.save()
+        self.assertFalse(self.offer.is_open)
+
+    def test_the_max_global_applications_is_exceeded(self):
+        self.offer.max_global_applications = 5
+        self.assertTrue(self.offer.is_open)
+
+        self.offer.num_applications += 10
+        self.offer.save()
+        self.assertFalse(self.offer.is_open)

--- a/tests/unit/offer/availability_tests.py
+++ b/tests/unit/offer/availability_tests.py
@@ -18,20 +18,20 @@ class TestADateBasedConditionalOffer(TestCase):
         self.offer = models.ConditionalOffer(start_date=self.start,
                                              end_date=self.end)
 
-    def test_is_active_during_date_range(self):
+    def test_is_available_during_date_range(self):
         test = datetime.date(2011, 01, 10)
-        self.assertTrue(self.offer.is_active(test))
+        self.assertTrue(self.offer.is_available(test_date=test))
 
     def test_is_inactive_before_date_range(self):
         test = datetime.date(2010, 03, 10)
-        self.assertFalse(self.offer.is_active(test))
+        self.assertFalse(self.offer.is_available(test_date=test))
 
     def test_is_inactive_after_date_range(self):
         test = datetime.date(2011, 03, 10)
-        self.assertFalse(self.offer.is_active(test))
+        self.assertFalse(self.offer.is_available(test_date=test))
 
-    def test_is_inactive_on_end_date(self):
-        self.assertFalse(self.offer.is_active(self.end))
+    def test_is_active_on_end_date(self):
+        self.assertTrue(self.offer.is_available(test_date=self.end))
 
 
 class TestAConsumptionFrequencyBasedConditionalOffer(TestCase):
@@ -39,20 +39,20 @@ class TestAConsumptionFrequencyBasedConditionalOffer(TestCase):
     def setUp(self):
         self.offer = models.ConditionalOffer(max_global_applications=4)
 
-    def test_is_active_with_no_applications(self):
-        self.assertTrue(self.offer.is_active())
+    def test_is_available_with_no_applications(self):
+        self.assertTrue(self.offer.is_available())
 
-    def test_is_active_with_fewer_applications_than_max(self):
+    def test_is_available_with_fewer_applications_than_max(self):
         self.offer.num_applications = 3
-        self.assertTrue(self.offer.is_active())
+        self.assertTrue(self.offer.is_available())
 
     def test_is_inactive_with_equal_applications_to_max(self):
         self.offer.num_applications = 4
-        self.assertFalse(self.offer.is_active())
+        self.assertFalse(self.offer.is_available())
 
     def test_is_inactive_with_more_applications_than_max(self):
         self.offer.num_applications = 4
-        self.assertFalse(self.offer.is_active())
+        self.assertFalse(self.offer.is_available())
 
     def test_restricts_number_of_applications_correctly_with_no_applications(self):
         self.assertEqual(4, self.offer.get_max_applications())
@@ -72,8 +72,8 @@ class TestAPerUserConditionalOffer(TestCase):
         self.offer = models.ConditionalOffer(max_user_applications=1)
         self.user = G(User)
 
-    def test_is_active_with_no_applications(self):
-        self.assertTrue(self.offer.is_active())
+    def test_is_available_with_no_applications(self):
+        self.assertTrue(self.offer.is_available())
 
     def test_max_applications_is_correct_when_no_applications(self):
         self.assertEqual(1, self.offer.get_max_applications(self.user))
@@ -96,13 +96,13 @@ class TestCappedDiscountConditionalOffer(TestCase):
             max_discount=D('100.00'),
             total_discount=D('0.00'))
 
-    def test_is_active_when_below_threshold(self):
-        self.assertTrue(self.offer.is_active())
+    def test_is_available_when_below_threshold(self):
+        self.assertTrue(self.offer.is_available())
 
     def test_is_inactive_when_on_threshold(self):
         self.offer.total_discount = self.offer.max_discount
-        self.assertFalse(self.offer.is_active())
+        self.assertFalse(self.offer.is_available())
 
     def test_is_inactive_when_above_threshold(self):
         self.offer.total_discount = self.offer.max_discount + D('10.00')
-        self.assertFalse(self.offer.is_active())
+        self.assertFalse(self.offer.is_available())


### PR DESCRIPTION
These can track when an offer is 'expired' from a consumption point of view which will make it more efficient to load offers within the applicator.
