### PR TITLE
Remove unintended side-effect

### DIFF
--- a/oscar/apps/checkout/mixins.py
+++ b/oscar/apps/checkout/mixins.py
@@ -159,12 +159,13 @@ class OrderPlacementMixin(CheckoutSessionMixin):
         shipping_addr.save()
         return shipping_addr
 
-    def create_user_address(self, addr_data):
+    def create_user_address(self, session_addr_data):
         """
         For signed-in users, we create a user address model which will go
         into their address book.
         """
         if self.request.user.is_authenticated():
+            addr_data = session_addr_data.copy()
             addr_data['user_id'] = self.request.user.id
             user_addr = UserAddress(**addr_data)
             # Check that this address isn't already in the db as we don't want


### PR DESCRIPTION
`create_user_address` modified the passed dictionary, which is
undocumented, and as far as I'm aware, unintended.
This leads to altering session data.

The problem was spotted because I call `place_order multiple` times in one
checkout process, and the `UserAddress` form would complain about the `user_id`
keyword parameter that it was passed on the second call of `place_order`.

It is fixed by copying the passed dictionary and only altering the latter.
