### PR TITLE
Docs: Remove duplicate OSCAR_IMAGE_FOLDER entry

### DIFF
--- a/docs/source/reference/settings.rst
+++ b/docs/source/reference/settings.rst
@@ -188,13 +188,6 @@ Default: 604800 (1 week in seconds)
 
 The time to live for the basket cookie in seconds
 
-OSCAR_IMAGE_FOLDER
-------------------
-
-Default: ``images/products/%Y/%m/``
-
-The path for uploading images to.
-
 OSCAR_RECENTLY_VIEWED_PRODUCTS
 ------------------------------
 


### PR DESCRIPTION
http://django-oscar.readthedocs.org/en/latest/reference/settings.html currently explains OSCAR_IMAGE_FOLDER twice. I removed the less detailed explanation.
