### PR TITLE
Fix template error for product class.

### DIFF
--- a/oscar/templates/oscar/dashboard/catalogue/product_update.html
+++ b/oscar/templates/oscar/dashboard/catalogue/product_update.html
@@ -109,7 +109,6 @@
             {% include "partials/form_fields_inline.html" with form=category_form %}
         {% endfor %}
     </div>
-</div>
 
 <div class="table-header">
     <h3>{% trans "Upload, change or remove images" %}</h3>


### PR DESCRIPTION
templates/oscar/dashboard/catalogue/product_update.html tried to render the product class via `{{ product.product_class }}`. `product` is not in the template context, but `product_class` is. Altering the template code gives the expected result.

The bug is currently visible in the Oscar Sandbox.

Note: This was spotted because I have [TEMPLATE_STRING_IF_INVALID](https://docs.djangoproject.com/en/dev/ref/settings/#template-string-if-invalid) set to something obnoxious. Recommended.

dashboard/catalogue/views.py:

```
class ProductCreateView(generic.CreateView):
    [...]

    def get_context_data(self, **kwargs):
        ctx = super(ProductCreateView, self).get_context_data(**kwargs)
        pclass = self.get_product_class()
        if 'stockrecord_form' not in ctx:
            ctx['stockrecord_form'] = StockRecordForm(pclass)
        if 'category_formset' not in ctx:
            ctx['category_formset'] = ProductCategoryFormSet()
        if 'image_formset' not in ctx:
            ctx['image_formset'] = ProductImageFormSet()
        ctx['title'] = _('Create new %s product') % pclass.name
        ctx['product_class'] = pclass
        return ctx

    def get_product_class(self):
        return ProductClass.objects.get(id=self.kwargs['product_class_id'])

    def get_form_kwargs(self):
        kwargs = super(ProductCreateView, self).get_form_kwargs()
        kwargs['product_class'] = self.get_product_class()
        return kwargs
```
