### PR TITLE
#658 reduce db calls at product list page

### DIFF
--- a/oscar/apps/catalogue/abstract_models.py
+++ b/oscar/apps/catalogue/abstract_models.py
@@ -401,7 +401,7 @@ class AbstractProduct(models.Model):
         """
         if not self.has_stockrecord:
             return False, _("No stock available")
-        return self.stockrecord.is_purchase_permitted(self, user, quantity)
+        return self.stockrecord.is_purchase_permitted(user, quantity, self)
 
     def add_category_from_breadcrumbs(self, breadcrumb):
         from oscar.apps.catalogue.categories import create_from_breadcrumbs

--- a/oscar/apps/partner/abstract_models.py
+++ b/oscar/apps/partner/abstract_models.py
@@ -238,12 +238,12 @@ class AbstractStockRecord(models.Model):
         """
         return get_partner_wrapper(self.partner_id).is_available_to_buy(self)
 
-    def is_purchase_permitted(self, product=None, user=None, quantity=1):
+    def is_purchase_permitted(self, user=None, quantity=1, product=None):
         """
         Return whether this stockrecord allows the product to be purchased by a
         specific user and quantity
         """
-        return get_partner_wrapper(self.partner_id).is_purchase_permitted(self, product, user, quantity)
+        return get_partner_wrapper(self.partner_id).is_purchase_permitted(self, user, quantity, product)
 
     @property
     def is_below_threshold(self):

--- a/oscar/apps/partner/wrappers.py
+++ b/oscar/apps/partner/wrappers.py
@@ -21,7 +21,7 @@ class DefaultWrapper(object):
             return True
         return stockrecord.net_stock_level > 0
 
-    def is_purchase_permitted(self, stockrecord, product=None, user=None, quantity=1):
+    def is_purchase_permitted(self, stockrecord, user=None, quantity=1, product=None):
         """
         Test whether a particular purchase is possible (is a user buying a
         given quantity of the product)
@@ -30,7 +30,7 @@ class DefaultWrapper(object):
         product = product or stockrecord.product
         if not self.is_available_to_buy(stockrecord):
             return False, _("'%s' is not available to purchase") % product.title
-        max_qty = self.max_purchase_quantity(stockrecord, product, user)
+        max_qty = self.max_purchase_quantity(stockrecord, user, product)
         if max_qty is None:
             return True, None
         if max_qty < quantity:
@@ -38,7 +38,7 @@ class DefaultWrapper(object):
                             {'max': max_qty})
         return True, None
 
-    def max_purchase_quantity(self, stockrecord, product=None, user=None):
+    def max_purchase_quantity(self, stockrecord, user=None, product=None):
         """
         Return the maximum available purchase quantity for a given user
         """


### PR DESCRIPTION
On fetching Products from db (default url is /catalogue/), all needed information is gathered with select_related and prefetch_related in [get_product_base_queryset](https://github.com/tangentlabs/django-oscar/blob/master/oscar/apps/catalogue/views.py#L88).
But, function [DefaultWrapper.max_purchase_quantity](https://github.com/tangentlabs/django-oscar/blob/master/oscar/apps/partner/wrappers.py#L39) access to product through stockrecord. Product and StockRecord has OneToOne relation, so product == product.stockrecord.product. But last one will access database one more time. And, consequently, furcher attempts on product will also make db call: stockrecord.product.get_product_class().

Idea of this commit is to use fetched product, and not a stockrecord.product.

Linked to [#658](https://github.com/tangentlabs/django-oscar/issues/658)
