### PR TITLE
Fix installing haystack from github at specific commit using setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,7 @@ setup(name='django-oscar',
           'python-memcached>=1.48,<1.49',
           'Babel>=0.9,<0.10',
           'django-compressor>=1.2,<1.3'],
-      dependency_links=['git+git://github.com/toastdriven/django-haystack.git@0e95d8696f8ba770f9c60152136aba32f5591fd6#egg=django-haystack-2.0.0-beta'],
-      #dependency_links=['http://github.com/toastdriven/django-haystack/tarball/master@0e95d8696f8ba770f9c60152136aba32f5591fd6#egg=django-haystack-2.0.0-beta'],
+      dependency_links=['https://github.com/toastdriven/django-haystack/tarball/0e95d8696f8ba770f9c60152136aba32f5591fd6#egg=django-haystack-2.0.0-beta'],
       # See http://pypi.python.org/pypi?%3Aaction=list_classifiers
       classifiers=[
           'Development Status :: 4 - Beta',


### PR DESCRIPTION
I just opened this issue to track the problem with installing haystack from github at a specific commit. This was thought to be fixed in #489 but there still seems to be an issue with that as [described at the end of the PR](https://github.com/tangentlabs/django-oscar/pull/489#commitcomment-2508241).

I can reproduce the issue locally from a fresh checkout. The setup that works with `make sandbox` (meaning `python setup.py develop` is:

```
      dependency_links=['https://github.com/toastdriven/django-haystack/tarball/0e95d8696f8ba770f9c60152136aba32f5591fd6#egg=django-haystack-2.0.0-beta'],
```

However, I haven't tested whether this works with `python setup.py install` as well. We had issues with installing from a tarball like this before so I am not sure if it will work with the above solution or not. This needs some additional testing before putting it up as a PR.
