### PR TITLE
Add the git protocol to the django-haystack dependency link

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(name='django-oscar',
           'python-memcached>=1.48,<1.49',
           'Babel>=0.9,<0.10',
           'django-compressor>=1.2,<1.3'],
-      dependency_links=['git://github.com/toastdriven/django-haystack.git@0e95d8696f8ba770f9c60152136aba32f5591fd6#egg=django-haystack-2.0.0-beta'],
+      dependency_links=['git+git://github.com/toastdriven/django-haystack.git@0e95d8696f8ba770f9c60152136aba32f5591fd6#egg=django-haystack-2.0.0-beta'],
       #dependency_links=['http://github.com/toastdriven/django-haystack/tarball/master@0e95d8696f8ba770f9c60152136aba32f5591fd6#egg=django-haystack-2.0.0-beta'],
       # See http://pypi.python.org/pypi?%3Aaction=list_classifiers
       classifiers=[


### PR DESCRIPTION
Without it, it is a malformed VCS url.

Valid format is <vcs>+<protocol>://<url>.
