### PR TITLE
Fix mapping quantities to selected lines

### DIFF
--- a/oscar/apps/dashboard/orders/views.py
+++ b/oscar/apps/dashboard/orders/views.py
@@ -326,7 +326,10 @@ class OrderDetailView(DetailView):
                 return self.reload_page_response()
             else:
                 line_ids = request.POST.getlist('selected_line')
-                line_quantities = [int(qty) for qty in request.POST.getlist('selected_line_qty')]
+                line_quantities = []
+                for line_id in line_ids:
+                    qty = request.POST.get('selected_line_qty_%s' % line_id)
+                    line_quantities.append(int(qty))
                 lines = order.lines.filter(id__in=line_ids)
                 if lines.count() == 0:
                     messages.error(self.request, _("You must select some lines to act on"))

--- a/oscar/templates/oscar/dashboard/orders/order_detail.html
+++ b/oscar/templates/oscar/dashboard/orders/order_detail.html
@@ -107,7 +107,7 @@
 						<tr>
 							<td>
 								<input type="checkbox" name="selected_line" value="{{ line.id }}" />
-								<input type="text" name="selected_line_qty" value="{{ line.quantity }}" class="span1" size="2" />
+								<input type="text" name="selected_line_qty_{{ line.id }}" value="{{ line.quantity }}" class="span1" size="2" />
 							</td>
 							<td>{{ line.quantity }}</td>
 							<td>{{ line.title }}</td>


### PR DESCRIPTION
**I need this fix in 0.3 and 0.4 branches.**

Before fix `selected_line` list depends on selected checkboxes, but we always get all `selected_line_qty` regardless of the checkboxes. So we can end up having two lists of different length which are then zipped. So when you have two order lines on the list and you check only second checkbox you will get incorrect mapping of quantities to lines.

This view should probably use formset for order lines and form for actions. But I didn't want to make a revolution here as there are probably few other project that could get incompatible with this changes.
