### PR TITLE
Alter how absolute discounts are applied

### DIFF
--- a/oscar/apps/basket/abstract_models.py
+++ b/oscar/apps/basket/abstract_models.py
@@ -487,9 +487,9 @@ class AbstractLine(models.Model):
 
     def __unicode__(self):
         return _(
-            u"%(basket)s, Product '%(product)s', quantity %(quantity)d") % {
-                'basket': self.basket,
-                'product': self.product,
+            u"Basket #%(basket_id)d, Product #%(product_id)d, quantity %(quantity)d") % {
+                'basket_id': self.basket.pk,
+                'product_id': self.product.pk,
                 'quantity': self.quantity}
 
     def save(self, *args, **kwargs):
@@ -519,10 +519,18 @@ class AbstractLine(models.Model):
         self._affected_quantity = 0
 
     def discount(self, discount_value, affected_quantity):
+        """
+        Apply a discount
+        """
         self._discount += discount_value
         self._affected_quantity += int(affected_quantity)
 
     def consume(self, quantity):
+        """
+        Mark all or part of the line as 'consumed'
+
+        Consumed items are no longer available to be used in offers.
+        """
         if quantity > self.quantity - self._affected_quantity:
             inc = self.quantity - self._affected_quantity
         else:
@@ -531,8 +539,10 @@ class AbstractLine(models.Model):
 
     def get_price_breakdown(self):
         """
-        Returns a breakdown of line prices after discounts have
-        been applied.
+        Return a breakdown of line prices after discounts have been applied.
+
+        Returns a list of (unit_price_incl_tx, unit_price_excl_tax, quantity)
+        tuples.
         """
         prices = []
         if not self.has_discount:

--- a/tests/integration/offer/condition_tests.py
+++ b/tests/integration/offer/condition_tests.py
@@ -60,19 +60,6 @@ class TestCountCondition(OfferTest):
         self.condition.consume_items(self.basket, [])
         self.assertFalse(self.condition.is_satisfied(self.basket))
 
-    def test_count_condition_is_applied_multpile_times(self):
-        benefit = models.AbsoluteDiscountBenefit(range=self.range, type="Absolute", value=Decimal('10.00'))
-        for i in range(10):
-            self.basket.add_product(create_product(price=Decimal('5.00'), upc='upc_%i' % i), 1)
-        product_range = models.Range.objects.create(name="All products", includes_all_products=True)
-        condition = models.CountCondition(range=product_range, type="Count", value=2)
-
-        first_discount = benefit.apply(self.basket, condition=condition)
-        self.assertEquals(Decimal('10.00'), first_discount.discount)
-
-        second_discount = benefit.apply(self.basket, condition=condition)
-        self.assertEquals(Decimal('10.00'), second_discount.discount)
-
 
 class ValueConditionTest(OfferTest):
     def setUp(self):


### PR DESCRIPTION
Port https://github.com/tangentlabs/django-oscar/pull/588 to master.

Instead of applying absolute discounts iteratively, the discount should be averaged across all products in the benefit range.
