### PR TITLE
Fix dashboard order list basic seach

### DIFF
--- a/oscar/apps/dashboard/orders/forms.py
+++ b/oscar/apps/dashboard/orders/forms.py
@@ -75,7 +75,7 @@ class OrderSearchForm(forms.Form):
 
     format_choices = (('html', _('HTML')),
                       ('csv', _('CSV')),)
-    response_format = forms.ChoiceField(widget=forms.RadioSelect,
+    response_format = forms.ChoiceField(widget=forms.RadioSelect, required=False,
             choices=format_choices, initial='html', label=_("Get results as"))
 
     def __init__(self, *args, **kwargs):

--- a/oscar/apps/dashboard/orders/views.py
+++ b/oscar/apps/dashboard/orders/views.py
@@ -78,7 +78,7 @@ class OrderListView(ListView, BulkEditMixin):
     current_view = 'dashboard:order-list'
 
     def get(self, request, *args, **kwargs):
-        if 'order_number' in request.GET and request.GET.get('response_format', None) == 'html':
+        if 'order_number' in request.GET and request.GET.get('response_format', 'html') == 'html':
             try:
                 order = Order.objects.get(number=request.GET['order_number'])
             except Order.DoesNotExist:


### PR DESCRIPTION
Without these changes basic search (the one with only one field `order number`) just doesn't work.
