### PR TITLE
Discuss: Merge ProductUpdateView and ProductCreateView

### DIFF
--- a/oscar/apps/dashboard/catalogue/app.py
+++ b/oscar/apps/dashboard/catalogue/app.py
@@ -10,8 +10,7 @@ class CatalogueApplication(Application):
 
     product_list_view = views.ProductListView
     product_create_redirect_view = views.ProductCreateRedirectView
-    product_create_view = views.ProductCreateView
-    product_update_view = views.ProductUpdateView
+    product_createupdate_view = views.ProductCreateUpdateView
     product_delete_view = views.ProductDeleteView
 
     category_list_view = views.CategoryListView
@@ -24,13 +23,13 @@ class CatalogueApplication(Application):
 
     def get_urls(self):
         urlpatterns = patterns('',
-            url(r'^products/(?P<pk>\d+)/$', self.product_update_view.as_view(),
+            url(r'^products/(?P<pk>\d+)/$', self.product_createupdate_view.as_view(),
                 name='catalogue-product'),
             url(r'^products/create/$',
                 self.product_create_redirect_view.as_view(),
                 name='catalogue-product-create'),
             url(r'^products/create/(?P<product_class_id>\d+)/$',
-                self.product_create_view.as_view(),
+                self.product_createupdate_view.as_view(),
                 name='catalogue-product-create'),
             url(r'^products/(?P<pk>\d+)/delete/$',
                 self.product_delete_view.as_view(),

--- a/oscar/apps/dashboard/catalogue/forms.py
+++ b/oscar/apps/dashboard/catalogue/forms.py
@@ -66,11 +66,6 @@ class ProductSearchForm(forms.Form):
 
 
 class StockRecordForm(forms.ModelForm):
-    partner = forms.ModelChoiceField(queryset=Partner.objects.all(),
-                                    required=False,
-                                    label=_("Partner"))
-    partner_sku = forms.CharField(required=False,
-                                  label=_("Partner SKU"))
 
     def __init__(self, product_class, *args, **kwargs):
         self.product_class = product_class

--- a/oscar/templates/oscar/dashboard/catalogue/product_update.html
+++ b/oscar/templates/oscar/dashboard/catalogue/product_update.html
@@ -40,7 +40,7 @@
                     {% if product %}
                     <li class="active"><a href="#overview" data-toggle="tab">{% trans 'Overview' %}</a></li>
                     {% endif %}
-                    <li {% if not product %}class="active"{% endif %}><a href="#product_details" data-toggle="tab">{% trans 'Product details' %}</a></li>
+                    <li{% if not product %} class="active"{% endif %}><a href="#product_details" data-toggle="tab">{% trans 'Product details' %}</a></li>
                     <li><a href="#product_recommended" data-toggle="tab">{% trans 'Recommended Products' %}</a></li>
                     {% with variants=product.variants.all %}
                     {% if variants|length > 0 %}
@@ -326,29 +326,20 @@
                             {% for field in stockrecord_form %}
                                 {% if "partner" in field.id_for_label %}
                                     <td>
-                                        {% if field.is_hidden %}
-                                            {{ field }}
-                                        {% else %}
-                                            {{ field }}
-                                        {% endif %}
+                                        {{ field }}
+                                        {{ field.errors }}
                                     </td>
                                 {% endif %}
                                 {% if "price" in field.id_for_label %}
                                     <td>
-                                        {% if field.is_hidden %}
-                                            {{ field }}
-                                        {% else %}
-                                            {{ field }}
-                                        {% endif %}
+                                        {{ field }}
+                                        {{ field.errors }}
                                     </td>
                                 {% endif %}
                                 {% if "stock" in field.id_for_label %}
                                     <td>
-                                        {% if field.is_hidden %}
-                                            {{ field }}
-                                        {% else %}
-                                            {{ field }}
-                                        {% endif %}
+                                        {{ field }}
+                                        {{ field.errors }}
                                     </td>
                                 {% endif %}
                             {% endfor %}


### PR DESCRIPTION
There's a lot of code duplication between the two views, which means more testing and more work for customizing. This is an attempt of merging the two.

The only difference between Django's `BaseUpdateView` and `BaseCreateView` is that `self.object` is `None` for the latter. Hence I've adapted `get_object` to return `None` if we're creating a product.
- 104 insertions, 169 deletions.
- The additional Formsets are now easily overriden.
- is_valid logic is more concise

Note: I can create and update products, and the tests run through. Given how mission-critical this is, I'd still call it experimental code. There's more optimizations that could be done (esp. abstracting away handling all the single formsets), but this was the sweet spot for effort vs. results for me.
