### PR TITLE
Wrap less compilation in own block

### DIFF
--- a/oscar/templates/oscar/base.html
+++ b/oscar/templates/oscar/base.html
@@ -22,6 +22,7 @@
             <link rel="shortcut icon" href="{{ STATIC_URL }}oscar/favicon.ico" />
         {% endblock %}
 
+        {% block mainstylesheet %}
         {% if use_less %}
             {# LESS - use in debug mode #}
             {% block less %}
@@ -41,6 +42,7 @@
                 {% endblock %}
             {% endcompress %}
         {% endif %}
+        {% endblock %}
 
         {# Additional CSS - specific to certain pages #}
         {% compress css %}


### PR DESCRIPTION
This is related to the change merge in with PR #246. The changes to `base.html` are cause problems for projects where we are using the virtual-(less|node) approach to deploy both as PyPI packages and compile on the fly in dev and using the `compress` management command in production.

The problem is this approach does not work with the new template and there is now way of overwriting that section of the template without replacing it entirely. So I am suggestion that we wrap the main stylesheets in a `mainstylesheet` block (as previously) that can be overwritten in extended templates. 

I am merging this in right away but wanted to provide some reasoning for this change. If you can see any reason for this causing problems, please let me know.
