### PR TITLE
Rename base for ProductCategoryFormSet

### DIFF
--- a/oscar/apps/dashboard/catalogue/forms.py
+++ b/oscar/apps/dashboard/catalogue/forms.py
@@ -218,7 +218,7 @@ class ProductCategoryForm(forms.ModelForm):
         model = ProductCategory
 
 
-class ProductCategoryFormSet(BaseInlineFormSet):
+class BaseProductCategoryFormSet(BaseInlineFormSet):
 
     def clean(self):
         if self.instance.is_top_level and self.get_num_categories() == 0:
@@ -241,7 +241,7 @@ class ProductCategoryFormSet(BaseInlineFormSet):
 
 ProductCategoryFormSet = inlineformset_factory(Product, ProductCategory,
                                                form=ProductCategoryForm,
-                                               formset=ProductCategoryFormSet,
+                                               formset=BaseProductCategoryFormSet,
                                                fields=('category',), extra=1)
 
 


### PR DESCRIPTION
Currently, the base class that is used to construct the `ProductCategoryFormSet` and the `ProductCategoryFormSet` (as returned by inlineformset_factory) share the same name. This makes overriding harder and is different from the suggested method in the [Django docs](https://docs.djangoproject.com/en/1.4/topics/forms/formsets/#custom-formset-validation). In my case, I'd like to change the number of extra forms rendered and can't easily do so.
As the base FormSet is never used in Oscar apart from using it in the factory, I've renamed it to `BaseProductCategoryFormSet`, keeping it in line with Django docs.

Tests run through just fine. The change affects two lines.
