### PR TITLE
Fixing less compilation in sandbox and during offline compression

### DIFF
--- a/docs/source/howto/how_to_handle_statics.rst
+++ b/docs/source/howto/how_to_handle_statics.rst
@@ -45,6 +45,22 @@ setting like::
         ('text/less', 'lessc {infile} {outfile}'),
     )
 
+Using offline compression
++++++++++++++++++++++++++
+
+Django compressor also provides a way of running offline compression which can
+be used during deployment to automatically generate CSS files from your LESS
+files. To make sure that compressor is obeying the ``USE_LESS`` setting and
+is not trying to compress CSS files that are not available, the setting has to
+be passed into the ``COMPRESS_OFFLINE_CONTEXT``. You should add something like
+this to your settings file::
+
+    COMPRESS_OFFLINE_CONTEXT = {
+        # this is the only default value from compressor itself
+        'STATIC_URL': 'STATIC_URL',
+        'use_less': USE_LESS,
+    }
+
 
 Javascript
 ~~~~~~~~~~

--- a/oscar/templates/oscar/base.html
+++ b/oscar/templates/oscar/base.html
@@ -37,17 +37,15 @@
                 executable is available and you have COMPRESS_PRECOMPILERES specified
                 correctly.
                 {% endcomment %}
-                {% if use_less %}
-                    {% compress css %}
+                {% compress css %}
+                    {% if use_less %}
                         <link rel="stylesheet" type="text/less" href="{% static "oscar/less/styles.less" %}" />
                         <link rel="stylesheet" type="text/less" href="{% static "oscar/less/responsive.less" %}" />
-                    {% endcompress %}
-                {% else %}
-                    {% compress css %}
+                    {% else %}
                         <link rel="stylesheet" type="text/css" href="{% static "oscar/css/styles.css" %}" />
                         <link rel="stylesheet" type="text/css" href="{% static "oscar/css/responsive.css" %}" />
-                    {% endcompress %}
-                {% endif %}
+                    {% endif %}
+                {% endcompress %}
             {% endblock %}
         {% endblock %}
 

--- a/oscar/templates/oscar/dashboard/layout.html
+++ b/oscar/templates/oscar/dashboard/layout.html
@@ -7,17 +7,15 @@
 {% load staticfiles %}
 
 {% block mainstyles %}
-    {% if use_less %}
-        {% compress css %}
-        <link rel="stylesheet" href="{% static "oscar/css/bootstrap.min.css" %}" />
-        <link rel="stylesheet" type="text/less" href="{% static "oscar/less/dashboard.less" %}" />
-        {% endcompress %}
-    {% else %}
-        {% compress css %}
-        <link rel="stylesheet" href="{% static "oscar/css/bootstrap.min.css" %}" />
-        <link rel="stylesheet" type="text/css" href="{% static "oscar/css/dashboard.css" %}" />
-        {% endcompress %}
-    {% endif %}
+    {% compress css %}
+        {% if use_less %}
+            <link rel="stylesheet" href="{% static "oscar/css/bootstrap.min.css" %}" />
+            <link rel="stylesheet" type="text/less" href="{% static "oscar/less/dashboard.less" %}" />
+        {% else %}
+            <link rel="stylesheet" href="{% static "oscar/css/bootstrap.min.css" %}" />
+            <link rel="stylesheet" type="text/css" href="{% static "oscar/css/dashboard.css" %}" />
+        {% endif %}
+    {% endcompress %}
 {% endblock %}
 
 {% block extrastyles %}

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(name='django-oscar',
           'Babel>=0.9,<0.10',
           # Oscar's default templates use compressor (but you can override
           # this)
-          'django-compressor>=1.2,<1.3',
+          'django-compressor>=1.2,<1.4',
           # For converting non-ASCII to ASCII when creating slugs
           'Unidecode>=0.04.12,<0.05',
       ],

--- a/sites/sandbox/settings.py
+++ b/sites/sandbox/settings.py
@@ -357,12 +357,17 @@ OSCAR_ORDER_STATUS_PIPELINE = {
 #
 # which will install node.js and less in your virtualenv.
 
-USE_LESS = False
+USE_LESS = True
 
 COMPRESS_ENABLED = True
 COMPRESS_PRECOMPILERS = (
     ('text/less', 'lessc {infile} {outfile}'),
 )
+
+COMPRESS_OFFLINE_CONTEXT = {
+    'STATIC_URL': 'STATIC_URL',
+    'use_less': USE_LESS,
+}
 
 
 # Logging


### PR DESCRIPTION
The changes made in #546, once more, caused issue with using
offline compression functionality in django-compressor. I looked
at the templates again and found a solution that actually accommodates
both by moving the `use_less` flag into the `compress` block and
passing the `USE_LESS` setting into the `COMPRESS_OFFLINE_CONTEXT`.

The reason for that is in the way django-compressor works. It basically
parses **all** templates that it can find for compress blocks,
disregarding inheritance. This means even overriding the `styles` will
cause compressor to try and compress both the LESS and CSS files. However,
compressor provides a specific context when rendering the compress nodes
during offline compression. So moving the `USE_LESS` flag into the
compress context does the trick.

I have also added a small section to the docs explaining the setitngs for
someone using offline compression, like we do.

@codeinthehole can you please take a look at this soon, as this is
causing problems in the deployment of multiple project. If you disagree
with this fix, we need to find another way.
