### PR TITLE
Make ProductSearchForm customisable.

### DIFF
--- a/oscar/apps/dashboard/catalogue/views.py
+++ b/oscar/apps/dashboard/catalogue/views.py
@@ -5,16 +5,17 @@ from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 
-from oscar.apps.dashboard.catalogue import forms
 from oscar.core.loading import get_classes
 
 (ProductForm,
+ ProductSearchForm,
  CategoryForm,
  StockRecordForm,
  StockAlertSearchForm,
  ProductCategoryFormSet,
  ProductImageFormSet) = get_classes('dashboard.catalogue.forms',
                                     ('ProductForm',
+                                     'ProductSearchForm',
                                      'CategoryForm',
                                      'StockRecordForm',
                                      'StockAlertSearchForm',
@@ -33,7 +34,7 @@ class ProductListView(generic.ListView):
     template_name = 'dashboard/catalogue/product_list.html'
     model = Product
     context_object_name = 'products'
-    form_class = forms.ProductSearchForm
+    form_class = ProductSearchForm
     description_template = _(u'Products %(upc_filter)s %(title_filter)s')
     paginate_by = 20
 


### PR DESCRIPTION
Note: Please review before merging.

All forms in the oscar.dashboard.catalogue app are overridable via the
common get_classes pattern, apart from the ProductSearchForm which is
imported directly from oscar.dashboard.catalogue.forms.
I've grepped through the source code, but couldn't find any hints on
why that would be necessary. As ProductSearchForm is quite simple
(not a ModelForm, and just two fields) I deemed it a bug and updated the
code to allow customising like everywhere else.
The tests run through fine, and the sandbox site works as expected.
