### PR TITLE
Report section proof of concept

### DIFF
--- a/oscar/apps/catalogue/reports.py
+++ b/oscar/apps/catalogue/reports.py
@@ -1,0 +1,46 @@
+from oscar.core.reports import Report
+from oscar.core.reports import Generator
+from oscar.core.reports.formatters import HTMLFormatter
+from oscar.core.reports.formatters import CSVFormatter
+
+from oscar.apps.catalogue.models import Product
+
+
+class ProductReport(Report):
+    """
+    Report that shows all the available products in the system
+    """
+    def get_data(self, params=None):
+        return Product.objects.all()
+
+
+class ProductReportHTMLFormatter(HTMLFormatter):
+    template_name = 'dashboard/reports/catalogue/product.html'
+
+
+class ProductReportHTMLGenerator(Generator):
+    """
+    HTML Report Generator
+    """
+    report_class = ProductReport
+    formatter_class = ProductReportHTMLFormatter
+    title = 'Product HTML Report'
+
+
+class ProductReportCSVFormatter(CSVFormatter):
+    fields = [
+        'upc',
+        'title',
+        'status',
+        'product_class'
+    ]
+
+
+class ProductReportCSVGenerator(Generator):
+    """
+    CSV Report Generator
+    """
+    report_class = ProductReport
+    formatter_class = ProductReportCSVFormatter
+    title = 'Product CSV Report'
+

--- a/oscar/apps/dashboard/reports/app.py
+++ b/oscar/apps/dashboard/reports/app.py
@@ -1,17 +1,23 @@
 from django.conf.urls import patterns, url
+from django.contrib.admin.views.decorators import staff_member_required
+from django.utils.translation import ugettext_lazy as _
 
-from oscar.views.decorators import staff_member_required
 from oscar.core.application import Application
 from oscar.apps.dashboard.reports import views
+from oscar.apps.dashboard.nav import register, Node
+
+node = Node(_('Reports'), 'dashboard:reports-index')
+register(node, 90)
 
 
 class ReportsApplication(Application):
     name = None
-    index_view = views.IndexView
+    index_view = views.ReportIndexView
 
     def get_urls(self):
         urlpatterns = patterns('',
             url(r'^$', self.index_view.as_view(), name='reports-index'),
+            url(r'^(?P<report_slug>[-\w]+)/$', views.ReportGeneratorView.as_view(), name='report-generator-view'),
         )
         return self.post_process_urls(urlpatterns)
 

--- a/oscar/apps/dashboard/reports/views.py
+++ b/oscar/apps/dashboard/reports/views.py
@@ -1,58 +1,31 @@
-from django.http import HttpResponseForbidden, Http404
-from django.template.response import TemplateResponse
-from django.views.generic import ListView
+from django.http import HttpResponse
+from django.views import generic
+
 from django.utils.translation import ugettext_lazy as _
 
 from oscar.core.loading import get_class
-ReportForm = get_class('dashboard.reports.forms', 'ReportForm')
-GeneratorRepository = get_class('dashboard.reports.utils', 'GeneratorRepository')
 
-class IndexView(ListView):
+from oscar.core.reports.views import ReportView
+from oscar.core.reports.autodiscover import _get_report_generator_map
+
+
+class ReportMapMixin(object):
+    report_generator_map = _get_report_generator_map()
+
+
+class ReportGeneratorView(ReportView, ReportMapMixin):
+    template_name = 'dashboard/reports/generator.html'
+
+    def get_generator_class(self):
+        return self.report_generator_map[self.kwargs['report_slug']]
+
+
+class ReportIndexView(generic.base.TemplateView, ReportMapMixin):
     template_name = 'dashboard/reports/index.html'
-    paginate_by = 25
-    context_object_name = 'objects'
-    report_form_class = ReportForm
-    generator_repository = GeneratorRepository
 
-    def _get_generator(self, form):
-        code = form.cleaned_data['report_type']
-
-        repo = self.generator_repository()
-        generator_cls = repo.get_generator(code)
-        if not generator_cls:
-            raise Http404()
-
-        download = form.cleaned_data['download']
-        formatter = 'CSV' if download else 'HTML'
-
-        return generator_cls(start_date=form.cleaned_data['date_from'],
-                             end_date=form.cleaned_data['date_to'],
-                             formatter=formatter)
-
-    def get(self, request, *args, **kwargs):
-        if 'report_type' in request.GET:
-            form = self.report_form_class(request.GET)
-            if form.is_valid():
-                generator = self._get_generator(form)
-                if not generator.is_available_to(request.user):
-                    return HttpResponseForbidden(_("You do not have access to this report"))
-
-                report = generator.generate()
-
-                if form.cleaned_data['download']:
-                    return report
-                else:
-                    self.set_list_view_attrs(generator, report)
-                    context = self.get_context_data(object_list=self.queryset)
-                    context['form'] = form
-                    context['description'] = generator.report_description()
-                    return self.render_to_response(context)
-        else:
-            form = self.report_form_class()
-        return TemplateResponse(request, self.template_name, {'form': form})
-
-    def set_list_view_attrs(self, generator, report):
-        self.template_name = generator.filename()
-        self.object_list = self.queryset = report
+    def get_context_data(self, *args, **kwargs):
+        ctx = super(ReportIndexView, self).get_context_data(*args, **kwargs)
+        ctx['report_generator_map'] = self.report_generator_map
+        return ctx
 
 

--- a/oscar/core/reports/__init__.py
+++ b/oscar/core/reports/__init__.py
@@ -1,0 +1,2 @@
+from .report import *
+from .generators import *

--- a/oscar/core/reports/autodiscover.py
+++ b/oscar/core/reports/autodiscover.py
@@ -1,0 +1,24 @@
+import importlib
+from django.conf import settings
+from oscar.core.reports.generators import Generator
+from django.template.defaultfilters import slugify
+
+def _get_report_generator_map():
+    report_map = {}
+
+    for app in settings.INSTALLED_APPS:
+        try:
+            module = importlib.import_module("%s.reports" % app)
+        except ImportError:
+            continue
+
+        for attr_name in dir(module):
+            attr = getattr(module, attr_name)
+            if not isinstance(attr, type):
+                continue
+            if issubclass(attr, Generator):
+                if attr.title is not None:
+                    report_map[slugify(attr.title)] = attr
+    return report_map
+
+

--- a/oscar/core/reports/formatters.py
+++ b/oscar/core/reports/formatters.py
@@ -1,0 +1,46 @@
+import StringIO
+import csv
+from django.template.loader import render_to_string
+from django.utils.html import mark_safe
+
+
+class Formatter(object):
+
+    def __init__(self, context={}):
+        self.context = context
+
+    def render(self):
+        pass
+
+
+class CSVFormatter(Formatter):
+    content_type = 'application/csv'
+    fields = []
+
+    def render(self, data):
+        def _getattr(obj, attr_path):
+            parts = attr_path.split('.')
+            return_value = obj
+            for part in parts:
+                return_value = getattr(return_value, part)
+            return return_value
+
+        fd = StringIO.StringIO()
+        output_file = csv.writer(fd, delimiter=',', quotechar='"')
+        output_file.writerow(self.fields)
+        for row in data:
+            output_row = [_getattr(row, field) for field in self.fields]
+            output_file.writerow(output_row)
+        output = fd.getvalue()
+        fd.close()
+        return output
+
+class HTMLFormatter(Formatter):
+    content_type = 'text/html'
+    data_context_name = 'data'
+    template_name = ''
+
+    def render(self, data):
+        self.context.update({self.data_context_name: data})
+        return mark_safe(render_to_string(self.template_name, self.context))
+

--- a/oscar/core/reports/forms.py
+++ b/oscar/core/reports/forms.py
@@ -1,0 +1,10 @@
+from django import forms
+
+class DefaultForm(forms.Form):
+    """
+    As the report generator view is a FormView we give it a Empty form as
+    the default form.
+    If needed the Report form can be overriden to provide data validation
+    before the form to be run.
+    """
+

--- a/oscar/core/reports/generators.py
+++ b/oscar/core/reports/generators.py
@@ -1,0 +1,22 @@
+
+class Generator(object):
+    """
+    This class is the one that carries out with the Full report generation.
+    """
+
+    report_class = None
+    formatter_class = None
+    title = None
+
+    def __init__(self, context={}, params={}):
+        # context is passed to the formatter
+        # params is passed to the form get_data
+        self.context = context
+        self.params = params
+        self.formatter = self.formatter_class(self.context)
+
+    def run(self):
+        self.report = self.report_class()
+        data = self.report.get_data(self.params)
+        self.output_text = self.formatter.render(data)
+

--- a/oscar/core/reports/generators.py
+++ b/oscar/core/reports/generators.py
@@ -8,12 +8,18 @@ class Generator(object):
     formatter_class = None
     title = None
 
+    def get_formatter_class(self):
+        return self.formatter_class
+
+    def get_formatter(self, *args, **kwargs):
+        return self.get_formatter_class()(*args, **kwargs)
+
     def __init__(self, context={}, params={}):
         # context is passed to the formatter
         # params is passed to the form get_data
         self.context = context
         self.params = params
-        self.formatter = self.formatter_class(self.context)
+        self.formatter = self.get_formatter(self.context)
 
     def run(self):
         self.report = self.report_class()

--- a/oscar/core/reports/report.py
+++ b/oscar/core/reports/report.py
@@ -6,10 +6,17 @@ class Report(object):
     A report to be generated has to validate the given input
     """
 
+    data = []
     form_class = DefaultForm
-    params = {}
 
-    def get_data(self, params=None):
+    def get_form(self, *args, **kwargs):
+        return self.form_class(*args, **kwargs)
+
+    def __init__(self, params={}, **kwargs):
+        self.params = params
+        self.form = self.get_form(self.params)
+
+    def get_data(self, params={}):
         "This is the method to be overriden"
-        pass
+        return self.data
 

--- a/oscar/core/reports/report.py
+++ b/oscar/core/reports/report.py
@@ -1,0 +1,15 @@
+from .forms import DefaultForm
+
+
+class Report(object):
+    """
+    A report to be generated has to validate the given input
+    """
+
+    form_class = DefaultForm
+    params = {}
+
+    def get_data(self, params=None):
+        "This is the method to be overriden"
+        pass
+

--- a/oscar/core/reports/views.py
+++ b/oscar/core/reports/views.py
@@ -1,0 +1,38 @@
+from django.views import generic
+from django.http import HttpResponse
+from django.template import RequestContext
+
+from .generators import Generator
+
+class ReportView(generic.edit.FormView):
+    """
+    This class is meant to be used when creating a report view
+    """
+
+    generator_class = Generator
+    template_name = 'dashboard/reports/base.html'
+
+    def get_generator_class(self, *args, **kwargs):
+        return self.generator_class
+
+    def get_generator(self, *args, **kwargs):
+        return self.get_generator_class()(*args, **kwargs)
+
+    def get_form_class(self):
+        return self.generator_class.report_class.form_class
+
+    def get(self, *args, **kwargs):
+        self.generator_class = self.get_generator_class()
+        return super(ReportView, self).get(*args, **kwargs)
+
+    def post(self, *args, **kwargs):
+        self.generator_class = self.get_generator_class()
+        return super(ReportView, self).post(*args, **kwargs)
+
+    def form_valid(self, form):
+        context = RequestContext(self.request)
+        self.generator = self.get_generator(context, form.cleaned_data)
+        self.generator.run()
+        return HttpResponse(self.generator.output_text,
+                    content_type=self.generator.formatter.content_type)
+

--- a/oscar/templates/oscar/dashboard/reports/catalogue/product.html
+++ b/oscar/templates/oscar/dashboard/reports/catalogue/product.html
@@ -1,0 +1,43 @@
+{% extends 'dashboard/layout.html' %}
+{% load currency_filters %}
+{% load i18n %}
+
+{% block body_class %}reports{% endblock %}
+{% block title %}
+{% trans "Reports" %} | {{ block.super }}
+{% endblock %}
+
+{% block breadcrumbs %}
+<ul class="breadcrumb">	  	
+    <li>	  	
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>	  	
+        <span class="divider">/</span>
+        <a href="{% url dashboard:reports-index %}">{% trans "Reporting Dashboard" %}</a>	  	
+    </li>	  	
+</ul>
+{% endblock %}
+
+{% block header %}
+<div class="page-header">
+	<h1>{% trans "Product Report" %}</h1>
+</div>
+{% endblock header %}
+
+{% block dashboard_content%}
+    <table class="table table-striped table-bordered table-hover">
+    <tr>
+        <th>{% trans "UPC" %}</th>
+        <th>{% trans "Title" %}</th>
+        <th>{% trans "Product class" %}</th>
+        <th>{% trans "Status" %}</th>
+    </td>
+    {% for row in data %}
+        <tr> 
+            <td>{{ row.upc }}</td>
+            <td>{{ row.title }}</td>
+            <td>{{ row.product_class }}</td>
+            <td>{{ row.status }}</td>
+        </tr>
+    {% endfor %}
+    </table>
+{% endblock %}

--- a/oscar/templates/oscar/dashboard/reports/generator.html
+++ b/oscar/templates/oscar/dashboard/reports/generator.html
@@ -11,9 +11,9 @@
 <ul class="breadcrumb">	  	
     <li>	  	
         <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>	  	
-        <span class="divider">/</span>	  	
+        <span class="divider">/</span>
+        <a href="{% url dashboard:reports-index %}">{% trans "Reporting Dashboard" %}</a>	  	
     </li>	  	
-    <li class="active">{% trans "Reporting Dashboard" %}</li>	  	
 </ul>
 {% endblock %}
 
@@ -29,13 +29,11 @@
     <h3><i class="icon-bar-chart icon-large"></i>{% trans "Reporting dashboard" %}</h3>
 </div>
 <div class="well">
-
-    <ul> 
-    {% for key, generator in report_generator_map.iteritems %} 
-        <li><a href="{% url dashboard:report-generator-view key %}">{{ generator.title }}</a></li>
-    {% endfor %}    
-    </ul>
-    
+    <form method="POST" action="." enctype="multipart/form-data">
+        {% csrf_token %}
+        {{ form }}
+        <button type="submit">Generate</button>
+    </form>     
 </div>
 
 {% if description %}

--- a/sites/sandbox/templates/promotions/home.html
+++ b/sites/sandbox/templates/promotions/home.html
@@ -1,6 +1,6 @@
 {% extends 'oscar/promotions/home.html' %}
 
 {% block content %}
-<a href="{% url gateway %}" class="btn btn-large btn-success">Get dashboard access</a>
+<a href="{% url gateway %}">Get dashboard access</a>
 
 {% endblock %}

--- a/tests/unit/dashboard/reports_tests.py
+++ b/tests/unit/dashboard/reports_tests.py
@@ -1,0 +1,65 @@
+import mock
+from django.test import TestCase
+
+
+class GeneratorTest(TestCase):
+    """
+    """
+
+    def _get_test_class(self):
+        from oscar.core.reports import Generator
+        return Generator
+
+    def _create_generator_object(self, **kwargs):
+        return self._get_test_class()(**kwargs)
+
+    def test_constructor_test(self):
+        self._get_test_class()
+        pass
+
+
+class ReportTest(TestCase):
+    """
+    """
+
+    def _get_test_class(self):
+        from oscar.core.reports import Report
+        return Report
+
+    def test_constructor_calls_get_form_and_sets_params(self):
+        params_dict = {'name': 'oscar'}
+        with mock.patch('oscar.core.reports.Report.get_form') as get_form:
+            report_class = self._get_test_class()
+            report = report_class(params=params_dict)
+            self.assertEqual(get_form.call_count, 1)
+            get_form.assert_called_once_with(params_dict)
+            self.assertEqual(report.params, params_dict)
+
+
+class FormatterTest(TestCase):
+    """
+    """
+
+    def _get_test_formatter_class(self):
+        from oscar.core.reports.formatters import Formatter
+        return Formatter
+
+    def _get_test_paginated_formatter_class(self, _paginator_class, _paginated_by):
+        formatter_klass = self._get_test_formatter_class()
+        class PaginatedFormatter(formatter_klass):
+            paginated_by = _paginated_by
+            paginator_class = _paginator_class
+        return PaginatedFormatter
+
+    def test_get_data_chunk__returns_data_if_has_paginator_and_paginated_by(self):
+        from django.core.paginator import Paginator
+        formatter_class = self._get_test_paginated_formatter_class(Paginator, 2)
+        formatter = formatter_class(context={})
+        self.assertEqual(formatter.get_data_chunk([1, 2, 3, 4], 1), [1, 2])
+        self.assertEqual(formatter.get_data_chunk([1, 2, 3, 4], 2), [3, 4])
+
+    def test_get_data_chunk__returns_all_data_if_not_paginated(self):
+        formatter_class = self._get_test_formatter_class()
+        formatter = formatter_class()
+        self.assertEqual(formatter.get_data_chunk([1, 2, 3]), [1, 2, 3])
+


### PR DESCRIPTION
Created a proof of concept on how Report section on the dashboard should
work.

There is still a couple of big question marks on how right this approach
is to the problem. There is some cross-logic on Generator and Formatters
going on which will have to be tackled in the future in order a user to
be able to override the Generator.run() method.

One good idea could be to create a CeleryGenerator class which would be
capable to dispatch a report generator to a different machine.

Examples on how to create reports can be found on
oscar/apps/catalogue/reports.py.

There is also an autodiscover function which will pick all the available
report generators and make them available for a user to run on the
dashboard reports page.
