### PR TITLE
Fix error when trying to delete image field set to None

### DIFF
--- a/oscar/apps/catalogue/receivers.py
+++ b/oscar/apps/catalogue/receivers.py
@@ -3,7 +3,9 @@ from django.db.models import get_model
 
 from django.db import models
 from django.db.models.signals import post_delete
+
 from sorl import thumbnail
+from sorl.thumbnail.helpers import ThumbnailError
 
 ProductImage = get_model('catalogue', 'ProductImage')
 Category = get_model('catalogue', 'Category')
@@ -19,7 +21,10 @@ def delete_image_files(sender, instance, **kwargs):
         if isinstance(field, image_fields):
             # Make Django return ImageFieldFile instead of ImageField
             fieldfile = getattr(instance, field.name)
-            thumbnail.delete(fieldfile)
+            try:
+                thumbnail.delete(fieldfile)
+            except ThumbnailError:
+                pass
 
 # connect for all models with ImageFields - add as needed
 models_with_images = [ProductImage, Category]

--- a/tests/unit/catalogue/__init__.py
+++ b/tests/unit/catalogue/__init__.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
-
 from django.test import TestCase
 
-from oscar.apps.catalogue.models import Product, ProductClass
+from oscar.apps.catalogue.models import Product, ProductClass, Category
 
 
 class TestProductPickling(TestCase):
@@ -28,3 +27,11 @@ class TestProductPickling(TestCase):
         product_pickle = unpickler.load()
 
         pickler.dump(product_pickle)
+
+
+class TestReceivingDeleteImageSignal(TestCase):
+
+    def test_doesnt_fail_for_empty_image_field(self):
+        category = Category.add_root(name='Test Category')
+        from oscar.apps.catalogue.receivers import delete_image_files
+        delete_image_files(Category, category)


### PR DESCRIPTION
The signal receiver `delete_image_files` fails when attempting to delete
an image field that is `None`. This raises a `ThumbnailError` rather than
handling it gracefully.

I added a test for that and basically ignore the exception as I can't think of
a case where this should be handeled differently. We are trying to delete the
image anyway, so this shouldn't matter.
