### PR TITLE
Adding transactions listing on order details, payment tab

### DIFF
--- a/oscar/templates/oscar/dashboard/orders/order_detail.html
+++ b/oscar/templates/oscar/dashboard/orders/order_detail.html
@@ -39,8 +39,8 @@
             <td>{{ order.user.email|default:"-" }}</td>
         </tr>
     {% else %}
-	    <tr><td>{% trans "Customer checked out anonymously." %}</td></tr>
-	{% endif %}
+        <tr><td>{% trans "Customer checked out anonymously." %}</td></tr>
+    {% endif %}
 </table>
 
 <table class="table table-striped table-bordered table-hover">
@@ -63,7 +63,7 @@
 {% endblock additional_order_information %}
 
 <div class="sub-header">
-	<h2>{% trans "Order Details" %}</h2>
+    <h2>{% trans "Order Details" %}</h2>
 </div>
 
 <div class="tabbable dashboard">
@@ -79,278 +79,278 @@
         {% endblock nav_tabs %}
     </ul>
 
-	<div class="tab-content">
-		<div class="tab-pane {% if active_tab == 'lines' %}active{% endif %}" id="lines">
-			<div class="table-header">
-				<h3>{% trans "Items ordered" %}</h3>
-			</div>
-			<form action="." method="post" class="form-inline">
-				{% csrf_token %}
-				<table class="table table-striped table-bordered table-hover">
-					<thead>
-						<tr>
-							<th>{% trans "Select" %}</th>
-							<th>{% trans "Quantity" %}</th>
-							<th>{% trans "Product" %}</th>
-							<th>{% trans "UPC" %}</th>
-							<th>{% trans "Status" %}</th>
-							<th>{% trans "Supplier" %}</th>
-							<th>{% trans "Supplier SKU" %}</th>
-							<th>{% trans "Est. delivery date" %}</th>
-							<th>{% trans "Price (before discounts)" %}</th>
-							<th>{% trans "Actions" %}</th>
-						</tr>
-					</thead>
-					<tbody>
-						{% for line in order.lines.all %}
-						<tr>
-							<td>
-								<input type="checkbox" name="selected_line" value="{{ line.id }}" />
-								<input type="text" name="selected_line_qty" value="{{ line.quantity }}" class="span1" size="2" />
-							</td>
-							<td>{{ line.quantity }}</td>
-							<td>{{ line.title }}</td>
-							<td>{{ line.upc|default:"-" }}</td>
-							<td>{{ line.status|default:"-" }}</td>
-							<td>{{ line.partner_name }}</td>
-							<td>{{ line.partner_sku }}</td>
-							<td>{{ line.est_dispatch_date|default:"-" }}</td>
-							<td>{{ line.line_price_before_discounts_incl_tax|currency }}</td>
-							<td>
-								<a href="{% url dashboard:order-line-detail order.number line.id %}" class="btn btn-info">{% trans "View" %}</a>
-							</td>
-						</tr>
-						{% endfor %}
-						<tr>
-							<td colspan="7"></td>
-							<th>{% trans "Discount" %}</th>
-							<td>{{ order.total_discount_incl_tax|currency }}</td>
-							<td></td>
-						</tr>
-						<tr>
-							<td colspan="7"></td>
-							<th>{% trans "Shipping charge" %}</th>
-							<td>{{ order.shipping_incl_tax|currency }}</td>
-							<td></td>
-						</tr>
-						<tr>
-							<td colspan="7"></td>
-							<th>{% trans "Total" %}</th>
-							<td>{{ order.total_incl_tax|currency }}</td>
-							<td></td>
-						</tr>
-					</tbody>
-				</table>
+    <div class="tab-content">
+        <div class="tab-pane {% if active_tab == 'lines' %}active{% endif %}" id="lines">
+            <div class="table-header">
+                <h3>{% trans "Items ordered" %}</h3>
+            </div>
+            <form action="." method="post" class="form-inline">
+                {% csrf_token %}
+                <table class="table table-striped table-bordered table-hover">
+                    <thead>
+                        <tr>
+                            <th>{% trans "Select" %}</th>
+                            <th>{% trans "Quantity" %}</th>
+                            <th>{% trans "Product" %}</th>
+                            <th>{% trans "UPC" %}</th>
+                            <th>{% trans "Status" %}</th>
+                            <th>{% trans "Supplier" %}</th>
+                            <th>{% trans "Supplier SKU" %}</th>
+                            <th>{% trans "Est. delivery date" %}</th>
+                            <th>{% trans "Price (before discounts)" %}</th>
+                            <th>{% trans "Actions" %}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for line in order.lines.all %}
+                        <tr>
+                            <td>
+                                <input type="checkbox" name="selected_line" value="{{ line.id }}" />
+                                <input type="text" name="selected_line_qty" value="{{ line.quantity }}" class="span1" size="2" />
+                            </td>
+                            <td>{{ line.quantity }}</td>
+                            <td>{{ line.title }}</td>
+                            <td>{{ line.upc|default:"-" }}</td>
+                            <td>{{ line.status|default:"-" }}</td>
+                            <td>{{ line.partner_name }}</td>
+                            <td>{{ line.partner_sku }}</td>
+                            <td>{{ line.est_dispatch_date|default:"-" }}</td>
+                            <td>{{ line.line_price_before_discounts_incl_tax|currency }}</td>
+                            <td>
+                                <a href="{% url dashboard:order-line-detail order.number line.id %}" class="btn btn-info">{% trans "View" %}</a>
+                            </td>
+                        </tr>
+                        {% endfor %}
+                        <tr>
+                            <td colspan="7"></td>
+                            <th>{% trans "Discount" %}</th>
+                            <td>{{ order.total_discount_incl_tax|currency }}</td>
+                            <td></td>
+                        </tr>
+                        <tr>
+                            <td colspan="7"></td>
+                            <th>{% trans "Shipping charge" %}</th>
+                            <td>{{ order.shipping_incl_tax|currency }}</td>
+                            <td></td>
+                        </tr>
+                        <tr>
+                            <td colspan="7"></td>
+                            <th>{% trans "Total" %}</th>
+                            <td>{{ order.total_incl_tax|currency }}</td>
+                            <td></td>
+                        </tr>
+                    </tbody>
+                </table>
 
-				{% block line_actions %}
+                {% block line_actions %}
                 <div class="well">
-    				<h3><i class="icon-refresh"></i> With selected lines:</h3>
+                    <h3><i class="icon-refresh"></i> With selected lines:</h3>
 
-    				<div class="control-group">
-    					<div class="controls">
-    						<label class="radio inline">
-    							<input type="radio" name="line_action" value="change_line_statuses" /> {% trans "Change status to" %}
-    						</label>
-    						<label class="radio inline">
-    							<select name="new_status">
-    								<option value=""> -- {% trans "choose new status" %} -- </option>
-    								{% for status in line_statuses %}
-    								<option>{{ status }}</option>
-    								{% endfor %}
-    							</select>
-    						</label>
-    					</div>
-    				</div>
-    				<div class="control-group">
-    					<div class="controls">
-    						<label class="radio inline">
-    							<input type="radio" name="line_action" value="create_shipping_event" /> {% trans "Create shipping event" %}
-    						</label>
-    						<label class="radio inline">
-    							<select name="shipping_event_type">
-    								<option value=""> -- {% trans "choose event type" %} -- </option>
-    								{% for event_type in shipping_event_types %}
-    								<option value="{{ event_type.code }}">{{ event_type.name }}</option>
-    								{% endfor %}
-    							</select>
-    						</label>
-    						<label class="radio inline">
-    							with reference <input type="text" name="reference" value="" />
-    						</label>
-    					</div>
-    				</div>
-    				<div class="control-group">
-    					<div class="controls">
-    						<label class="radio inline">
-    							<input type="radio" name="line_action" value="create_payment_event" /> {% trans "Create payment event" %}
-    						</label>
-    						<label class="radio inline">
-    							<select name="payment_event_type">
-    								<option value=""> -- {% trans "choose event type" %} -- </option>
-    								{% for event_type in payment_event_types %}
-    								<option value="{{ event_type.code }}">{{ event_type.name }}</option>
-    								{% endfor %}
-    							</select>
-    						</label>
-    						<label class="radio inline">
-    							with amount <input type="text" name="amount" value="" />
-    						</label>
-    					</div>
-    				</div>
-					<input type="submit" value="{% trans "Go!" %}" class="btn btn-primary" />
-    			</form>
-			</div>
-			{% endblock line_actions %}
+                    <div class="control-group">
+                        <div class="controls">
+                            <label class="radio inline">
+                                <input type="radio" name="line_action" value="change_line_statuses" /> {% trans "Change status to" %}
+                            </label>
+                            <label class="radio inline">
+                                <select name="new_status">
+                                    <option value=""> -- {% trans "choose new status" %} -- </option>
+                                    {% for status in line_statuses %}
+                                    <option>{{ status }}</option>
+                                    {% endfor %}
+                                </select>
+                            </label>
+                        </div>
+                    </div>
+                    <div class="control-group">
+                        <div class="controls">
+                            <label class="radio inline">
+                                <input type="radio" name="line_action" value="create_shipping_event" /> {% trans "Create shipping event" %}
+                            </label>
+                            <label class="radio inline">
+                                <select name="shipping_event_type">
+                                    <option value=""> -- {% trans "choose event type" %} -- </option>
+                                    {% for event_type in shipping_event_types %}
+                                    <option value="{{ event_type.code }}">{{ event_type.name }}</option>
+                                    {% endfor %}
+                                </select>
+                            </label>
+                            <label class="radio inline">
+                                with reference <input type="text" name="reference" value="" />
+                            </label>
+                        </div>
+                    </div>
+                    <div class="control-group">
+                        <div class="controls">
+                            <label class="radio inline">
+                                <input type="radio" name="line_action" value="create_payment_event" /> {% trans "Create payment event" %}
+                            </label>
+                            <label class="radio inline">
+                                <select name="payment_event_type">
+                                    <option value=""> -- {% trans "choose event type" %} -- </option>
+                                    {% for event_type in payment_event_types %}
+                                    <option value="{{ event_type.code }}">{{ event_type.name }}</option>
+                                    {% endfor %}
+                                </select>
+                            </label>
+                            <label class="radio inline">
+                                with amount <input type="text" name="amount" value="" />
+                            </label>
+                        </div>
+                    </div>
+                    <input type="submit" value="{% trans "Go!" %}" class="btn btn-primary" />
+                </form>
+            </div>
+            {% endblock line_actions %}
 
-			<div class="table-header">
-				<h3>{% trans "Shipping Events" %}</h3>
-			</div>
-			{% with events=order.shipping_events.all %}
-			<table class="table table-striped table-bordered table-hover">
-			    {% if events %}
-    				<thead>
-    					<tr>
-    						<th>{% trans "Date" %}</th>
-    						<th>{% trans "Event" %}</th>
-    						<th>{% trans "Lines" %}</th>
-    						<th>{% trans "Notes" %}</th>
-    					</tr>
-    				</thead>
-    				<tbody>
-    					{% for event in events %}
-    					{% with line_qtys=event.line_quantities.all %}
-    					<tr>
-    						<td rowspan="{{ line_qtys|length }}">{{ event.date }}</td>
-    						<td rowspan="{{ line_qtys|length }}">{{ event.event_type.name }}</td>
-    						<td>
-    							{% for line_qty in event.line_quantities.all %}
-    							{% trans "Product:" %} {{ line_qty.line.title }} - {% trans "quantity" %} {{ line_qty.quantity }}</br>
-    							{% endfor %}
-    						</td>
-    						<td>{{ event.notes }}</td>
-    					</tr>
-    					{% endwith %}
-    					{% endfor %}
-    				</tbody>
-				{% else %}
+            <div class="table-header">
+                <h3>{% trans "Shipping Events" %}</h3>
+            </div>
+            {% with events=order.shipping_events.all %}
+            <table class="table table-striped table-bordered table-hover">
+                {% if events %}
+                    <thead>
+                        <tr>
+                            <th>{% trans "Date" %}</th>
+                            <th>{% trans "Event" %}</th>
+                            <th>{% trans "Lines" %}</th>
+                            <th>{% trans "Notes" %}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for event in events %}
+                        {% with line_qtys=event.line_quantities.all %}
+                        <tr>
+                            <td rowspan="{{ line_qtys|length }}">{{ event.date }}</td>
+                            <td rowspan="{{ line_qtys|length }}">{{ event.event_type.name }}</td>
+                            <td>
+                                {% for line_qty in event.line_quantities.all %}
+                                {% trans "Product:" %} {{ line_qty.line.title }} - {% trans "quantity" %} {{ line_qty.quantity }}</br>
+                                {% endfor %}
+                            </td>
+                            <td>{{ event.notes }}</td>
+                        </tr>
+                        {% endwith %}
+                        {% endfor %}
+                    </tbody>
+                {% else %}
                 <tbody>
                     <tr>
                         <td>No shipping events.</td>
                     </tr>
                 </tbody>
-    			{% endif %}
-			</table>
+                {% endif %}
+            </table>
 
-			{% endwith %}
+            {% endwith %}
 
-			<div class="table-header">
-				<h3 >{% trans "Payment Events" %}</h3>
-			</div>
-			{% with events=order.payment_events.all %}
-			<table class="table table-striped table-bordered table-hover">
-			    {% if events %}
-    				<thead>
-    					<tr>
-    						<th>{% trans "Date" %}</th>
-    						<th>{% trans "Event" %}</th>
-    						<th>{% trans "Amount" %}</th>
-    						<th>{% trans "Lines" %}</th>
-    					</tr>
-    				</thead>
-    				<tbody>
-    					{% for event in events %}
-    					{% with line_qtys=event.line_quantities.all %}
-    					<tr>
-    						<td >{{ event.date }}</td>
-    						<td >{{ event.event_type.name }}</td>
-    						<td >{{ event.amount|currency }}</td>
-    						<td>
-    							{% for line_qty in event.line_quantities.all %}
-    							{% trans "Product:" %} {{ line_qty.line.title }} - {% trans "quantity" %} {{ line_qty.quantity }}</br>
-    							{% endfor %}
-    						</td>
-    					</tr>
-    					{% endwith %}
-    					{% endfor %}
-    				</tbody>
-				{% else %}
+            <div class="table-header">
+                <h3 >{% trans "Payment Events" %}</h3>
+            </div>
+            {% with events=order.payment_events.all %}
+            <table class="table table-striped table-bordered table-hover">
+                {% if events %}
+                    <thead>
+                        <tr>
+                            <th>{% trans "Date" %}</th>
+                            <th>{% trans "Event" %}</th>
+                            <th>{% trans "Amount" %}</th>
+                            <th>{% trans "Lines" %}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for event in events %}
+                        {% with line_qtys=event.line_quantities.all %}
+                        <tr>
+                            <td >{{ event.date }}</td>
+                            <td >{{ event.event_type.name }}</td>
+                            <td >{{ event.amount|currency }}</td>
+                            <td>
+                                {% for line_qty in event.line_quantities.all %}
+                                {% trans "Product:" %} {{ line_qty.line.title }} - {% trans "quantity" %} {{ line_qty.quantity }}</br>
+                                {% endfor %}
+                            </td>
+                        </tr>
+                        {% endwith %}
+                        {% endfor %}
+                    </tbody>
+                {% else %}
                     <tbody>
                         <tr><td>{% trans "No payment events." %}</td></tr>
                     </tbody>
-    			{% endif %}
-    			{% endwith %}
-			</table>
-		</div>
+                {% endif %}
+                {% endwith %}
+            </table>
+        </div>
 
-		<div class="tab-pane {% if active_tab == 'shipping' %}active{% endif %}" id="shipping">
-			{% block tab_shipping %}
+        <div class="tab-pane {% if active_tab == 'shipping' %}active{% endif %}" id="shipping">
+            {% block tab_shipping %}
                 <div class="table-header">
                     <h3>Shipping</h3>
                 </div>
-				<table class="table table-striped table-bordered table-hover">
-					<tbody>
-						<tr>
-							<th>{% trans "Method" %}</th>
-							<td>{{ order.shipping_method }}</td>
-						</tr>
-						<tr>
-							<th>{% trans "Charge (incl tax)" %}</th>
-							<td>{{ order.shipping_incl_tax|currency }}</td>
-						</tr>
-						<tr>
-							<th>{% trans "Charge (excl tax)" %}</th>
-							<td>{{ order.shipping_excl_tax|currency }}</td>
-						</tr>
-						<tr>
-							<th>{% trans "Address" %}</th>
-							<td>
-								{% for field in order.shipping_address.active_address_fields %}
-								{{ field }}<br/>
-								{% endfor %}
-							</td>
-						</tr>
-					</tbody>
-				</table>
-			{% endblock %}
-		</div>
+                <table class="table table-striped table-bordered table-hover">
+                    <tbody>
+                        <tr>
+                            <th>{% trans "Method" %}</th>
+                            <td>{{ order.shipping_method }}</td>
+                        </tr>
+                        <tr>
+                            <th>{% trans "Charge (incl tax)" %}</th>
+                            <td>{{ order.shipping_incl_tax|currency }}</td>
+                        </tr>
+                        <tr>
+                            <th>{% trans "Charge (excl tax)" %}</th>
+                            <td>{{ order.shipping_excl_tax|currency }}</td>
+                        </tr>
+                        <tr>
+                            <th>{% trans "Address" %}</th>
+                            <td>
+                                {% for field in order.shipping_address.active_address_fields %}
+                                {{ field }}<br/>
+                                {% endfor %}
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            {% endblock %}
+        </div>
 
-		<div class="tab-pane {% if active_tab == 'payment' %}active{% endif %}" id="payment">
-			{% if order.billing_address %}
-				<div class="sub-header">
-					<h3 >{% trans "Billing address" %}</h3>
-				</div>
-				<p>
-				{% for field in order.billing_address.active_address_fields %}
-				{{ field }}<br/>
-				{% endfor %}
-				</p>
-			{% endif %}
+        <div class="tab-pane {% if active_tab == 'payment' %}active{% endif %}" id="payment">
+            {% if order.billing_address %}
+                <div class="sub-header">
+                    <h3 >{% trans "Billing address" %}</h3>
+                </div>
+                <p>
+                {% for field in order.billing_address.active_address_fields %}
+                {{ field }}<br/>
+                {% endfor %}
+                </p>
+            {% endif %}
 
-			{% with sources=order.sources.all %}
-			<div class="table-header">
-				<h3 >{% trans "Payment sources" %}</h3>
-			</div>
+            {% with sources=order.sources.all %}
+            <div class="table-header">
+                <h3 >{% trans "Payment sources" %}</h3>
+            </div>
 
-				<table class="table table-striped table-bordered table-hover">
-				    {% if sources %}
-    					<thead>
-    						<tr>
-    							<th>{% trans "Source" %}</th>
-    							<th>{% trans "Allocation" %}</th>
-    							<th>{% trans "Amount debited" %}</th>
-    							<th>{% trans "Amount refunded" %}</th>
-    							<th>{% trans "Reference" %}</th>
-    						</tr>
-    					</thead>
-    					<tbody>
-    						{% for source in sources %}
-    						<tr>
-    							<td>{{ source.source_type }}</td>
-    							<td>{{ source.amount_allocated|currency }}</td>
-    							<td>{{ source.amount_debited|currency }}</td>
-    							<td>{{ source.amount_refunded|currency }}</td>
-    							<td>{{ source.reference|default:"-" }}</td>
-    						</tr>
+                <table class="table table-striped table-bordered table-hover">
+                    {% if sources %}
+                        <thead>
+                            <tr>
+                                <th>{% trans "Source" %}</th>
+                                <th>{% trans "Allocation" %}</th>
+                                <th>{% trans "Amount debited" %}</th>
+                                <th>{% trans "Amount refunded" %}</th>
+                                <th>{% trans "Reference" %}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for source in sources %}
+                            <tr>
+                                <td>{{ source.source_type }}</td>
+                                <td>{{ source.amount_allocated|currency }}</td>
+                                <td>{{ source.amount_debited|currency }}</td>
+                                <td>{{ source.amount_refunded|currency }}</td>
+                                <td>{{ source.reference|default:"-" }}</td>
+                            </tr>
 
                             <tr>
                                 <td colspan="5">
@@ -389,123 +389,123 @@
                                     {% endwith %}
                                 </td>
                             </tr>
-    						{% endfor %}
-    					</tbody>
-					{% else %}
+                            {% endfor %}
+                        </tbody>
+                    {% else %}
                         <tbody>
                             <tr><td>{% trans "No payment sources" %}</td></tr>
                         </tbody>
-        			{% endif %}
-				</table>
-			{% endwith %}
-		</div>
+                    {% endif %}
+                </table>
+            {% endwith %}
+        </div>
 
-		<div class="tab-pane {% if active_tab == 'discounts' %}active{% endif %}" id="discounts">
-			{% block tab_discounts %}
-				<div class="table-header">
-					<h3>{% trans "Discounts" %}</h3>
-				</div>
-				{% with discounts=order.discounts.all %}
+        <div class="tab-pane {% if active_tab == 'discounts' %}active{% endif %}" id="discounts">
+            {% block tab_discounts %}
+                <div class="table-header">
+                    <h3>{% trans "Discounts" %}</h3>
+                </div>
+                {% with discounts=order.discounts.all %}
 
-					<table class="table table-striped table-bordered table-hover">
-					    {% if discounts %}
-    						<thead>
-    							<tr>
-    								<th>{% trans "Voucher code" %}</th>
-    								<th>{% trans "Offer name" %}</th>
-    								<th>{% trans "Amount" %}</th>
-    							</tr>
-    						</thead>
-    						<tbody>
-    						{% for discount in discounts %}
-    						<tr>
-    							<td>{{ discount.voucher_code|default:"-" }}</td>
-    							<td>{{ discount.offer.name }}</td>
-    							<td>{{ discount.amount|currency}}</td>
-    						</tr>
-    						{% endfor %}
-    						</tbody>
-						{% else %}
+                    <table class="table table-striped table-bordered table-hover">
+                        {% if discounts %}
+                            <thead>
+                                <tr>
+                                    <th>{% trans "Voucher code" %}</th>
+                                    <th>{% trans "Offer name" %}</th>
+                                    <th>{% trans "Amount" %}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                            {% for discount in discounts %}
+                            <tr>
+                                <td>{{ discount.voucher_code|default:"-" }}</td>
+                                <td>{{ discount.offer.name }}</td>
+                                <td>{{ discount.amount|currency}}</td>
+                            </tr>
+                            {% endfor %}
+                            </tbody>
+                        {% else %}
                             <tbody>
                                 <tr><td>{% trans "No discounts were applied in this order." %}</td></tr>
                             </tbody>
-        				{% endif %}
-					</table>
+                        {% endif %}
+                    </table>
 
-				{% endwith %}
-			{% endblock %}
-		</div>
+                {% endwith %}
+            {% endblock %}
+        </div>
 
-		<div class="tab-pane {% if active_tab == 'emails' %}active{% endif %}" id="emails">
-			{% block tab_emails %}
-			<div class="table-header">
-				<h3>{% trans "Emails" %}</h3>
-			</div>
-			<table class="table table-striped table-bordered table-hover">
+        <div class="tab-pane {% if active_tab == 'emails' %}active{% endif %}" id="emails">
+            {% block tab_emails %}
+            <div class="table-header">
+                <h3>{% trans "Emails" %}</h3>
+            </div>
+            <table class="table table-striped table-bordered table-hover">
                 <tr><td>{% trans "No email data available." %}</td></tr>
             </table>
-			{% endblock %}
-		</div>
+            {% endblock %}
+        </div>
 
-		<div class="tab-pane {% if active_tab == 'notes' %}active{% endif %}" id="notes">
-			{% block tab_notes %}
-			<div class="table-header">
-				<h3>{% trans "Notes" %}</h3>
-			</div>
-			{% with notes=order.notes.all %}
+        <div class="tab-pane {% if active_tab == 'notes' %}active{% endif %}" id="notes">
+            {% block tab_notes %}
+            <div class="table-header">
+                <h3>{% trans "Notes" %}</h3>
+            </div>
+            {% with notes=order.notes.all %}
 
-			<table class="table table-striped table-bordered table-hover">
-			    {% if notes %}
-				<tr>
-					<th>{% trans "Date" %}</th>
-					<th>{% trans "User" %}</th>
-					<th>{% trans "Type" %}</th>
-					<th>{% trans "Message" %}</th>
-					<th></th>
-				</tr>
-				{% for note in notes %}
-				<tr>
-					<td>{{ note.date_created }}</td>
-					<td>{{ note.user }}</td>
-					<td>{{ note.note_type }}</td>
-					<td>{{ note.message|linebreaks }}</td>
-					<td class="span2">
-						{% if note.is_editable %}
-						&nbsp;<a href="{% url dashboard:order-detail-note order.number note.id %}#notes" class="btn btn-info">{% trans "Edit" %}</a>
-						<form action="." method="post" class="pull-left">
-							{% csrf_token %}
-							<input type="hidden" name="order_action" value="delete_note" />
-							<input type="hidden" name="note_id" value="{{ note.id }}" />
-							<input type="submit" value="Delete" class="btn btn-danger" />
-						</form>
-						{% endif %}
-					</td>
-				</tr>
-				{% endfor %}
-				{% else %}
+            <table class="table table-striped table-bordered table-hover">
+                {% if notes %}
+                <tr>
+                    <th>{% trans "Date" %}</th>
+                    <th>{% trans "User" %}</th>
+                    <th>{% trans "Type" %}</th>
+                    <th>{% trans "Message" %}</th>
+                    <th></th>
+                </tr>
+                {% for note in notes %}
+                <tr>
+                    <td>{{ note.date_created }}</td>
+                    <td>{{ note.user }}</td>
+                    <td>{{ note.note_type }}</td>
+                    <td>{{ note.message|linebreaks }}</td>
+                    <td class="span2">
+                        {% if note.is_editable %}
+                        &nbsp;<a href="{% url dashboard:order-detail-note order.number note.id %}#notes" class="btn btn-info">{% trans "Edit" %}</a>
+                        <form action="." method="post" class="pull-left">
+                            {% csrf_token %}
+                            <input type="hidden" name="order_action" value="delete_note" />
+                            <input type="hidden" name="note_id" value="{{ note.id }}" />
+                            <input type="submit" value="Delete" class="btn btn-danger" />
+                        </form>
+                        {% endif %}
+                    </td>
+                </tr>
+                {% endfor %}
+                {% else %}
                 <tr>
                     <td>{% trans "No notes available." %}</td>
                 </tr>
-				{% endif %}
-			</table>
+                {% endif %}
+            </table>
 
-			{% endwith %}
+            {% endwith %}
 
-			<form action=".?note={{ note_id }}" method="post" class="form-stacked">
-				{% csrf_token %}
-				<input type="hidden" value="save_note" name="order_action" />
-				{% include "partials/form_fields.html" with form=note_form %}
-				<!-- {{ note_form.as_p }} -->
-				<div class="form-actions">
-					<input type="submit" value="Save note" class="btn btn-primary" />
-					{% trans "Notes are only editable for 5 minutes after being saved." %}
-				</div>
-			</form>
-			{% endblock %}
-		</div>
+            <form action=".?note={{ note_id }}" method="post" class="form-stacked">
+                {% csrf_token %}
+                <input type="hidden" value="save_note" name="order_action" />
+                {% include "partials/form_fields.html" with form=note_form %}
+                <!-- {{ note_form.as_p }} -->
+                <div class="form-actions">
+                    <input type="submit" value="Save note" class="btn btn-primary" />
+                    {% trans "Notes are only editable for 5 minutes after being saved." %}
+                </div>
+            </form>
+            {% endblock %}
+        </div>
 
-		{% block extra_tabs %}{% endblock %}
-	</div>
+        {% block extra_tabs %}{% endblock %}
+    </div>
 </div>
 
 {% endblock dashboard_content %}


### PR DESCRIPTION
When viewing the details of an order, the payment transactions are not being shown.

Since I didn't find any bug report, pull request or doc about it, I made a simple patch that show all transactions "grouped" by source type.

It isn't pretty, but it is working. How could I improve it?

Thanks
