### PR TITLE
Remove images when deleting a product

### DIFF
--- a/oscar/apps/catalogue/models.py
+++ b/oscar/apps/catalogue/models.py
@@ -62,3 +62,5 @@ class Option(AbstractOption):
 
 class ProductImage(AbstractProductImage):
     pass
+
+from .receivers import *

--- a/oscar/apps/catalogue/receivers.py
+++ b/oscar/apps/catalogue/receivers.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from django.db.models import get_model
+
+from django.db import models
+from django.db.models.signals import post_delete
+from sorl import thumbnail
+
+ProductImage = get_model('catalogue', 'ProductImage')
+Category = get_model('catalogue', 'Category')
+
+
+def delete_image_files(sender, instance, **kwargs):
+    """
+    Deletes the original image, created thumbnails, and any entries
+    in sorl's key-value store.
+    """
+    image_fields = (models.ImageField, thumbnail.ImageField)
+    for field in instance._meta.fields:
+        if isinstance(field, image_fields):
+            # Make Django return ImageFieldFile instead of ImageField
+            fieldfile = getattr(instance, field.name)
+            thumbnail.delete(fieldfile)
+
+# connect for all models with ImageFields - add as needed
+models_with_images = [ProductImage, Category]
+for sender in models_with_images:
+    post_delete.connect(delete_image_files, sender=sender)


### PR DESCRIPTION
As suggested in #435, all product images should be removed from the server when the related product is deleted. This should use a post delete signal. 
