### PR TITLE
Fix URL for category update view in dashboard.

### DIFF
--- a/oscar/apps/dashboard/catalogue/app.py
+++ b/oscar/apps/dashboard/catalogue/app.py
@@ -46,7 +46,7 @@ class CatalogueApplication(Application):
                 name='catalogue-category-detail-list'),
             url(r'^categories/create/$', self.category_create_view.as_view(),
                 name='catalogue-category-create'),
-            url(r'^categories/(?P<pk>\d+)/$',
+            url(r'^categories/(?P<pk>\d+)/update/$',
                 self.category_update_view.as_view(),
                 name='catalogue-category-update'),
             url(r'^categories/(?P<pk>\d+)/delete/$',


### PR DESCRIPTION
Detail view and update view had the same URL, update view is now /{pk}/update/, which is consistent with other URLs. 
I spotted this trying to edit categories in the dashboard, and couldn't edit the category itself, as it was the same link for editing the children.
