### PR TITLE
Templates: Remove stray tag.

### DIFF
--- a/oscar/templates/oscar/checkout/thank_you.html
+++ b/oscar/templates/oscar/checkout/thank_you.html
@@ -140,7 +140,7 @@
 		<h4>{% trans "Tracking your order" %}</h4>
     </div>
 	<p>{% trans "You can" %}
-		<a href="{% url customer:anon-order order.number order.verification_hash %}">{% trans "track the status of your order" %}</a>.</p>
+		<a href="{% url customer:anon-order order.number order.verification_hash %}">{% trans "track the status of your order" %}</a>.
 	</p>
 {% endif %}
 


### PR DESCRIPTION
`checkout/thank_you.html` had a stray `</p>` tag in it. Removed.
