### PR TITLE
Print contributing guidelines when installing in 'develop' mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,13 +60,20 @@ setup(name='django-oscar',
 
 # Show contributing instructions if being installed in 'develop' mode
 if len(sys.argv) > 1 and sys.argv[1] == 'develop':
-    url = 'http://django-oscar.readthedocs.org/en/latest/contributing.html'
+    docs_url = 'http://django-oscar.readthedocs.org/en/latest/contributing.html'
+    mailing_list = 'django-oscar@googlegroups.com'
+    mailing_list_url = 'https://groups.google.com/forum/?fromgroups#!forum/django-oscar'
+    twitter_url = 'https://twitter.com/django_oscar'
     msg = (
         "You're installing Oscar in 'develop' mode so I presume you're thinking\n"
         "of contributing:\n\n"
         "(a) That's brilliant - thank you for your time\n"
-        "(b) If you have any questions, please use the mailing list:\n    django-oscar@googlegroups.com\n"
+        "(b) If you have any questions, please use the mailing list:\n    %s\n"
+        "    %s\n"
         "(c) There are more detailed contributing guidelines that you should "
-        "have a look at:\n    %s\n\nHappy hacking!") % url
+        "have a look at:\n    %s\n"
+        "(d) Consider following @django_oscar on Twitter to stay up-to-date\n"
+        "    %s\n\nHappy hacking!") % (mailing_list, mailing_list_url,
+                                       docs_url, twitter_url)
     line = '=' * 82
     print "\n%s\n%s\n%s" % (line, msg, line)


### PR DESCRIPTION
# Problem

So Github has a useful feature where it shows the contributing guidelines when you open an issue or pull request: https://github.com/blog/1184-contributing-guidelines.  I can see them right now:

![image](https://f.cloud.github.com/assets/80975/205064/c0eb18e4-8196-11e2-829d-a74450939471.png)

In my view, this is too late though.  By the time you are submitting the pull request, you have already done the work and may have missed crucial information.
# Solution?

I have modified `setup.py` to print some contributing instructions when Oscar is installed in `develop` mode.  You see something like this:

``` bash
$ ./setup.py develop
running develop
running egg_info
writing requirements to django_oscar.egg-info/requires.txt
writing django_oscar.egg-info/PKG-INFO
writing top-level names to django_oscar.egg-info/top_level.txt
writing dependency_links to django_oscar.egg-info/dependency_links.txt
reading manifest file 'django_oscar.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'django_oscar.egg-info/SOURCES.txt'
running build_ext
Creating /Users/dwinterbottom/.virtualenvs/oscar/lib/python2.7/site-packages/django-oscar.egg-link (link to .)
django-oscar 0.5-pre-alpha is already the active version in easy-install.pth

...

Finished processing dependencies for django-oscar==0.5-pre-alpha

==================================================================================
You're installing Oscar in 'develop' mode so I presume you're thinking
of contributing:

(a) That's brilliant - thank you for your time
(b) If you have any questions, please use the mailing list:
    django-oscar@googlegroups.com
(c) There are more detailed contributing guidelines that you should have a look at:
    http://django-oscar.readthedocs.org/en/latest/contributing.html

Happy hacking!
==================================================================================
```

Is this a good thing?  
