### PR TITLE
Cannot include "recently viewed products" block on non-product page

### DIFF
--- a/oscar/templatetags/history_tags.py
+++ b/oscar/templatetags/history_tags.py
@@ -24,7 +24,7 @@ def recently_viewed_products(context):
     product_ids = get_recently_viewed_product_ids(request)
 
     current_product = context.get('product', None)
-    if current_product.id in product_ids:
+    if current_product and current_product.id in product_ids:
         product_ids.remove(current_product.id)
 
     # Reordering as the id order gets messed up in the query


### PR DESCRIPTION
The recently_viewed_products template tag in templatetags/history_tags.py does not work if there is no "product" object in the context. This is because it tries to access the id attribute of the product which is None if included on a non-product page .
