### PR TITLE
Fix view name in oscar.apps.search.urls.

### DIFF
--- a/oscar/apps/search/urls.py
+++ b/oscar/apps/search/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import *
 from haystack.query import SearchQuerySet
 
 from oscar.core.loading import import_module
-import_module('search.views', ['Suggestions', 'MultiFacetedSearchView'], locals())
+import_module('search.views', ['SuggestionsView', 'MultiFacetedSearchView'], locals())
 import_module('search.forms', ['MultiFacetedSearchForm'], locals())
 import_module('search.search_indexes', ['ProductIndex'], locals())
 
@@ -14,7 +14,7 @@ for field_name, field in ProductIndex.fields.items():
         sqs.facet(field_name)
 
 urlpatterns = patterns('search.apps.views',
-    url(r'^suggest/$', Suggestions.as_view(), name='oscar-search-suggest'),
-    url(r'^$', MultiFacetedSearchView(form_class=MultiFacetedSearchForm, 
+    url(r'^suggest/$', SuggestionsView.as_view(), name='oscar-search-suggest'),
+    url(r'^$', MultiFacetedSearchView(form_class=MultiFacetedSearchForm,
                                       searchqueryset=sqs), name='oscar-search'),
 )


### PR DESCRIPTION
SuggestionsView is incorrectly named in oscar.apps.search.urls.

I didn't use this view, an import error occured when my application searched all urls.py in every installed app for javascript settings (https://github.com/pozytywnie/django-javascript-settings). It's very special case, but the same error would occur if I just used those urls.

I know that this file would likely be revamped in 0.6, but I'd like to use this change right now in my project.
