### PR TITLE
Google analytics extra tracking does not work

### DIFF
--- a/oscar/templates/oscar/base.html
+++ b/oscar/templates/oscar/base.html
@@ -63,9 +63,7 @@
 
         {% block tracking %}
             {# Default to using Google analytics #}
-            {% if google_analytics_id %}
-                {% include 'partials/google_analytics.html' %}
-            {% endif %}
+            {% include "partials/google_analytics.html" %}
         {% endblock %}
 
         {% comment %}

--- a/oscar/templates/oscar/checkout/thank_you.html
+++ b/oscar/templates/oscar/checkout/thank_you.html
@@ -197,8 +197,6 @@
 </div>
 {% endblock content %}
 
-{% block extratracking %}
-    {% if google_analytics_id %}
-        {% include 'partials/google_analytics_transaction.html' %}
-    {% endif %}
+{% block tracking %}
+{% include "partials/google_analytics_transaction.html" %}
 {% endblock %}

--- a/oscar/templates/oscar/partials/google_analytics.html
+++ b/oscar/templates/oscar/partials/google_analytics.html
@@ -1,3 +1,4 @@
+{% if google_analytics_id %}
 <script type="text/javascript">
     var _gaq = _gaq || [];
     _gaq.push(['_setAccount', '{{ google_analytics_id }}']);
@@ -9,4 +10,4 @@
         var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
     })();
 </script>
-
+{% endif %}

--- a/oscar/templates/oscar/partials/google_analytics_transaction.html
+++ b/oscar/templates/oscar/partials/google_analytics_transaction.html
@@ -1,3 +1,5 @@
+{% extends "partials/google_analytics.html" %}
+{% block extratracking %}
 _gaq.push(['_addTrans',
     '{{ order.number|escapejs }}',
     '{{ shop_name|escapejs }}',
@@ -18,4 +20,4 @@ _gaq.push(['_addTrans',
         '{{ line.quantity }}']);
 {% endfor %}
 _gaq.push(['_trackTrans']);
-
+{% endblock %}


### PR DESCRIPTION
The following partial has a block tag which allows different templates to insert extra javascript code to the google analytics tracking by overriding the extratracking block.

<a href="https://github.com/tangentlabs/django-oscar/blob/master/oscar/templates/oscar/partials/google_analytics.html">templates / oscar / partials / google_analytics.html:</a>

``` html
<script type="text/javascript">
    var _gaq = _gaq || [];
    _gaq.push(['_setAccount', '{{ google_analytics_id }}']);
    _gaq.push(['_trackPageview']);
    {% block extratracking %}{% endblock %}
    (function() {
        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
    })();
</script>
```

However, this does not work as the partial is being included in base.html and included templates cannot be extended. See https://code.djangoproject.com/ticket/6646.
