### PR TITLE
Throw exception if attribute does not exist

### DIFF
--- a/oscar/apps/catalogue/abstract_models.py
+++ b/oscar/apps/catalogue/abstract_models.py
@@ -344,16 +344,13 @@ class ProductAttributesContainer(object):
     def __getattr__(self, name):
         if not name.startswith('_') and not self.initialised:
             values = list(self.get_values().select_related('attribute'))
-            result = None
             for v in values:
                 setattr(self, v.attribute.code, v.value)
-                if v.attribute.code == name:
-                    result = v.value
             self.initialised = True
-            return result
-        raise AttributeError((_(u"%(obj)s has no attribute named " \
-                                       u"'%(attr)s'") % \
-                                     {'obj': self.product.product_class, 'attr': name}))
+            return getattr(self, name)
+        raise AttributeError((_(u"%(obj)s has no attribute named "\
+                                u"'%(attr)s'") %\
+                              {'obj': self.product.product_class, 'attr': name}))
         
     def validate_attributes(self):
         for attribute in self.get_all_attributes():

--- a/oscar/apps/catalogue/tests.py
+++ b/oscar/apps/catalogue/tests.py
@@ -6,6 +6,8 @@ from django.core.urlresolvers import reverse
 from oscar.apps.catalogue.models import Product, ProductClass, Category
 from oscar.apps.catalogue.utils import breadcrumbs_to_category
 
+import mock
+
 
 class CategoryTests(TestCase):
     
@@ -87,3 +89,17 @@ class SingleProductViewTest(TestCase):
         wrong_url = reverse('catalogue:detail', kwargs=args)
         response = self.client.get(wrong_url)
         self.assertEquals(301, response.status_code)
+
+
+class ProductAttributesTests(TestCase):
+    fixtures = ['sample-products']
+
+    @mock.patch("oscar.apps.catalogue.abstract_models.ENABLE_ATTRIBUTE_BINDING")
+    def test_existence_of_attribute(self, attribute_binding):
+
+        def get_fake_attribute(product):
+            return product.attr.fake_attribute
+
+        product = Product.objects.get(pk=1)
+
+        self.assertRaises(AttributeError, get_fake_attribute, product)


### PR DESCRIPTION
The very first call of `_getattr_` on `ProductAttributesContainer` behaved differently from any other later on. It returned `None` instead of throwing an exception.

The visible behaviour now is exact the same on every call.
