### PR TITLE
Make AbstractStockAlert abstract

### DIFF
--- a/oscar/apps/partner/abstract_models.py
+++ b/oscar/apps/partner/abstract_models.py
@@ -299,6 +299,7 @@ class AbstractStockAlert(models.Model):
         return _('<stockalert for "%(stock)s" status %(status)s>') % {'stock': self.stockrecord, 'status': self.status}
 
     class Meta:
+        abstract = True
         ordering = ('-date_created',)
         verbose_name = _('Stock Alert')
         verbose_name_plural = _('Stock Alerts')


### PR DESCRIPTION
This class is not declared as abstract, so south automatically creates a migration for this model.
