### PR TITLE
Separate order lines from the main dashboard order_detail template

### DIFF
--- a/oscar/templates/oscar/dashboard/orders/order_detail.html
+++ b/oscar/templates/oscar/dashboard/orders/order_detail.html
@@ -86,61 +86,8 @@
 			</div>
 			<form action="." method="post" class="form-inline">
 				{% csrf_token %}
-				<table class="table table-striped table-bordered table-hover">
-					<thead>
-						<tr>
-							<th>{% trans "Select" %}</th>
-							<th>{% trans "Quantity" %}</th>
-							<th>{% trans "Product" %}</th>
-							<th>{% trans "UPC" %}</th>
-							<th>{% trans "Status" %}</th>
-							<th>{% trans "Supplier" %}</th>
-							<th>{% trans "Supplier SKU" %}</th>
-							<th>{% trans "Est. delivery date" %}</th>
-							<th>{% trans "Price (before discounts)" %}</th>
-							<th>{% trans "Actions" %}</th>
-						</tr>
-					</thead>
-					<tbody>
-						{% for line in order.lines.all %}
-						<tr>
-							<td>
-								<input type="checkbox" name="selected_line" value="{{ line.id }}" />
-								<input type="text" name="selected_line_qty" value="{{ line.quantity }}" class="span1" size="2" />
-							</td>
-							<td>{{ line.quantity }}</td>
-							<td>{{ line.title }}</td>
-							<td>{{ line.upc|default:"-" }}</td>
-							<td>{{ line.status|default:"-" }}</td>
-							<td>{{ line.partner_name }}</td>
-							<td>{{ line.partner_sku }}</td>
-							<td>{{ line.est_dispatch_date|default:"-" }}</td>
-							<td>{{ line.line_price_before_discounts_incl_tax|currency }}</td>
-							<td>
-								<a href="{% url dashboard:order-line-detail order.number line.id %}" class="btn btn-info">{% trans "View" %}</a>
-							</td>
-						</tr>
-						{% endfor %}
-						<tr>
-							<td colspan="7"></td>
-							<th>{% trans "Discount" %}</th>
-							<td>{{ order.total_discount_incl_tax|currency }}</td>
-							<td></td>
-						</tr>
-						<tr>
-							<td colspan="7"></td>
-							<th>{% trans "Shipping charge" %}</th>
-							<td>{{ order.shipping_incl_tax|currency }}</td>
-							<td></td>
-						</tr>
-						<tr>
-							<td colspan="7"></td>
-							<th>{% trans "Total" %}</th>
-							<td>{{ order.total_incl_tax|currency }}</td>
-							<td></td>
-						</tr>
-					</tbody>
-				</table>
+
+                {% include "dashboard/orders/partials/order_line_list.html" %}
 
 				{% block line_actions %}
                 <div class="well">

--- a/oscar/templates/oscar/dashboard/orders/partials/order_line_list.html
+++ b/oscar/templates/oscar/dashboard/orders/partials/order_line_list.html
@@ -1,0 +1,58 @@
+{% load i18n %}
+{% load currency_filters %}
+
+<table class="table table-striped table-bordered table-hover">
+    <thead>
+    <tr>
+        <th>{% trans "Select" %}</th>
+        <th>{% trans "Quantity" %}</th>
+        <th>{% trans "Product" %}</th>
+        <th>{% trans "UPC" %}</th>
+        <th>{% trans "Status" %}</th>
+        <th>{% trans "Supplier" %}</th>
+        <th>{% trans "Supplier SKU" %}</th>
+        <th>{% trans "Est. delivery date" %}</th>
+        <th>{% trans "Price (before discounts)" %}</th>
+        <th>{% trans "Actions" %}</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for line in order.lines.all %}
+    <tr>
+        <td>
+            <input type="checkbox" name="selected_line" value="{{ line.id }}" />
+            <input type="text" name="selected_line_qty" value="{{ line.quantity }}" class="span1" size="2" />
+        </td>
+        <td>{{ line.quantity }}</td>
+        <td>{{ line.title }}</td>
+        <td>{{ line.upc|default:"-" }}</td>
+        <td>{{ line.status|default:"-" }}</td>
+        <td>{{ line.partner_name }}</td>
+        <td>{{ line.partner_sku }}</td>
+        <td>{{ line.est_dispatch_date|default:"-" }}</td>
+        <td>{{ line.line_price_before_discounts_incl_tax|currency }}</td>
+        <td>
+            <a href="{% url dashboard:order-line-detail order.number line.id %}" class="btn btn-info">{% trans "View" %}</a>
+        </td>
+    </tr>
+    {% endfor %}
+    <tr>
+        <td colspan="7"></td>
+        <th>{% trans "Discount" %}</th>
+        <td>{{ order.total_discount_incl_tax|currency }}</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td colspan="7"></td>
+        <th>{% trans "Shipping charge" %}</th>
+        <td>{{ order.shipping_incl_tax|currency }}</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td colspan="7"></td>
+        <th>{% trans "Total" %}</th>
+        <td>{{ order.total_incl_tax|currency }}</td>
+        <td></td>
+    </tr>
+    </tbody>
+</table>


### PR DESCRIPTION
In case you need to add more or custom fields to the order details page, it is easier to change just this partial file rather than the whole template

Q. Thinking now, should it have been done using `{% block %}` or is include file OK?
