### PR TITLE
Add delete functionality for products

### DIFF
--- a/oscar/apps/dashboard/catalogue/app.py
+++ b/oscar/apps/dashboard/catalogue/app.py
@@ -20,7 +20,8 @@ class CatalogueApplication(Application):
     product_create_redirect_view = views.ProductCreateRedirectView
     product_create_view = views.ProductCreateView
     product_update_view = views.ProductUpdateView
-    
+    product_delete_view = views.ProductDeleteView
+
     category_list_view = views.CategoryListView
     category_detail_list_view = views.CategoryDetailListView
     category_create_view = views.CategoryCreateView
@@ -33,23 +34,31 @@ class CatalogueApplication(Application):
         urlpatterns = patterns('',
             url(r'^products/(?P<pk>\d+)/$', self.product_update_view.as_view(),
                 name='catalogue-product'),
-            url(r'^products/create/$', self.product_create_redirect_view.as_view(),
+            url(r'^products/create/$',
+                self.product_create_redirect_view.as_view(),
                 name='catalogue-product-create'),
-            url(r'^products/create/(?P<product_class_id>\d+)/$', self.product_create_view.as_view(),
+            url(r'^products/create/(?P<product_class_id>\d+)/$',
+                self.product_create_view.as_view(),
                 name='catalogue-product-create'),
+            url(r'^products/delete/(?P<pk>\d+)/$',
+                self.product_delete_view.as_view(),
+                name='catalogue-product-delete'),
             url(r'^$', self.product_list_view.as_view(),
                 name='catalogue-product-list'),
             url(r'^stock-alerts/$', self.stock_alert_view.as_view(),
                 name='stock-alert-list'),
             url(r'^categories/$', self.category_list_view.as_view(),
                 name='catalogue-category-list'),
-            url(r'^categories/(?P<pk>\d+)/$', self.category_detail_list_view.as_view(),
+            url(r'^categories/(?P<pk>\d+)/$',
+                self.category_detail_list_view.as_view(),
                 name='catalogue-category-detail-list'),
             url(r'^categories/create/$', self.category_create_view.as_view(),
                 name='catalogue-category-create'),
-            url(r'^categories/update/(?P<pk>\d+)/$', self.category_update_view.as_view(),
+            url(r'^categories/update/(?P<pk>\d+)/$',
+                self.category_update_view.as_view(),
                 name='catalogue-category-update'),
-            url(r'^categories/delete/(?P<pk>\d+)/$', self.category_delete_view.as_view(),
+            url(r'^categories/delete/(?P<pk>\d+)/$',
+                self.category_delete_view.as_view(),
                 name='catalogue-category-delete'),
         )
         return self.post_process_urls(urlpatterns)

--- a/oscar/apps/dashboard/catalogue/views.py
+++ b/oscar/apps/dashboard/catalogue/views.py
@@ -8,13 +8,21 @@ from django.utils.translation import ugettext_lazy as _
 from oscar.apps.dashboard.catalogue import forms
 from oscar.core.loading import get_classes
 
-ProductForm, CategoryForm, StockRecordForm, StockAlertSearchForm, ProductCategoryFormSet, ProductImageFormSet = get_classes(
-    'dashboard.catalogue.forms', ('ProductForm', 'CategoryForm', 'StockRecordForm',
-                                  'StockAlertSearchForm',
-                                  'ProductCategoryFormSet',
-                                  'ProductImageFormSet'))
+(ProductForm,
+ CategoryForm,
+ StockRecordForm,
+ StockAlertSearchForm,
+ ProductCategoryFormSet,
+ ProductImageFormSet) = get_classes('dashboard.catalogue.forms',
+                                    ('ProductForm',
+                                     'CategoryForm',
+                                     'StockRecordForm',
+                                     'StockAlertSearchForm',
+                                     'ProductCategoryFormSet',
+                                     'ProductImageFormSet'))
 Product = get_model('catalogue', 'Product')
 Category = get_model('catalogue', 'Category')
+ProductImage = get_model('catalogue', 'ProductImage')
 ProductCategory = get_model('catalogue', 'ProductCategory')
 ProductClass = get_model('catalogue', 'ProductClass')
 StockRecord = get_model('partner', 'StockRecord')
@@ -268,6 +276,17 @@ class ProductUpdateView(generic.UpdateView):
     def get_success_url(self):
         messages.success(self.request, _("Updated product '%s'") %
                          self.object.title)
+        return reverse('dashboard:catalogue-product-list')
+
+
+class ProductDeleteView(generic.DeleteView):
+    template_name = 'dashboard/catalogue/product_delete.html'
+    model = Product
+    context_object_name = 'product'
+
+    def get_success_url(self):
+        msg =_("Deleted product '%s'") % self.object.title
+        messages.success(self.request, msg)
         return reverse('dashboard:catalogue-product-list')
 
 

--- a/oscar/templates/oscar/dashboard/catalogue/product_delete.html
+++ b/oscar/templates/oscar/dashboard/catalogue/product_delete.html
@@ -1,0 +1,55 @@
+{% extends 'dashboard/layout.html' %}
+{% load i18n %}
+
+{% block body_class %}
+create-page
+{% endblock %}
+
+{% block breadcrumbs %}
+<ul class="breadcrumb">
+    <li>
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>
+        <span class="divider">/</span>
+    </li>
+    <li>
+        <a href="{% url dashboard:catalogue-product-list %}">{% trans "Products" %}</a>
+        <span class="divider">/</span>
+    </li>
+    <li class="active">{% trans "Delete product?" %}</li>
+</ul>
+{% endblock %}
+
+{% block header %}
+<div class="page-header">
+	<h1>{% trans "Delete product?" %}</h1>
+</div>
+{% endblock header%}
+
+{% block dashboard_content %}
+<div class="table-header">
+    <h2>{% trans "Delete product" %}</h2>
+</div>
+<form action="." method="post" class="well">
+    {% csrf_token %}
+
+    {% blocktrans with title=product.title %}
+    <p>Delete product <strong>{{ title }}</strong> - are you sure?</p>
+    {% endblocktrans %}
+
+    {% if product.is_group %}
+    <p> {% trans "This will also delete the following variant products:" %}
+        <ul>
+            {% for variant in product.variants.all %}
+            <li><strong>{{ variant.title }}</strong></li>
+            {% endfor %}
+        </ul>
+    </p>
+    {% endif %}
+
+    <div class="form-actions">
+        <button type="submit" class="btn btn-danger">{% trans "Delete" %}</button>
+        {% trans "or" %}
+        <a href="{% url dashboard:catalogue-product-list %}">{% trans "cancel" %}</a>
+    </div>
+</form>
+{% endblock %}

--- a/oscar/templates/oscar/dashboard/catalogue/product_list.html
+++ b/oscar/templates/oscar/dashboard/catalogue/product_list.html
@@ -9,12 +9,12 @@
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">	
-    <li>	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a> 	
-        <span class="divider">/</span>	
-    </li> 	
-    <li class="active">{% trans "Product Management" %}</li> 	
+<ul class="breadcrumb">
+    <li>
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>
+        <span class="divider">/</span>
+    </li>
+    <li class="active">{% trans "Product Management" %}</li>
 </ul>
 {% endblock %}
 
@@ -61,46 +61,59 @@
     {% csrf_token %}
 	<table class="table table-striped table-bordered">
 	    <tr>
-			<th>{% trans "UPC" %}</th>
-			<th>{% trans "Title" %}</th>
-			<th>{% trans "Product class" %}</th>
-			<th>{% trans "Status" %}</th>
-			<th>{% trans "Partner" %}</th>
-			<th>{% trans "Partner SKU" %}</th>
-			<th>{% trans "Price excl. tax" %}</th>
-			<th>{% trans "Price incl. tax" %}</th>
-			<th>{% trans "Number in stock" %}</th>
-			<th>{% trans "Number allocated" %}</th>
+                <th>{% trans "UPC" %}</th>
+                <th>{% trans "Title" %}</th>
+                <th>{% trans "Product class" %}</th>
+                <th>{% trans "Status" %}</th>
+                <th>{% trans "Partner" %}</th>
+                <th>{% trans "Partner SKU" %}</th>
+                <th>{% trans "Price excl. tax" %}</th>
+                <th>{% trans "Price incl. tax" %}</th>
+                <th>{% trans "Number in stock" %}</th>
+                <th>{% trans "Number allocated" %}</th>
 	        <th></th>
 	    </tr>
 	    {% for product in products %}
 	    <tr>
-			<td>{{ product.upc|default:"-" }}</td>
+                <td>{{ product.upc|default:"-" }}</td>
 	        <td>{{ product.get_title }}</td>
-			<td>{{ product.product_class.name }}</td>
-			<td>{{ product.status|default:"-" }}</td>
-			{% with stockrecord=product.stockrecord %}
-				<td>{{ stockrecord.partner.name }}</td>
-				<td>{{ stockrecord.partner_sku }}</td>
-				<td>{{ stockrecord.price_excl_tax|currency }}</td>
-				<td>{{ stockrecord.price_incl_tax|currency }}</td>
-				<td>{{ stockrecord.num_in_stock }}</td>
-				<td>{{ stockrecord.num_allocated }}</td>
-			{% endwith %}
-			<td>
-			    <div class="btn-toolbar">
-                    <div class="btn-group">
-                      <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
-                        {% trans "Actions" %}
-                        <span class="caret"></span>
-                      </a>
-                      <ul class="dropdown-menu pull-right">
-                          <li><a href="{% url dashboard:catalogue-product product.id %}">{% trans "Edit" %}</a></li>
-          				  <li><a href="{{ product.get_absolute_url }}">{% trans "View on site" %}</a></li>
-                      </ul>
+                <td>{{ product.product_class.name }}</td>
+                <td>{{ product.status|default:"-" }}</td>
+                {% with stockrecord=product.stockrecord %}
+                    <td>{{ stockrecord.partner.name }}</td>
+                    <td>{{ stockrecord.partner_sku }}</td>
+                    <td>{{ stockrecord.price_excl_tax|currency }}</td>
+                    <td>{{ stockrecord.price_incl_tax|currency }}</td>
+                    <td>{{ stockrecord.num_in_stock }}</td>
+                    <td>{{ stockrecord.num_allocated }}</td>
+                {% endwith %}
+                <td>
+		    <div class="btn-toolbar">
+                        <div class="btn-group">
+                            <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
+                                {% trans "Actions" %}
+                                <span class="caret"></span>
+                            </a>
+                            <ul class="dropdown-menu pull-right">
+                                <li>
+                                    <a href="{% url dashboard:catalogue-product product.id %}">
+                                        {% trans "Edit" %}
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="{{ product.get_absolute_url }}">
+                                        {% trans "View on site" %}
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="{% url dashboard:catalogue-product-delete product.id %}">
+                                        {% trans "Delete" %}
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
                     </div>
-                </div>
-			</td>
+                </td>
 	    </tr>
 	    {% endfor %}
 	</table>


### PR DESCRIPTION
This PR adds delete functionality for products in the dashboard as described in #413. Deleting a product will prompt the user with the product title of the product to be deleted as well as all its variants (if any). If the user confirms the delete the following related objects are deleted as well:
- `StockRecord`
- `ProductImage`
- `ProductCategory` (only the mapping not the actual Category)
- all child/variant products

Let me know what you think and if there are any changes needed to get this PR merged.
