### PR TITLE
Attribute 'score' in Product model breaks the use of haystacks simple backend

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(name='django-oscar',
           'django-compressor>=1.2,<1.3',
           'virtual-node>=0.0.1',
           'virtual-less>=0.0.1-1.3.3'],
-      dependency_links=['https://github.com/toastdriven/django-haystack/tarball/0e95d8696f8ba770f9c60152136aba32f5591fd6#egg=django-haystack-2.0.0-beta'],
+      dependency_links=['https://github.com/toastdriven/django-haystack/tarball/f91a9a7ce6fb26093f4ecf09b28d71cf4b59283c#egg=django-haystack-2.0.0-beta'],
       # See http://pypi.python.org/pypi?%3Aaction=list_classifiers
       classifiers=[
           'Development Status :: 4 - Beta',


### PR DESCRIPTION
I just came across an issue where haystack's simple backend raises an exception:

`TypeError: "__init__() got multiple values for keyword argument 'score'`

This is caused by Oscar's `Product` model and its attribute `score`. A corresponding issue is mentioned in [streeter's comment](https://github.com/toastdriven/django-haystack/issues/482#issuecomment-7473328).

I am aware that this might not be something that will be fixed as the only solution in Oscar that I can think of is changing the attribute `score` to something else. I thought, I'd put it in here though, in case some one comes across the same issue. 

The easiest solution seems to be to use  Mplsbeb/whoosh instead of the simple backend or patching the simple backend by removing the `score` attribute before passing it into the constructor of the result class in [line 74](https://github.com/toastdriven/django-haystack/blob/master/haystack/backends/simple_backend.py#L74).
