### PR TITLE
non permanent redirect on logout

### DIFF
--- a/oscar/apps/customer/views.py
+++ b/oscar/apps/customer/views.py
@@ -38,6 +38,7 @@ ProductAlert = get_model('customer', 'ProductAlert')
 
 class LogoutView(RedirectView):
     url = '/'
+    permanent = False
 
     def get(self, request, *args, **kwargs):
         auth_logout(request)


### PR DESCRIPTION
Django redirect view by default is permanent. We probably don't want it when logging out, because if browser caches it user won't be able to logout secend time.
