### PR TITLE
Adding __setstate__ magic resolves pickle error

### DIFF
--- a/oscar/apps/catalogue/abstract_models.py
+++ b/oscar/apps/catalogue/abstract_models.py
@@ -518,6 +518,10 @@ class ProductAttributesContainer(object):
     Stolen liberally from django-eav, but simplified to be product-specific
     """
 
+    def __setstate__(self, state):
+        self.__dict__ = state
+        self.initialised = False
+
     def __init__(self, product):
         self.product = product
         self.initialised = False

--- a/tests/unit/catalogue/__init__.py
+++ b/tests/unit/catalogue/__init__.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+from django.test import TestCase
+
+from oscar.apps.catalogue.models import Product, ProductClass
+
+
+class TestProductPickling(TestCase):
+    def setUp(self):
+        self.product_class, _ = ProductClass.objects.get_or_create(
+            name='Pickle')
+
+    def test_product_pickling_works(self):
+        import pickle
+        from StringIO import StringIO
+
+        src = StringIO()
+        pickler = pickle.Pickler(src)
+
+        product = Product.objects.create(title='test_pickle_product',
+                                         product_class=self.product_class)
+
+        pickler.dump(product)
+
+        dst = StringIO(src.getvalue())
+        unpickler = pickle.Unpickler(dst)
+
+        product_pickle = unpickler.load()
+
+        pickler.dump(product_pickle)


### PR DESCRIPTION
By adding the **setstate** method an infinite loop is avoided regarding
the use of **getattr** on the ProductAttributesContainer model.

Moving tests into appropriate folder

I didnt realize that I had such an existing fork with a old master, updated.
