### PR TITLE
Set PostCode not required as some countries do not have post codes

### DIFF
--- a/oscar/apps/address/abstract_models.py
+++ b/oscar/apps/address/abstract_models.py
@@ -39,7 +39,7 @@ class AbstractAddress(models.Model):
     line4 = models.CharField(_("City"), max_length=255, blank=True, null=True)
     state = models.CharField(_("State/County"), max_length=255, blank=True,
                              null=True)
-    postcode = models.CharField(_("Post/Zip-code"), max_length=64)
+    postcode = models.CharField(_("Post/Zip-code"), max_length=64, blank=True, null=True)
     country = models.ForeignKey('address.Country', verbose_name=_("Country"))
 
     # A field only used for searching addresses - this contains all the


### PR DESCRIPTION
Some countries, ie. Ireland, don't have post codes, so:
1) post code should not be a required field
2) maybe conditional validation making PostCode required for some countries
