### PR TITLE
correct field reference in AbstractCommunicationEvent.__unicode__

### DIFF
--- a/oscar/apps/order/abstract_models.py
+++ b/oscar/apps/order/abstract_models.py
@@ -312,7 +312,7 @@ class AbstractCommunicationEvent(models.Model):
         verbose_name_plural = _("Communication Events")
 
     def __unicode__(self):
-        return _("'%(type)s' event for order #%(number)s") % {'type': self.type.name, 'number': self.order.number}
+        return _("'%(type)s' event for order #%(number)s") % {'type': self.event_type.name, 'number': self.order.number}
 
 
 class AbstractLine(models.Model):


### PR DESCRIPTION
Bad field reference in `__unicode__`: `self.type` instead of `self.event_type`.

Was trying to access CommunicationEvents via admin page, and got:

```
Exception Type: AttributeError
Exception Value: 'CommunicationEvent' object has no attribute 'type'
```
