### PR TITLE
Fix for <form> action attribute.

### DIFF
--- a/oscar/templates/oscar/partials/form.html
+++ b/oscar/templates/oscar/partials/form.html
@@ -1,5 +1,7 @@
 {% load i18n %}
-<form class="form-stacked {{ class }}" method="{{ method|default:"post" }}" action="{{ action|default:"." }}" {% if includes_files %}enctype="multipart/form-data"{% endif %}>
+<form class="form-stacked {{ class }}" method="{{ method|default:"post" }}"
+    {% if action %}action="{{ action }}"{% endif %}
+    {% if includes_files %}enctype="multipart/form-data"{% endif %}>
 	{% if not method == "get" %}{% csrf_token %}{% endif %}
 	{% include 'partials/form_fields.html' %}
 	<div class="form-actions">


### PR DESCRIPTION
Old behavior is to default to action="." if no action is given. The dot
makes the browser submit to the current URL, but without the query string; 
dropping any GET parameters in the process.
A common case of mixing POST and GET parameters is supplying ?_popup=1
to a popup. The view processes the form data in POST as usual, but then
might return a different HTTPResponse if 'popup' was supplied, e.g.
return Javascript to close the popup.

My fix drops specifying 'action' if none is given. This is okay in
HTML5 and HTML3, and defaults to the URL (including GET parameters).
It's required in HTML4, but as far as I know handled gracefully in
all browsers.
