### PR TITLE
Improve AbstractBasket lines cache handling

### DIFF
--- a/oscar/apps/basket/abstract_models.py
+++ b/oscar/apps/basket/abstract_models.py
@@ -207,21 +207,23 @@ class AbstractBasket(models.Model):
                                              line.quantity)
             existing_line.save()
             line.delete()
+        finally:
+            self._lines = None
     merge_line.alters_data = True
 
     def merge(self, basket, add_quantities=True):
         """
         Merges another basket with this one.
 
-        :basket: The basket to merge into this one
+        :basket: The basket to merge into this one.
         :add_quantities: Whether to add line quantities when they are merged.
         """
         for line_to_merge in basket.all_lines():
             self.merge_line(line_to_merge, add_quantities)
         basket.status = self.MERGED
         basket.date_merged = now()
+        basket._lines = None
         basket.save()
-        self._lines = None
     merge.alters_data = True
 
     def freeze(self):


### PR DESCRIPTION
Currently, merge() only invalidated the line cache of the own instance,
and the public-facing merge_line() did not invalidate the cache at all.

Now, merge_line() invalidates the instances' line cache, and merge()
invalidates both instances' line cache.

I discovered this when using merge_line() to split a basket into
subbaskets and .is_empty would not reflect the current state.

Tests run through.
