### PR TITLE
Pickle of ProductAttribute causes infinite loop

### DIFF
--- a/oscar/apps/catalogue/abstract_models.py
+++ b/oscar/apps/catalogue/abstract_models.py
@@ -552,7 +552,9 @@ class ProductAttributesContainer(object):
         self.initialised = False
 
     def __getattr__(self, name):
-        if not name.startswith('_') and not self.initialised:
+        if not name.startswith('_') and not object.__getattr__(
+            self, 'initialised', False):
+
             values = list(self.get_values().select_related('attribute'))
             result = None
             for v in values:


### PR DESCRIPTION
Addressed by using superclass (object) to access the attribute.
