### PR TITLE
Ignore signals when loading fixtures

### DIFF
--- a/oscar/apps/analytics/receivers.py
+++ b/oscar/apps/analytics/receivers.py
@@ -101,23 +101,31 @@ def _record_user_product_search(user, query):
 
 @receiver(product_viewed)
 def receive_product_view(sender, product, user, **kwargs):
+    if kwargs.get('raw', False):
+        return
     _record_product_view(product)
     _record_user_product_view(user, product)
 
 
 @receiver(product_search)
 def receive_product_search(sender, query, user, **kwargs):
+    if kwargs.get('raw', False):
+        return
     _record_user_product_search(user, query)
 
 
 @receiver(basket_addition)
 def receive_basket_addition(sender, product, user, **kwargs):
+    if kwargs.get('raw', False):
+        return
     _record_basket_addition(product)
     _record_user_basket_addition(user, product)
 
 
 @receiver(order_placed)
 def receive_order_placed(sender, order, user, **kwargs):
+    if kwargs.get('raw', False):
+        return
     _record_products_in_order(order)
     if user:
         _record_user_order(user, order)

--- a/oscar/apps/customer/alerts/receivers.py
+++ b/oscar/apps/customer/alerts/receivers.py
@@ -6,6 +6,8 @@ from django.contrib.auth.models import User
 
 
 def send_product_alerts(sender, instance, created, **kwargs):
+    if kwargs.get('raw', False):
+        return
     from oscar.apps.customer.alerts import utils
     utils.send_product_alerts(instance.product)
 

--- a/oscar/apps/partner/receivers.py
+++ b/oscar/apps/partner/receivers.py
@@ -10,7 +10,7 @@ def update_stock_alerts(sender, instance, created, **kwargs):
     """
     Update low-stock alerts
     """
-    if created:
+    if created or kwargs.get('raw', False):
         return
     stockrecord = instance
     try:


### PR DESCRIPTION
Loading fixtures using the `loaddata` command in Django causes problems
with signals registered in Oscar. The suggested solution is to check for
in the receiver function whether the `raw` parameter is set to `True`
which indicates that fixtures are loaded.

I added a condition to all receiver methods that skips processing when in
`raw` mode.
