### PR TITLE
Missing Product Image handling. 

### DIFF
--- a/oscar/apps/catalogue/abstract_models.py
+++ b/oscar/apps/catalogue/abstract_models.py
@@ -339,6 +339,8 @@ class AbstractProduct(models.Model):
     objects = models.Manager()
     browsable = BrowsableProductManager()
 
+    missing_image = None
+
     # Properties
 
     @property
@@ -455,12 +457,21 @@ class AbstractProduct(models.Model):
             return self.parent.product_class
         return None
 
+    def get_missing_image(self):
+        """
+        Returns a missing image object
+        """
+        missing_image = getattr(self, 'missing_image', None)
+        if missing_image is not None:
+            return missing_image
+        return MissingProductImage()
+
     def primary_image(self):
         images = self.images.all()
         if images.count():
             return images[0]
         return {
-            'original': MissingProductImage(),
+            'original': self.get_missing_image(),
             'caption': '',
             'is_missing': True}
 


### PR DESCRIPTION
In case of a Product don't have a ProductImage it's possible now to
mimic a Image object so that we can handle this situations more
elegantly.

class Product(models.Model):
    missing_image = None

```
def get_missing_image(self):
    # We can use this to return a missing image base on some
    # criteria e.g product_class attribute
```

:: Example
class MissingProductImage(self):

```
def fullsize_url(self):
    return "/static/%s/not_found.jpg" % self.product_class

def __init__(self, product_class=None):
    self.product_class = product_class
```

class Product(models.Model):
    def get_missing_image(self):
        return MissingProductImage(product_class=self.product_class)
