### PR TITLE
get_class fails with top level packages.

### DIFF
--- a/oscar/core/loading.py
+++ b/oscar/core/loading.py
@@ -44,8 +44,11 @@ def get_classes(module_label, classnames):
     # App must be local - check if module is in local app (it could be in
     # oscar's)
     app_label = module_label.split('.')[0]
-    base_package = app_module_path.rsplit('.' + app_label, 1)[0]
-    local_app = "%s.%s" % (base_package, module_label)
+    if '.' in app_module_path:
+        base_package = app_module_path.rsplit('.' + app_label, 1)[0]
+        local_app = "%s.%s" % (base_package, module_label)
+    else:
+        local_app = module_label
     try:
         imported_local_module = __import__(local_app, fromlist=classnames)
     except ImportError:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,17 @@
+import sys
+
+
+class temporary_python_path(object):
+    """
+    Acts as a context manager to temporarily append a list of paths to sys.path
+    """
+
+    def __init__(self, paths):
+        self.paths = paths
+
+    def __enter__(self):
+        self.original_paths = sys.path[:]
+        sys.path = self.paths + self.original_paths
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        sys.path = self.original_paths


### PR DESCRIPTION
Hello.
In an attemp to extend the shipping "app" we came into a problem.

We copied the shipping package into our project's package. So we have 
MyProject/
  shipping/
     repository.py
  MyProject/
     settings.py
....

But after several tries and debugging, the get_class (and more precisely, get_classes) in oscar/core/loading.py was not picking the classes in this package and son, it defaulted to the oscar's system wide shipping module.

After a grep in oscar, it seems that everytime that Repository is required, it is loaded with get_classs. So it should not need any additional bonding other than overriding in INSTALLED_APPS:

INSTALLED_APPS = INSTALLED_APPS +  get_core_apps(['shipping'])

It turns out that when get_classes generating the module path, if it is a top level package, it will generate something like : shipping.shipping.repository instead of shipping.repository.

The problem is that _get_app_module_path assumes there's always a dot in the module's name. get_classes should check that there is a dot in the module label before calling _get_app_module_path.
