### PR TITLE
Tabs to spaces in templates

### DIFF
--- a/oscar/templates/oscar/basket/partials/basket_content.html
+++ b/oscar/templates/oscar/basket/partials/basket_content.html
@@ -4,19 +4,19 @@
 
 {% if basket_warnings %}
     <h5>{% trans "Important messages about items in your basket" %}</h5>
-	{% for warning in basket_warnings %}
-	<div class="alert">{{ warning }}</div>
-	{% endfor %}
+    {% for warning in basket_warnings %}
+    <div class="alert">{{ warning }}</div>
+    {% endfor %}
 {% endif %}
 
 {% if upsell_messages %}
 <div class="well">
-	<h2>{% trans "You could be missing out on offers!" %}</h2>
-	{% for upsell in upsell_messages %}
+    <h2>{% trans "You could be missing out on offers!" %}</h2>
+    {% for upsell in upsell_messages %}
     {% blocktrans with message=upsell.message url=upsell.offer.get_absolute_url offer_name=upsell.offer.name %}
-	<div class="warning">{{ message }} to qualify for the <a href="{{ url }}">{{ offer_name }}</a> special offer</div>
+    <div class="warning">{{ message }} to qualify for the <a href="{{ url }}">{{ offer_name }}</a> special offer</div>
     {% endblocktrans %}
-	{% endfor %}
+    {% endfor %}
 </div>
 {% endif %}
 
@@ -145,23 +145,23 @@
         {{ saved_formset.management_form }}
         {% for form in saved_formset %}
         <div class="row-fluid basket-items">
-	    <div class="span8">
-			{{ form.id }}
-		    <div class="image_container">
-					{% with image=form.instance.product.primary_image %}
-					{% thumbnail image.original "200x200" upscale=False as thumb %}
-					<a href="{{ form.instance.product.get_absolute_url }}"><img class="thumbnail" src="{{ thumb.url }}" alt="{{ product.get_title }}"></a>
-					{% endthumbnail %}
-					{% endwith %}
-		    </div>
-			<h4><a href="{{ form.instance.product.get_absolute_url }}">{{ form.instance.description }}</a></h4>
+        <div class="span8">
+            {{ form.id }}
+            <div class="image_container">
+                    {% with image=form.instance.product.primary_image %}
+                    {% thumbnail image.original "200x200" upscale=False as thumb %}
+                    <a href="{{ form.instance.product.get_absolute_url }}"><img class="thumbnail" src="{{ thumb.url }}" alt="{{ product.get_title }}"></a>
+                    {% endthumbnail %}
+                    {% endwith %}
+            </div>
+            <h4><a href="{{ form.instance.product.get_absolute_url }}">{{ form.instance.description }}</a></h4>
                 <p class="availability {{ form.instance.product.stockrecord.availability_code }}">{{ form.instance.product.stockrecord.availability }}</p>
                 <a href="#" data-id="{{ forloop.counter0 }}" data-behaviours="remove">{% trans "Remove" %}</a>
-			<div style="display:none">
-				{{ form.move_to_basket }}
-				{{ form.DELETE }}
-			</div>
-		</div>
+            <div style="display:none">
+                {{ form.move_to_basket }}
+                {{ form.DELETE }}
+            </div>
+        </div>
             <div class="span2 align-center"><p class="price_color">{{ form.instance.unit_price_incl_tax|currency }}</p></div>
             <div class="span2"><a href="#" data-id="{{ forloop.counter0 }}" class="btn pull-right btn-full" data-behaviours="move">{% trans "Move to basket" %}</a></div>
         </div>

--- a/oscar/templates/oscar/basket/partials/basket_quick.html
+++ b/oscar/templates/oscar/basket/partials/basket_quick.html
@@ -21,15 +21,15 @@
             <div class="span6">
                 <h4><a href="{{ line.product.get_absolute_url }}">{{ line.description }}</a></h4>
             </div>
-			<div class="span1 align-center"><strong>{% trans "Qty" %}</strong> {{ line.quantity }}</div>
+            <div class="span1 align-center"><strong>{% trans "Qty" %}</strong> {{ line.quantity }}</div>
             <div class="span2 price_color align-right">{{ line.unit_price_excl_tax|currency }}</div>
         </div>
     </li>
     {% endfor %}
     <li class="form-actions">
-		<h4><small>{% trans "Total Excl Tax:" %} {{ request.basket.total_excl_tax|currency }}</small> <span class="price_color">{% trans "Total:" %} {{ basket.total_incl_tax|currency }}</span></h4>
-		<p class="pull-left"><a href="{% url basket:summary %}" class="btn btn-info btn-small">{% trans "View Basket" %}</a></p>
-		<p class="pull-right"><a href="{% url checkout:index %}" class="btn btn-primary btn-small"><i class="icon-shopping-cart"></i> {% trans "Checkout" %}</a></p>
+        <h4><small>{% trans "Total Excl Tax:" %} {{ request.basket.total_excl_tax|currency }}</small> <span class="price_color">{% trans "Total:" %} {{ basket.total_incl_tax|currency }}</span></h4>
+        <p class="pull-left"><a href="{% url basket:summary %}" class="btn btn-info btn-small">{% trans "View Basket" %}</a></p>
+        <p class="pull-right"><a href="{% url checkout:index %}" class="btn btn-primary btn-small"><i class="icon-shopping-cart"></i> {% trans "Checkout" %}</a></p>
     </li>
 {% else %}
     <li><p>{% trans "Your basket is empty." %}</p></li>

--- a/oscar/templates/oscar/catalogue/detail.html
+++ b/oscar/templates/oscar/catalogue/detail.html
@@ -7,7 +7,7 @@
 {% load i18n %}
 
 {% block extrastyles %}
-	<!-- Colorbox (a lightbox plugin) for image galleries -->
+    <!-- Colorbox (a lightbox plugin) for image galleries -->
     <link rel="stylesheet" href="{% static "oscar/js/colorbox/colorbox.css" %}" type="text/css" media="screen" charset="utf-8"/>
 {% endblock %}
 
@@ -17,18 +17,18 @@
 
 {% block breadcrumbs %}
 <ul class="breadcrumb">
-	<li> 
-		<a href="{% url promotions:home %}">{% trans "Home" %}</a>
+    <li> 
+        <a href="{% url promotions:home %}">{% trans "Home" %}</a>
         <span class="divider">/</span>
     </li>
-	{% with category=product.categories.all.0 %}
-		{% for c in category.get_ancestors %}
-		<li>
-			<a href="{{ c.get_absolute_url }}">{{ c.name }}</a>
-			<span class="divider">/</span>
-		</li>
-		{% endfor %}
-		<li class="active">{{ product.title }}</li>
+    {% with category=product.categories.all.0 %}
+        {% for c in category.get_ancestors %}
+        <li>
+            <a href="{{ c.get_absolute_url }}">{{ c.name }}</a>
+            <span class="divider">/</span>
+        </li>
+        {% endfor %}
+        <li class="active">{{ product.title }}</li>
 
         {% get_back_button as backbutton %}
         {% if backbutton %}
@@ -76,7 +76,7 @@
             {% include "catalogue/partials/stock_record.html" %}
             {% endblock %}
             
-			{% if product.rating != None %}
+            {% if product.rating != None %}
             <p class="star {{ product.rating|as_stars }}">
                 <small><a href="{% url catalogue:reviews-list product.slug product.id %}">
                         {% blocktrans count reviews|length as num_reviews %}
@@ -88,11 +88,11 @@
                 &nbsp;
                 <a id="write_review" href="{% url catalogue:reviews-add product.slug product.id %}#addreview" class="btn btn-success btn-small">{% trans "Write a review" %}</a>
             </p>
-			{% else %}
-				<p class="star">
-					<a id="write_review" href="{% url catalogue:reviews-add product.slug product.id %}#addreview" class="btn btn-success btn-small">{% trans "Write a review" %}</a>
-				</p>
-			{% endif %}
+            {% else %}
+                <p class="star">
+                    <a id="write_review" href="{% url catalogue:reviews-add product.slug product.id %}#addreview" class="btn btn-success btn-small">{% trans "Write a review" %}</a>
+                </p>
+            {% endif %}
              
             <hr/>
 
@@ -104,37 +104,37 @@
 
     </div><!-- /row-fluid -->
               
-	{% block product_description %}
+    {% block product_description %}
         {% if product.description %}
         <div id="product_description" class="sub-header">
             <h2>{% trans "Product Description" %}</h2>
         </div>
         <p>{{ product.description|safe }}</p>
         {% endif %}
-	{% endblock %}
+    {% endblock %}
     
-	{% block product_info %}
-	<div class="sub-header">
-		<h2>{% trans "Product Information" %}</h2>
-	</div>
+    {% block product_info %}
+    <div class="sub-header">
+        <h2>{% trans "Product Information" %}</h2>
+    </div>
     <table class="table table-striped table-condensed">
-		{% if product.upc %}
+        {% if product.upc %}
         <tr>
-			<th>{% trans "UPC" %}</th><td>{{ product.upc }}</td>
+            <th>{% trans "UPC" %}</th><td>{{ product.upc }}</td>
         </tr>
-		{% endif %}
+        {% endif %}
         <tr>
-			<th>{% trans "Product class" %}</th><td>{{ product.product_class.name }}</td>
+            <th>{% trans "Product class" %}</th><td>{{ product.product_class.name }}</td>
         </tr>
         {% if product.stockrecord %}
         <tr>
-			<th>{% trans "Price (excl. tax)" %}</th><td>{{ product.stockrecord.price_excl_tax|currency }}</td>
+            <th>{% trans "Price (excl. tax)" %}</th><td>{{ product.stockrecord.price_excl_tax|currency }}</td>
         </tr>
         <tr>
-			<th>{% trans "Price (incl. tax)" %}</th><td>{{ product.stockrecord.price_incl_tax|currency }}</td>
+            <th>{% trans "Price (incl. tax)" %}</th><td>{{ product.stockrecord.price_incl_tax|currency }}</td>
         </tr>
         <tr>
-			<th>{% trans "Availability" %}</th>
+            <th>{% trans "Availability" %}</th>
             <td>{{ product.stockrecord.availability }}</td>
         </tr>
         {% endif %}
@@ -145,7 +145,7 @@
         </tr>
         {% endfor %}
         <tr>
-			<th>{% trans "Num reviews" %}</th>
+            <th>{% trans "Num reviews" %}</th>
             <td>{{ reviews.count|default:0 }}</td>
         </tr>
         <tr>
@@ -153,7 +153,7 @@
             <td></td>
         </tr>
     </table>
-	{% endblock %}
+    {% endblock %}
 
     {% block product_review %}
     <section>
@@ -161,7 +161,7 @@
             {% if reviews %}
                 <a href="{% url catalogue:reviews-list product.slug product.id %}" class="btn pull-right">{% trans "See all reviews" %}</a>
             {% endif %}
-			<h2>{% trans "Customer Reviews" %}</h2>
+            <h2>{% trans "Customer Reviews" %}</h2>
         </div>
 
         {% if not reviews %}
@@ -183,7 +183,7 @@
         {% if product.related_products.count %}
         <div class="span6">
             <div class="sub-header">
-				<h2>{% trans "Related items" %}</h2>
+                <h2>{% trans "Related items" %}</h2>
             </div>
             <div class="es-carousel-wrapper">
                 <div class="es-carousel">
@@ -202,14 +202,14 @@
         {% if product.recommended_products.count %}
         <div class="span6">
             <div class="sub-header">
-				<h2>{% trans "Recommended items" %}</h2>
+                <h2>{% trans "Recommended items" %}</h2>
             </div>
             <div class="es-carousel-wrapper">
                 <div class="es-carousel">
                     <ul>
                         {% for product in product.recommended_products.all %}
                         <li>
-	                        {% render_product product %}
+                            {% render_product product %}
                         </li>
                         {% endfor %}
                     </ul>
@@ -218,7 +218,7 @@
         </div>
         {% endif %}
 
-		{% recently_viewed_products %}
+        {% recently_viewed_products %}
 
     </div>
 </article><!-- End of product page -->

--- a/oscar/templates/oscar/catalogue/partials/add_to_basket_form.html
+++ b/oscar/templates/oscar/catalogue/partials/add_to_basket_form.html
@@ -8,21 +8,21 @@
         {% csrf_token %}
         {% include "partials/form_fields.html" with form=basket_form %}
         <div class="form-actions">
-			<button type="submit" class="btn btn-large btn-primary btn-full" value="Add to basket">{% trans "Add to basket" %}</button>
+            <button type="submit" class="btn btn-large btn-primary btn-full" value="Add to basket">{% trans "Add to basket" %}</button>
         </div>
     </form>
     {% else %}
         {{ basket_form.reason }}
     {% endif %}
 {% else %}
-	{% if has_active_alert %}
-	<p>{% trans "You have an active stock alert for this product." %}</p>
-	{% else %}
-	<form id="alert_form" method="post" action="{% url customer:alert-create product.id %}">
+    {% if has_active_alert %}
+    <p>{% trans "You have an active stock alert for this product." %}</p>
+    {% else %}
+    <form id="alert_form" method="post" action="{% url customer:alert-create product.id %}">
         {% csrf_token %}
-		<p>{% trans "You can get an email alert when this product is back in stock." %}</p>
+        <p>{% trans "You can get an email alert when this product is back in stock." %}</p>
         {% include "partials/form_fields.html" with form=alert_form %}
         <button type="submit" class="btn btn-large btn-info btn-full">{% trans "Notify me" %}</button>
     </form>
-	{% endif %}
+    {% endif %}
 {% endif %}

--- a/oscar/templates/oscar/catalogue/partials/gallery.html
+++ b/oscar/templates/oscar/catalogue/partials/gallery.html
@@ -49,15 +49,15 @@
 
         {# Only one image to show #}
 
-		{% with image=product.primary_image %}
-		    {% thumbnail image.original "400x400" upscale=False as thumb %}
-			{% if not image.is_missing %}
+        {% with image=product.primary_image %}
+            {% thumbnail image.original "400x400" upscale=False as thumb %}
+            {% if not image.is_missing %}
                 <a href="{{ image.original.url }}" rel="lightbox"><img src="{{ thumb.url }}" data-large="{{ image.original.url }}" alt="image02" data-description="{% if image.caption %}{{ image.caption }}{% endif %}" /></a>
-			{% else %}
+            {% else %}
                 <img src="{{ thumb.url }}" alt="image02" />
-			{% endif %}
-			{% endthumbnail %}
-		{% endwith %}
+            {% endif %}
+            {% endthumbnail %}
+        {% endwith %}
 
     {% endif %}
 {% endwith %}

--- a/oscar/templates/oscar/catalogue/partials/product.html
+++ b/oscar/templates/oscar/catalogue/partials/product.html
@@ -6,11 +6,11 @@
 <article class="product_pod">
     {% block product_image %}
     <div class="image_container">
-		{% with image=product.primary_image %}
+        {% with image=product.primary_image %}
             {% thumbnail image.original "400x400" upscale=False as thumb %}
                 <a href="{{ product.get_absolute_url }}"><img src="{{ thumb.url }}" alt="{{ product.get_title }}" class="thumbnail"></a>
             {% endthumbnail %}
-		{% endwith %}
+        {% endwith %}
     </div>
     {% endblock %}
 

--- a/oscar/templates/oscar/catalogue/reviews/review_detail.html
+++ b/oscar/templates/oscar/catalogue/reviews/review_detail.html
@@ -11,23 +11,23 @@
 {% block breadcrumbs %}
 <ul class="breadcrumb">
     <li>
-	<a href="{% url promotions:home %}">{% trans "Home" %}</a>
+    <a href="{% url promotions:home %}">{% trans "Home" %}</a>
         <span class="divider">/</span>
     </li>
-	{% with category=product.categories.all.0 %}
-		{% for c in category.get_ancestors %}
-		<li>
-			<a href="{{ c.get_absolute_url }}">{{ c.name }}</a>
-			<span class="divider">/</span>
-		</li>
-		{% endfor %}
+    {% with category=product.categories.all.0 %}
+        {% for c in category.get_ancestors %}
+        <li>
+            <a href="{{ c.get_absolute_url }}">{{ c.name }}</a>
+            <span class="divider">/</span>
+        </li>
+        {% endfor %}
         <li>
             <a href="{{ product.get_absolute_url }}">{{ product.title }}</a>
-			<span class="divider">/</span>
+            <span class="divider">/</span>
         </li>
         <li>
             <a href="{% url catalogue:reviews-list product.slug product.pk %}">{% trans "Reviews" %}</a>
-			<span class="divider">/</span>
+            <span class="divider">/</span>
         </li>
     {% endwith %}
     <li class="active">{{ review.title }}</li>
@@ -51,11 +51,11 @@
 
         <div class="span3" style="text-align: center">
             <div class="thumbnail">
-				{% with image=product.primary_image %}
+                {% with image=product.primary_image %}
                     {% thumbnail image.original "400x400" upscale=False as thumb %}
                         <a href="{{ product.get_absolute_url }}"><img class="thumbnail" src="{{ thumb.url }}" alt="{{ product.get_title }}"></a>
                     {% endthumbnail %}
-				{% endwith %}
+                {% endwith %}
             </div>
             <div>
                 <h2><a href="{{ product.get_absolute_url }}">{{ product.get_title }}</a></h2>

--- a/oscar/templates/oscar/catalogue/reviews/review_form.html
+++ b/oscar/templates/oscar/catalogue/reviews/review_form.html
@@ -4,16 +4,16 @@
 {% block product_review %}
 <div id="addreview" class="review_add">
     <form id="add_review_form" method="post" action="./#addreview" class="form-horizontal" >
-	<fieldset>
-		<legend>{% trans "Leave a product review" %}</legend>
-	        {% csrf_token %}
-	        {% include "partials/form_fields.html" with form=form %}
-	        <div class="form-actions">
-				<button type="submit"  class="btn btn-primary">{% trans "Submit" %}</button>
-				{% trans "or" %}
-				<a href="{{ product.get_absolute_url }}" >{% trans "cancel" %}</a>
-	        </div>
-	</fieldset>
+    <fieldset>
+        <legend>{% trans "Leave a product review" %}</legend>
+            {% csrf_token %}
+            {% include "partials/form_fields.html" with form=form %}
+            <div class="form-actions">
+                <button type="submit"  class="btn btn-primary">{% trans "Submit" %}</button>
+                {% trans "or" %}
+                <a href="{{ product.get_absolute_url }}" >{% trans "cancel" %}</a>
+            </div>
+    </fieldset>
     </form>
 </div>
 {% endblock %}

--- a/oscar/templates/oscar/catalogue/reviews/review_list.html
+++ b/oscar/templates/oscar/catalogue/reviews/review_list.html
@@ -11,22 +11,22 @@
 {% block breadcrumbs %}
 <ul class="breadcrumb">
     <li>
-	<a href="{% url promotions:home %}">{% trans "Home" %}</a>
+    <a href="{% url promotions:home %}">{% trans "Home" %}</a>
         <span class="divider">/</span>
     </li>
-	{% with category=product.categories.all.0 %}
-		{% for c in category.get_ancestors %}
-		<li>
-			<a href="{{ c.get_absolute_url }}">{{ c.name }}</a>
-			<span class="divider">/</span>
-		</li>
-		{% endfor %}
+    {% with category=product.categories.all.0 %}
+        {% for c in category.get_ancestors %}
+        <li>
+            <a href="{{ c.get_absolute_url }}">{{ c.name }}</a>
+            <span class="divider">/</span>
+        </li>
+        {% endfor %}
         <li>
             <a href="{{ product.get_absolute_url }}">{{ product.title }}</a>
-			<span class="divider">/</span>
+            <span class="divider">/</span>
         </li>
     {% endwith %}
-	<li class="active">{% trans "All reviews" %}</li>
+    <li class="active">{% trans "All reviews" %}</li>
 </ul>
 {% endblock %}
 
@@ -64,11 +64,11 @@
 
         <div class="span3" style="text-align: center">
             <div class="thumbnail">
-				{% with image=product.primary_image %}
+                {% with image=product.primary_image %}
                     {% thumbnail image.original "400x400" upscale=False as thumb %}
                         <a href="{{ product.get_absolute_url }}"><img class="thumbnail" src="{{ thumb.url }}" alt="{{ product.get_title }}"></a>
                     {% endthumbnail %}
-				{% endwith %}
+                {% endwith %}
             </div>
             <div>
                 <h2><a href="{{ product.get_absolute_url }}">{{ product.get_title }}</a></h2>

--- a/oscar/templates/oscar/checkout/checkout.html
+++ b/oscar/templates/oscar/checkout/checkout.html
@@ -17,19 +17,19 @@
 {% block content %}
 
 {% if error %}
-	<div class="alert alert-error">
-		{{ error }}
-	</div>
+    <div class="alert alert-error">
+        {{ error }}
+    </div>
 {% endif %}
 
 <div class="row-fluid shipping-payment">
     {% block shipping_address %}
     <div class="span6">
         <div class="sub-header">
-			<h2>{% trans "Shipping" %}</h2>
+            <h2>{% trans "Shipping" %}</h2>
         </div>
         <div class="well well-info">
-			{% if shipping_address %}
+            {% if shipping_address %}
                 <h4>{% trans "Address" %}</h4>
                 <p>
                     {% for field in shipping_address.active_address_fields %}
@@ -45,23 +45,23 @@
                     <p>{{ shipping_address.notes|linebreaks }}</p>
                 {% endif %}
 
-				<h4>{% trans "Shipping method" %}</h4>
-				<p>{{ shipping_method.name }}
-					{% if shipping_method.description %}
-					- {{ shipping_method.description }}
-					{% endif %}
-				</p>
+                <h4>{% trans "Shipping method" %}</h4>
+                <p>{{ shipping_method.name }}
+                    {% if shipping_method.description %}
+                    - {{ shipping_method.description }}
+                    {% endif %}
+                </p>
             </dl>
 
             {% block shipping_address_actions %}
             <div class="alert-actions">
-				<a href="{% url checkout:shipping-address %}" class="btn">{% trans "Change shipping address" %}</a>
+                <a href="{% url checkout:shipping-address %}" class="btn">{% trans "Change shipping address" %}</a>
             </div>
             {% endblock %}
 
-			{% else %}
+            {% else %}
                 {% trans "No shipping is required for this order" %}
-			{% endif %}
+            {% endif %}
         </div>
     </div>
     {% endblock shipping_address %}
@@ -69,12 +69,12 @@
     {% block payment_method %}
    <div class="span6">
        <div class="sub-header">
-		   <h2>{% trans "Payment" %}</h2>
+           <h2>{% trans "Payment" %}</h2>
         </div>
         <div class="well well-success">
-			<p>{% trans "Payment details to go here" %}</p>
+            <p>{% trans "Payment details to go here" %}</p>
             <div class="alert-actions">
-				<a href="{% url checkout:payment-details %}" class="btn">{% trans "Change payment details" %}</a>
+                <a href="{% url checkout:payment-details %}" class="btn">{% trans "Change payment details" %}</a>
             </div>
         </div>    
     </div>
@@ -83,13 +83,13 @@
 
 {% block order_contents %}
     <div class="sub-header">
-		<h2>{% trans "Order contents" %}</h2>
+        <h2>{% trans "Order contents" %}</h2>
     </div>
     <div class="basket-title">
         <div class="row-fluid">
-			<h4 class="span9">{% trans "Items in basket" %}</h4>
-			<h4 class="span1 align-center">{% trans "Quantity" %}</h4>
-			<h4 class="span2 align-right">{% trans "Price" %}</h4>
+            <h4 class="span9">{% trans "Items in basket" %}</h4>
+            <h4 class="span1 align-center">{% trans "Quantity" %}</h4>
+            <h4 class="span2 align-right">{% trans "Price" %}</h4>
         </div>
     </div>
     {% for line in basket.all_lines %}
@@ -97,14 +97,14 @@
         <div class="row-fluid">
             <div class="span9">
                 <div class="image_container">
-					{% with image=line.product.primary_image %}
-					{% thumbnail image.original "200x200" upscale=False as thumb %}
-					<a href="{{ form.instance.product.get_absolute_url }}"><img class="thumbnail" src="{{ thumb.url }}" alt="{{ product.get_title }}"></a>
-					{% endthumbnail %}
-					{% endwith %}
-		    </div>
+                    {% with image=line.product.primary_image %}
+                    {% thumbnail image.original "200x200" upscale=False as thumb %}
+                    <a href="{{ form.instance.product.get_absolute_url }}"><img class="thumbnail" src="{{ thumb.url }}" alt="{{ product.get_title }}"></a>
+                    {% endthumbnail %}
+                    {% endwith %}
+            </div>
                 <h4><a href="{{ line.product.get_absolute_url }}">{{ line.description }}</a></h4>
-				<span class="availability {{ line.product.stockrecord.availability_code }}">{{ line.product.stockrecord.availability }}</span>
+                <span class="availability {{ line.product.stockrecord.availability_code }}">{{ line.product.stockrecord.availability }}</span>
             </div>
             <div class="span1 align-center">
                 {{ line.quantity }}
@@ -125,7 +125,7 @@
 
     {% block order_contents_actions %}
     <div class="form-actions">
-		<a href="{% url basket:summary %}" class="btn">{% trans "Edit order contents" %}</a>
+        <a href="{% url basket:summary %}" class="btn">{% trans "Edit order contents" %}</a>
     </div>
     {% endblock %}
 

--- a/oscar/templates/oscar/checkout/gateway.html
+++ b/oscar/templates/oscar/checkout/gateway.html
@@ -7,54 +7,54 @@
 {% endblock %}
 
 {% block checkout-nav %}
-	{% include 'checkout/nav.html' with step=0 %}
+    {% include 'checkout/nav.html' with step=0 %}
 {% endblock %}
 
 {% block content %}
 
 <div class="sub-header">
-	<h2>{% trans "Who are you?" %}</h2>
+    <h2>{% trans "Who are you?" %}</h2>
 </div>
 
 <form action="." method="post" class="form-stacked well well-info">
-	{% csrf_token %}
-	{{ form.non_field_errors }}
-	{% include 'partials/form_field.html' with field=form.username %}
-	
-	<div class="control-group">
-		{{ form.options.errors }}
-		<div class="controls">
-			<label class="radio">
-			     <input type="radio" id="id_options_1" name="options" value="existing" {% if form.password.errors %}checked="checked"{% endif %} />
-				 {% trans "I have an account and my password is" %}:
-			</label>
-		</div>
-	</div>
-	
-	<div class="control-group {% for error in form.password.errors %}error{% endfor %}">
-		<div class="controls">
-		    {{ form.password }}
-			<small><a href="{% url password-reset %}">{% trans "Get a password reminder" %}</a></small>
-		    {% for error in form.password.errors %}
-				<span class="help-block">
-					{{ error }}
-				</span>
+    {% csrf_token %}
+    {{ form.non_field_errors }}
+    {% include 'partials/form_field.html' with field=form.username %}
+    
+    <div class="control-group">
+        {{ form.options.errors }}
+        <div class="controls">
+            <label class="radio">
+                 <input type="radio" id="id_options_1" name="options" value="existing" {% if form.password.errors %}checked="checked"{% endif %} />
+                 {% trans "I have an account and my password is" %}:
+            </label>
+        </div>
+    </div>
+    
+    <div class="control-group {% for error in form.password.errors %}error{% endfor %}">
+        <div class="controls">
+            {{ form.password }}
+            <small><a href="{% url password-reset %}">{% trans "Get a password reminder" %}</a></small>
+            {% for error in form.password.errors %}
+                <span class="help-block">
+                    {{ error }}
+                </span>
             {% endfor %}
-		</div>
-	</div>	
-	
-	<div class="control-group">
-		<div class="controls">
-			<label class="radio">
-			     <input type="radio" id="id_options_0" name="options" value="new" {% if not form.password.errors %}checked="checked"{% endif %} />
-				 {% trans "I don't want to create an account" %}:
-			</label>
-		</div>
-	</div>
-		
-	<div class="form-actions">
-		<button type="submit" class="btn btn-large btn-primary">{% trans "Continue" %}</button>
-	</div>
+        </div>
+    </div>  
+    
+    <div class="control-group">
+        <div class="controls">
+            <label class="radio">
+                 <input type="radio" id="id_options_0" name="options" value="new" {% if not form.password.errors %}checked="checked"{% endif %} />
+                 {% trans "I don't want to create an account" %}:
+            </label>
+        </div>
+    </div>
+        
+    <div class="form-actions">
+        <button type="submit" class="btn btn-large btn-primary">{% trans "Continue" %}</button>
+    </div>
 </form>
 
 {% endblock content %}

--- a/oscar/templates/oscar/checkout/payment_details.html
+++ b/oscar/templates/oscar/checkout/payment_details.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block checkout-nav %}
-	{% include 'checkout/nav.html' with step=3 %}
+    {% include 'checkout/nav.html' with step=3 %}
 {% endblock %}
 
 {% block order_contents %}{% endblock %}
@@ -16,20 +16,20 @@
 {% block payment_method %}{% endblock %}
 
 {% block payment_details %}
-	<div class="sub-header">
-		<h2>Enter payment details</h2>
-	</div>
+    <div class="sub-header">
+        <h2>Enter payment details</h2>
+    </div>
 
-	{% block payment_details_content %}
-		<p>{% trans "This page needs implementing within your project.  You may want to use on one of Oscar's payment gateway libraries:" %}</p>
-		<ul>
-			<li><a href="https://github.com/tangentlabs/django-oscar-paypal">django-oscar-paypal</a></li>
-			<li><a href="https://github.com/tangentlabs/django-oscar-datacash">django-oscar-datacash</a></li>
-			<li><a href="https://github.com/tangentlabs/django-oscar-gocardless">django-oscar-gocardless</a></li>
-			<li><a href="https://github.com/tangentlabs/django-oscar-paymentexpress">django-oscar-paymentexpress</a></li>
-			<li><a href="https://github.com/tangentlabs/django-oscar-accounts">django-oscar-accounts</a></li>
-		</ul>
-		<a href="{% url checkout:preview %}" class="btn btn-primary btn-large">{% trans "Continue" %}</a>
-	{% endblock payment_details_content %}
+    {% block payment_details_content %}
+        <p>{% trans "This page needs implementing within your project.  You may want to use on one of Oscar's payment gateway libraries:" %}</p>
+        <ul>
+            <li><a href="https://github.com/tangentlabs/django-oscar-paypal">django-oscar-paypal</a></li>
+            <li><a href="https://github.com/tangentlabs/django-oscar-datacash">django-oscar-datacash</a></li>
+            <li><a href="https://github.com/tangentlabs/django-oscar-gocardless">django-oscar-gocardless</a></li>
+            <li><a href="https://github.com/tangentlabs/django-oscar-paymentexpress">django-oscar-paymentexpress</a></li>
+            <li><a href="https://github.com/tangentlabs/django-oscar-accounts">django-oscar-accounts</a></li>
+        </ul>
+        <a href="{% url checkout:preview %}" class="btn btn-primary btn-large">{% trans "Continue" %}</a>
+    {% endblock payment_details_content %}
 
 {% endblock payment_details %}

--- a/oscar/templates/oscar/checkout/preview.html
+++ b/oscar/templates/oscar/checkout/preview.html
@@ -6,13 +6,13 @@
 {% endblock %}
 
 {% block checkout-nav %}
-	{% include 'checkout/nav.html' with step=4 %}
+    {% include 'checkout/nav.html' with step=4 %}
 {% endblock %}
 
 {% block place_order %}
 <form method="post" action="{% url checkout:preview %}" id="place-order-form">
-	{% csrf_token %}
-	<input type="hidden" name="action" value="place_order" />
+    {% csrf_token %}
+    <input type="hidden" name="action" value="place_order" />
 
     {% comment %}
     When submitting sensitive data on the payment details page (eg a bankcard)
@@ -25,7 +25,7 @@
     </div>
 
     <div class="form-actions">
-		<button id='place-order' type="submit" class="pull-right btn btn-primary btn-large js-disable-on-click" data-loading-text="{% trans 'Submitting...' %}">{% trans "Place order" %}</button>
+        <button id='place-order' type="submit" class="pull-right btn btn-primary btn-large js-disable-on-click" data-loading-text="{% trans 'Submitting...' %}">{% trans "Place order" %}</button>
     </div>
 </form>
 {% endblock place_order %}

--- a/oscar/templates/oscar/checkout/shipping_address.html
+++ b/oscar/templates/oscar/checkout/shipping_address.html
@@ -13,41 +13,41 @@
 
 {% block shipping_address %}
     <div class="sub-header">
-		<h2>{% trans "Where should we ship to?" %}</h2>
+        <h2>{% trans "Where should we ship to?" %}</h2>
     </div>
     {% if request.user.is_authenticated %}
         {% if addresses %}
             
-		<h3>An address from your addressbook?</h3>
+        <h3>An address from your addressbook?</h3>
       
             <div class="choose-block">
                 <ul class="row-fluid">
                     {% for address in addresses %}
-					<li class="span3">
-						<div class="well well-info {% if address.is_default_for_shipping %}default-address{% endif %}">
-							<address>{% for field in address.active_address_fields %}
-							{{ field }}<br/>
-							{% endfor %}</address>
-							<form action="{% url checkout:shipping-address %}" method="post">
-								{% csrf_token %}
-								<input type="hidden" name="action" value="ship_to" />
-								<input type="hidden" name="address_id" value="{{ address.id }}" />
-								<button type="submit" class="btn btn-primary btn-full ship-address">{% trans "Ship to this address" %}</button>
-								<a class="btn btn-small btn-info" href="{% url checkout:user-address-update address.id %}">{% trans "Edit" %}</a>
-								<a href="{% url checkout:user-address-delete address.id %}" class="btn btn-small btn-danger">{% trans "Delete" %}</a>
-							</form>
-						</div>
-					</li>
+                    <li class="span3">
+                        <div class="well well-info {% if address.is_default_for_shipping %}default-address{% endif %}">
+                            <address>{% for field in address.active_address_fields %}
+                            {{ field }}<br/>
+                            {% endfor %}</address>
+                            <form action="{% url checkout:shipping-address %}" method="post">
+                                {% csrf_token %}
+                                <input type="hidden" name="action" value="ship_to" />
+                                <input type="hidden" name="address_id" value="{{ address.id }}" />
+                                <button type="submit" class="btn btn-primary btn-full ship-address">{% trans "Ship to this address" %}</button>
+                                <a class="btn btn-small btn-info" href="{% url checkout:user-address-update address.id %}">{% trans "Edit" %}</a>
+                                <a href="{% url checkout:user-address-delete address.id %}" class="btn btn-small btn-danger">{% trans "Delete" %}</a>
+                            </form>
+                        </div>
+                    </li>
                     {% if forloop.counter|divisibleby:4 %}
-						</ul>
-						{% if not forloop.last %}<ul class="row-fluid">{% endif %}
+                        </ul>
+                        {% if not forloop.last %}<ul class="row-fluid">{% endif %}
                     {% endif %}
                     {% endfor %}
                 </ul>
             </div>
             <h3>{% trans "Or a new address?" %}</h3>
         {% endif %}
-	</div>
+    </div>
     {% endif %}
 
     <form action="{% url checkout:shipping-address %}" method="post" class="form-horizontal">

--- a/oscar/templates/oscar/checkout/shipping_methods.html
+++ b/oscar/templates/oscar/checkout/shipping_methods.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block checkout-nav %}
-	{% include 'checkout/nav.html' with step=2 %}
+    {% include 'checkout/nav.html' with step=2 %}
 {% endblock %}
 
 {% block order_contents %}{% endblock %}
@@ -16,12 +16,12 @@
 
 {% block shipping_method %}
 <div class="sub-header">
-	<h2>{% trans "Choose a shipping method" %}</h2>
+    <h2>{% trans "Choose a shipping method" %}</h2>
 </div>
 <div class="basket-title">
     <div class="row-fluid">
-		<h4 class="span9">{% trans "Method" %}</h4>
-		<h4 class="span3">{% trans "Cost" %}</h4>
+        <h4 class="span9">{% trans "Method" %}</h4>
+        <h4 class="span3">{% trans "Cost" %}</h4>
     </div>
 </div>
 {% for method in methods %}
@@ -29,19 +29,19 @@
     <div class="row-fluid">
         <div class="span9">
             <h4>{{ method.name }}</h4>
-			{% if method.description %}
+            {% if method.description %}
                 <p>{{ method.description|safe }}</p>
-			{% endif %}
-			{% if method.is_discounted %}
-				<small>
-				{% with discount=method.get_discount %}
-				{% blocktrans with amount=discount.discount|currency name=discount.name %}
-				This includes a discount of {{ amount }} as
-				your basket qualifies for the '{{ name }}' offer.
-				{% endblocktrans %}
-				{% endwith %}
-				</small>
-			{% endif %}
+            {% endif %}
+            {% if method.is_discounted %}
+                <small>
+                {% with discount=method.get_discount %}
+                {% blocktrans with amount=discount.discount|currency name=discount.name %}
+                This includes a discount of {{ amount }} as
+                your basket qualifies for the '{{ name }}' offer.
+                {% endblocktrans %}
+                {% endwith %}
+                </small>
+            {% endif %}
         </div>
         <div class="span1">
             {{ method.basket_charge_incl_tax|currency }}
@@ -50,7 +50,7 @@
             <form method="post" action="{% url checkout:shipping-method %}">
                 {% csrf_token %}
                 <input type="hidden" name="method_code" value="{{ method.code }}" class="btn" />
-				<button type="submit" class="btn btn-large btn-primary pull-right">{% trans "Select option" %}</button>
+                <button type="submit" class="btn btn-large btn-primary pull-right">{% trans "Select option" %}</button>
             </form>
         </div>    
     </div>

--- a/oscar/templates/oscar/checkout/thank_you.html
+++ b/oscar/templates/oscar/checkout/thank_you.html
@@ -11,9 +11,9 @@
 
 {% block content %}
 <div class="sub-header">
-	<h1>{% blocktrans with order_num=order.number %}
-		Confirmation for order #{{ order_num }}
-		{% endblocktrans %}</h1>
+    <h1>{% blocktrans with order_num=order.number %}
+        Confirmation for order #{{ order_num }}
+        {% endblocktrans %}</h1>
 </div>
 <p>{% trans "Your order has been placed and a confirmation email has ben sent - your order number is" %}
 <span class="label label-success">{{ order.number }}</span></p>
@@ -21,57 +21,57 @@
 
 <div class="row-fluid shipping-payment">
     <div class="span6">
-		{% block shipping_info %}
+        {% block shipping_info %}
         <div class="well well-info">
-			<h3>{% trans "Shipping" %}</h3>
-			{% if order.shipping_address %}
-				<dl>
-					<dt>{% trans "Address" %}</dt>
-					<dd>
-						{% for field in order.shipping_address.active_address_fields %}
-						{{ field }}<br/>
-						{% endfor %}
-					</dd>
-					{% if order.shipping_address.phone_number %}
-					<dt>{% trans "Contact number" %}</dt>
-					<dd>{{ order.shipping_address.phone_number }}</dd>
-					{% endif %}
-					{% if order.shipping_address.notes %}
-					<dt>{% trans "Shipping notes" %}</dt>
-					<dd>{{ order.shipping_address.notes }}</dd>
-					{% endif %}
-					<dt>{% trans "Shipping method" %}</dt>
-					<dd>{{ order.shipping_method }}</dd>
-				</dl>
-			{% else %}
-				{% trans "No shipping is required for this order." %}
-			{% endif %}
+            <h3>{% trans "Shipping" %}</h3>
+            {% if order.shipping_address %}
+                <dl>
+                    <dt>{% trans "Address" %}</dt>
+                    <dd>
+                        {% for field in order.shipping_address.active_address_fields %}
+                        {{ field }}<br/>
+                        {% endfor %}
+                    </dd>
+                    {% if order.shipping_address.phone_number %}
+                    <dt>{% trans "Contact number" %}</dt>
+                    <dd>{{ order.shipping_address.phone_number }}</dd>
+                    {% endif %}
+                    {% if order.shipping_address.notes %}
+                    <dt>{% trans "Shipping notes" %}</dt>
+                    <dd>{{ order.shipping_address.notes }}</dd>
+                    {% endif %}
+                    <dt>{% trans "Shipping method" %}</dt>
+                    <dd>{{ order.shipping_method }}</dd>
+                </dl>
+            {% else %}
+                {% trans "No shipping is required for this order." %}
+            {% endif %}
         </div>
-		{% endblock %}
+        {% endblock %}
     </div>
     <div class="span6">
-		{% block payment_info %}
+        {% block payment_info %}
         <div class="well well-success">
-			<h3>{% trans "Payment" %}</h3>
+            <h3>{% trans "Payment" %}</h3>
             {% for source in order.sources.all %}
                 {{ source }}
-			{% empty %}
+            {% empty %}
                 {% trans "No payment was required for this order." %}
             {% endfor %}
         </div>
-		{% endblock %}
+        {% endblock %}
     </div>
 </div>
 <div class="sub-header">
-	<h3>{% trans "Order details" %}</h3>
+    <h3>{% trans "Order details" %}</h3>
 </div>
 
 <div class="basket-title">
     <div class="row-fluid">
-		<h4 class="span6">{% trans "Items purchased" %}</h4>
-		<h4 class="span3 align-center">{% trans "Estimated dispatch date" %}</h4>
-		<h4 class="span1 align-center">{% trans "Quantity" %}</h4>
-		<h4 class="span2 align-right">{% trans "Cost" %}</h4>
+        <h4 class="span6">{% trans "Items purchased" %}</h4>
+        <h4 class="span3 align-center">{% trans "Estimated dispatch date" %}</h4>
+        <h4 class="span1 align-center">{% trans "Quantity" %}</h4>
+        <h4 class="span2 align-right">{% trans "Cost" %}</h4>
     </div>
 </div>
 
@@ -80,12 +80,12 @@
     <div class="row-fluid">
         <div class="span6">
             <div class="image_container">
-				{% with image=line.product.primary_image %}
-				{% thumbnail image.original "200x200" upscale=False as thumb %}
-				<a href="{{ line.product.get_absolute_url }}"><img class="thumbnail" src="{{ thumb.url }}" alt="{{ product.get_title }}"></a>
-				{% endthumbnail %}
-				{% endwith %}
-		    </div>
+                {% with image=line.product.primary_image %}
+                {% thumbnail image.original "200x200" upscale=False as thumb %}
+                <a href="{{ line.product.get_absolute_url }}"><img class="thumbnail" src="{{ thumb.url }}" alt="{{ product.get_title }}"></a>
+                {% endthumbnail %}
+                {% endwith %}
+            </div>
             <h4><a href="{{ line.product.get_absolute_url }}">{{ line.description }}</a></h4>
         </div>
         <div class="span3 align-center">
@@ -183,7 +183,7 @@
                     <th colspan="2">&nbsp;</th>
                 </tr>
                 <tr>
-                	<td class="total"><h4>{% trans "Order total" %}</h4></td>
+                    <td class="total"><h4>{% trans "Order total" %}</h4></td>
                     <td class="total align-right"><h4 class="price_color">{{ order.total_incl_tax|currency }}</h4></td>
                 </tr>
 
@@ -195,16 +195,16 @@
 
 {% if not order.user %}
     <div class="sub-header">
-		<h2>{% trans "Tracking your order" %}</h2>
+        <h2>{% trans "Tracking your order" %}</h2>
     </div>
-	<p>{% trans "You can" %}
-		<a href="{% url customer:anon-order order.number order.verification_hash %}">{% trans "track the status of your order" %}</a>.
-	</p>
+    <p>{% trans "You can" %}
+        <a href="{% url customer:anon-order order.number order.verification_hash %}">{% trans "track the status of your order" %}</a>.
+    </p>
 {% endif %}
 
 <div class="form-actions">
-	<a onclick="window.print()" href="#" class="btn btn-primary btn-large">{% trans "Print this page" %}</a>
-	<a href="/" class="btn btn-primary btn-large pull-right">{% trans "Continue shopping" %}</a>
+    <a onclick="window.print()" href="#" class="btn btn-primary btn-large">{% trans "Print this page" %}</a>
+    <a href="/" class="btn btn-primary btn-large pull-right">{% trans "Continue shopping" %}</a>
 </div>
 {% endblock content %}
 

--- a/oscar/templates/oscar/checkout/user_address_delete.html
+++ b/oscar/templates/oscar/checkout/user_address_delete.html
@@ -7,7 +7,7 @@
 {% block payment_details %}{% endblock %}
 
 {% block checkout-nav %}
-	{% include 'checkout/nav.html' with step=1 %}
+    {% include 'checkout/nav.html' with step=1 %}
 {% endblock %}
 
 {% block shipping_address %}
@@ -15,9 +15,9 @@
 <h1>Delete address?</h1>
 <form action="." method="post">
     {% csrf_token %}
-	{{ object.summary }}
-	<p>{% trans "Are you sure you want to delete this address?" %} <button type="submit" class="btn btn-danger">{% trans "Yes!" %}</button>
-	{% trans "or" %} <a href="{% url checkout:shipping-address %}">{% trans "cancel" %}</a>.</p>
+    {{ object.summary }}
+    <p>{% trans "Are you sure you want to delete this address?" %} <button type="submit" class="btn btn-danger">{% trans "Yes!" %}</button>
+    {% trans "or" %} <a href="{% url checkout:shipping-address %}">{% trans "cancel" %}</a>.</p>
 </form>
 
 {% endblock shipping_address %}

--- a/oscar/templates/oscar/checkout/user_address_form.html
+++ b/oscar/templates/oscar/checkout/user_address_form.html
@@ -17,8 +17,8 @@
         {% csrf_token %}
         {% include "partials/form_fields.html" with form=form %}
         <div class="form-actions">
-			<button type="submit" class="btn btn-large btn-primary">{% trans "Save"	%}</button>
-			{% trans "or" %} <a href="{% url checkout:shipping-address %}">{% trans "cancel" %}</a>.
+            <button type="submit" class="btn btn-large btn-primary">{% trans "Save" %}</button>
+            {% trans "or" %} <a href="{% url checkout:shipping-address %}">{% trans "cancel" %}</a>.
         </div>
     </form>
 {% endblock shipping_address %}

--- a/oscar/templates/oscar/customer/anon_order.html
+++ b/oscar/templates/oscar/customer/anon_order.html
@@ -9,7 +9,7 @@
 
 {% block content %}
 <div class="sub-header">
-	<h3>{% trans 'Status' %}</h3>
+    <h3>{% trans 'Status' %}</h3>
 </div>
 <p>{{ order.status }}</p>
 

--- a/oscar/templates/oscar/customer/email.html
+++ b/oscar/templates/oscar/customer/email.html
@@ -19,7 +19,7 @@
         <a href="{% url customer:email-list %}">{% trans 'Email history' %}</a>
         <span class="divider">/</span>
     </li>
-	<li class="active">'{{ email.subject }}'</li>
+    <li class="active">'{{ email.subject }}'</li>
 </ul>
 {% endblock %}
 

--- a/oscar/templates/oscar/customer/email_list.html
+++ b/oscar/templates/oscar/customer/email_list.html
@@ -18,7 +18,7 @@
         <a href="{% url customer:summary %}">{% trans 'Account' %}</a>
         <span class="divider">/</span>
     </li>
-	<li class="active">{% trans 'Email history' %}</li>
+    <li class="active">{% trans 'Email history' %}</li>
 </ul>
 {% endblock %}
 
@@ -37,21 +37,21 @@
 {% endblock subheader %}
 
 {% block content %}
-	<table class="table table-striped table-bordered">
-		<tr>
-			<th>{% trans 'Date sent' %}</th>
-			<th>{% trans 'Subject' %}</th>
-			<th></th>
-		</tr>
-		{% for email in emails %}
-		<tr>
-			<td>{{ email.date_sent }}</td>
-			<td>{{ email.subject }}</td>
-			<td>
-				<a href="{% url customer:email-detail email.id %}" class="btn btn-info">{% trans 'View' %}</a>
-			</td>
-		</tr>
-		{% endfor %}
-	</table>
+    <table class="table table-striped table-bordered">
+        <tr>
+            <th>{% trans 'Date sent' %}</th>
+            <th>{% trans 'Subject' %}</th>
+            <th></th>
+        </tr>
+        {% for email in emails %}
+        <tr>
+            <td>{{ email.date_sent }}</td>
+            <td>{{ email.subject }}</td>
+            <td>
+                <a href="{% url customer:email-detail email.id %}" class="btn btn-info">{% trans 'View' %}</a>
+            </td>
+        </tr>
+        {% endfor %}
+    </table>
 {% endblock content %}
 

--- a/oscar/templates/oscar/customer/emails/commtype_password_reset_body.html
+++ b/oscar/templates/oscar/customer/emails/commtype_password_reset_body.html
@@ -4,7 +4,7 @@
 
 {% block body %}{% autoescape off %}
 <p>
-	{% blocktrans with name=site.name %}You're receiving this e-mail because you requested a password reset for your user account at {{ name }}.{% endblocktrans %}
+    {% blocktrans with name=site.name %}You're receiving this e-mail because you requested a password reset for your user account at {{ name }}.{% endblocktrans %}
 </p>
 
 <p>{% trans "Please go to the following page and choose a new password:" %}</p>

--- a/oscar/templates/oscar/customer/login_registration.html
+++ b/oscar/templates/oscar/customer/login_registration.html
@@ -12,7 +12,7 @@
         <a href="{% url promotions:home %}">{% trans 'Home' %}</a>
         <span class="divider">/</span>
     </li>
-	<li class="active">{% trans 'Login or register' %}</li>
+    <li class="active">{% trans 'Login or register' %}</li>
 </ul>
 {% endblock %}
 
@@ -26,7 +26,7 @@
             <h2>{% trans 'Log In' %}</h2>
             {% csrf_token %}
             {% include "partials/form_fields.html" with form=login_form %}
-			<p><a href="{% url password-reset %}">{% trans "I've forgotten my password" %}</a></p>
+            <p><a href="{% url password-reset %}">{% trans "I've forgotten my password" %}</a></p>
             <button name="login_submit" type="submit" value="Log In" class="btn btn-large btn-primary">{% trans 'Log In' %}</button>
         </form>
     </div>

--- a/oscar/templates/oscar/customer/notifications/list.html
+++ b/oscar/templates/oscar/customer/notifications/list.html
@@ -15,7 +15,7 @@
         <a href="{% url customer:summary %}">{% trans 'Account' %}</a>
         <span class="divider">/</span>
     </li>
-	<li class="active">{{ title }}</li>
+    <li class="active">{{ title }}</li>
 </ul>
 {% endblock %}
 
@@ -26,49 +26,49 @@
 {% block content %}
 
 <ul class="nav nav-tabs">
-	<li class="{% if list_type == 'inbox' %}active{% endif %}"><a href="{% url customer:notifications-inbox %}">{% trans "Inbox" %}</a></li>
-	<li class="{% if list_type == 'archive' %}active{% endif %}"><a href="{% url customer:notifications-archive %}">{% trans "Archive" %}</a></li>
+    <li class="{% if list_type == 'inbox' %}active{% endif %}"><a href="{% url customer:notifications-inbox %}">{% trans "Inbox" %}</a></li>
+    <li class="{% if list_type == 'archive' %}active{% endif %}"><a href="{% url customer:notifications-archive %}">{% trans "Archive" %}</a></li>
 </ul>
 
 {% if notifications %}
     {% include "partials/pagination.html" %}
 
 <form action="{% url customer:notifications-update %}" method="post">
-	{% csrf_token %}
-	<table class="table">
-		<tbody>
-		{% for notification in notifications %}
-		<tr>
-			<td>
-				<input type="checkbox" name="selected_notification" 
-				value="{{ notification.id }}"/>
-			</td>
-			<td>
-				{% if notification.is_new %}
-					<i class="icon-envelope"></i>
-				{% else %}
-					<i class="icon-envelope"></i>
-				{% endif %}
-			</td>
-			<td>
-				{{ notification.subject|safe }} <br/>
-				<em>{{ notification.date_sent }}</em> 
-			</td>
-			<td>
-				{% if list_type == 'inbox' %}
-				<a class="btn btn-success btn-small" href="#" data-behaviours="archive">{% trans "Archive" %}</a>
-				{% endif %}
-				<a class="btn btn-danger btn-small "href="#" data-behaviours="delete">{% trans "Delete" %}</a>
-			</td>
-		</tr>
-		{% endfor %}
-		</tbody>
-	</table>
-	{% trans "With selected items:" %} 
-	{% if list_type == 'inbox' %}
-	<button type="submit" class="btn btn-success" name="action" value="archive">{% trans "Archive" %}</button>
-	{% endif %}
-	<button type="submit" class="btn btn-danger" name="action" value="delete">{% trans "Delete" %}</button>
+    {% csrf_token %}
+    <table class="table">
+        <tbody>
+        {% for notification in notifications %}
+        <tr>
+            <td>
+                <input type="checkbox" name="selected_notification" 
+                value="{{ notification.id }}"/>
+            </td>
+            <td>
+                {% if notification.is_new %}
+                    <i class="icon-envelope"></i>
+                {% else %}
+                    <i class="icon-envelope"></i>
+                {% endif %}
+            </td>
+            <td>
+                {{ notification.subject|safe }} <br/>
+                <em>{{ notification.date_sent }}</em> 
+            </td>
+            <td>
+                {% if list_type == 'inbox' %}
+                <a class="btn btn-success btn-small" href="#" data-behaviours="archive">{% trans "Archive" %}</a>
+                {% endif %}
+                <a class="btn btn-danger btn-small "href="#" data-behaviours="delete">{% trans "Delete" %}</a>
+            </td>
+        </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    {% trans "With selected items:" %} 
+    {% if list_type == 'inbox' %}
+    <button type="submit" class="btn btn-success" name="action" value="archive">{% trans "Archive" %}</button>
+    {% endif %}
+    <button type="submit" class="btn btn-danger" name="action" value="delete">{% trans "Delete" %}</button>
 </form>
 
 {% include "partials/pagination.html" %}

--- a/oscar/templates/oscar/customer/order.html
+++ b/oscar/templates/oscar/customer/order.html
@@ -54,34 +54,34 @@
         <div class="tab-content">
             <div class="tab-pane active" id="1">
                 <table class="table table-striped table-bordered">
-				<thead>
-					<tr>
-						<th>{% trans 'Product' %}</th>
-						<th>{% trans 'Dispatch date' %}</th>
-						<th>{% trans 'Quantity' %}</th>
-						<th>{% trans 'Line price excl tax' %}</th>
-						<th>{% trans 'Line price incl tax' %}</th>
-						<th></th>
-					</tr>
-				</thead>
-				<tbody>
-					{% for line in order.lines.all %}
-					<tr>
-						<td><a href="{{ line.product.get_absolute_url }}">{{ line.description }}</a></td>
-						<td>{{ line.est_dispatch_date|default:"-" }}</td>
-						<td>{{ line.quantity }}</td>
-						<td>{{ line.line_price_before_discounts_excl_tax|currency }}</td>
-						<td>{{ line.line_price_before_discounts_incl_tax|currency }}</td>
-						<td>
-							<form id="line_form_{{ line.id }}" action="{% url customer:order-line order.number line.id %}" method="POST">
-								{% csrf_token %}
-								<input type="hidden" name="action" value="reorder" />
-								<button class="btn btn-success" type="submit">{% trans 'Re-order' %}</button>
-								<a class="btn btn-info" href="{% url catalogue:reviews-add line.product.slug line.product.id %}">{% trans 'Write a review' %}</a>
-							</form>
-						</td>
-					</tr>
-					{% endfor %}
+                <thead>
+                    <tr>
+                        <th>{% trans 'Product' %}</th>
+                        <th>{% trans 'Dispatch date' %}</th>
+                        <th>{% trans 'Quantity' %}</th>
+                        <th>{% trans 'Line price excl tax' %}</th>
+                        <th>{% trans 'Line price incl tax' %}</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for line in order.lines.all %}
+                    <tr>
+                        <td><a href="{{ line.product.get_absolute_url }}">{{ line.description }}</a></td>
+                        <td>{{ line.est_dispatch_date|default:"-" }}</td>
+                        <td>{{ line.quantity }}</td>
+                        <td>{{ line.line_price_before_discounts_excl_tax|currency }}</td>
+                        <td>{{ line.line_price_before_discounts_incl_tax|currency }}</td>
+                        <td>
+                            <form id="line_form_{{ line.id }}" action="{% url customer:order-line order.number line.id %}" method="POST">
+                                {% csrf_token %}
+                                <input type="hidden" name="action" value="reorder" />
+                                <button class="btn btn-success" type="submit">{% trans 'Re-order' %}</button>
+                                <a class="btn btn-info" href="{% url catalogue:reviews-add line.product.slug line.product.id %}">{% trans 'Write a review' %}</a>
+                            </form>
+                        </td>
+                    </tr>
+                    {% endfor %}
 
                     {% with discounts=order.basket_discounts %}
                         {% if discounts %}
@@ -135,11 +135,11 @@
                         </tr>
                     {% endif %}
 
-					<tr>
-						<th colspan="4">{% trans 'Order total' %}</th>
-						<td colspan="2">{{ order.total_incl_tax|currency }}</td>
-					</tr>
-				</tbody>
+                    <tr>
+                        <th colspan="4">{% trans 'Order total' %}</th>
+                        <td colspan="2">{{ order.total_incl_tax|currency }}</td>
+                    </tr>
+                </tbody>
                 </table>
             </div>
 
@@ -148,7 +148,7 @@
             </div>
 
             <div class="tab-pane" id="3">
-			<div class="row-fluid">
+            <div class="row-fluid">
                     <div class="span4">
                         <div class="well well-info">
                             <h4>{% trans 'Address:' %}</h4>

--- a/oscar/templates/oscar/customer/order_list.html
+++ b/oscar/templates/oscar/customer/order_list.html
@@ -61,7 +61,7 @@
         <td>{{ order.date_placed }}</td>
         <td>
             <a class="btn btn-info" href="{% url customer:order order.number %}">{% trans 'View' %}</a>
-			<form id="order_form_{{ order.id }}" action="{% url customer:order order.number %}" method="post">
+            <form id="order_form_{{ order.id }}" action="{% url customer:order order.number %}" method="post">
                 {% csrf_token %}
                 <input type="hidden" name="order_id" value="{{ order.id }}" />
                 <input type="hidden" name="action" value="reorder" />

--- a/oscar/templates/oscar/customer/profile.html
+++ b/oscar/templates/oscar/customer/profile.html
@@ -55,7 +55,7 @@
 
     <div class="tab-content">
 
-		<div class="tab-pane {% if active_tab == 'profile' %}active{% endif %}" id="profile">
+        <div class="tab-pane {% if active_tab == 'profile' %}active{% endif %}" id="profile">
             {% block tab_profile %}
             <div class="sub-header">
                 <h3>{% trans 'Profile' %}</h3>
@@ -195,47 +195,47 @@
             </div>
             
             {% endif %}
-			{% endblock %}
+            {% endblock %}
         </div>
 
         <div class="tab-pane {% if active_tab == 'alerts' %}active{% endif %}" id="alerts">
             {% block tab_alerts %}
             <div class="sub-header">
-			    <h3>{% trans "Alerts" %}</h3>
-			</div>
+                <h3>{% trans "Alerts" %}</h3>
+            </div>
 
-			{% if not alerts %}
-			<p>{% trans "You do not have any active alerts for out-of-stock products." %}</p>
-			{% else %}
-			    <form action="." method="post" id="alerts_form">
-			    {% csrf_token %}
-			        <table class="table table-stiped table-bordered">
-			            <tr>
-			                <th>{% trans "Product" %}</th>
-			                <th>{% trans "Status" %}</th>
-			                <th>{% trans "Date created" %}</th>
-			                <th></th>
-			            </tr>
+            {% if not alerts %}
+            <p>{% trans "You do not have any active alerts for out-of-stock products." %}</p>
+            {% else %}
+                <form action="." method="post" id="alerts_form">
+                {% csrf_token %}
+                    <table class="table table-stiped table-bordered">
+                        <tr>
+                            <th>{% trans "Product" %}</th>
+                            <th>{% trans "Status" %}</th>
+                            <th>{% trans "Date created" %}</th>
+                            <th></th>
+                        </tr>
 
-			            {% for alert in alerts %}
-			            <tr>
-			                <td>
-			                    {% with product=alert.product %}
-			                    <a href="{{ product.get_absolute_url }}">{{ product.get_title }}</a>
-			                    {% endwith %}
-			                </td>
-			                <td>{{ alert.status }}</td>
-			                <td>{{ alert.date_created }}</td>
-			                <td>
-			                    {% if alert.can_be_cancelled %}
-			                        <button class="btn btn-danger" type='submit' name='cancel_alert' value='{{ alert.id }}'>{% trans "Cancel" %}</button>
-			                    {% endif %}
-			                </td>
-			            </tr>
-			            {% endfor %}
-			        </table>
-			    </form>
-			{% endif %}
+                        {% for alert in alerts %}
+                        <tr>
+                            <td>
+                                {% with product=alert.product %}
+                                <a href="{{ product.get_absolute_url }}">{{ product.get_title }}</a>
+                                {% endwith %}
+                            </td>
+                            <td>{{ alert.status }}</td>
+                            <td>{{ alert.date_created }}</td>
+                            <td>
+                                {% if alert.can_be_cancelled %}
+                                    <button class="btn btn-danger" type='submit' name='cancel_alert' value='{{ alert.id }}'>{% trans "Cancel" %}</button>
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </table>
+                </form>
+            {% endif %}
 
             {% endblock %}
         </div>

--- a/oscar/templates/oscar/customer/profile_form.html
+++ b/oscar/templates/oscar/customer/profile_form.html
@@ -37,11 +37,11 @@
 
 {% block content %}
 <form id="profile_form" action="." method="post">
-	{% csrf_token %}
-	{% include 'partials/form_fields.html' with form=form %}
-	<div class="form-actions">
-		<button type="submit" class="btn btn-primary btn-large">{% trans 'Save' %}</button>
-		{% trans 'or' %} <a href="{% url customer:summary %}">{% trans 'cancel' %}</a>.
-	</div>
+    {% csrf_token %}
+    {% include 'partials/form_fields.html' with form=form %}
+    <div class="form-actions">
+        <button type="submit" class="btn btn-primary btn-large">{% trans 'Save' %}</button>
+        {% trans 'or' %} <a href="{% url customer:summary %}">{% trans 'cancel' %}</a>.
+    </div>
 </form>
 {% endblock content %}

--- a/oscar/templates/oscar/dashboard/catalogue/category_delete.html
+++ b/oscar/templates/oscar/dashboard/catalogue/category_delete.html
@@ -30,12 +30,12 @@ create-page
 <form action="." method="post" class="well">
     {% csrf_token %}
     {{ form }}
-	{% blocktrans with name=object.name %}
+    {% blocktrans with name=object.name %}
     <p>Delete category <strong>{{ name }}</strong> - are you sure?</p>
-	{% endblocktrans %}
+    {% endblocktrans %}
     <div class="form-actions">
-		<button type="submit" class="btn btn-danger">{% trans "Delete" %}</button>
-		{% trans "or" %} <a href="{% if parent %}{% url dashboard:catalogue-category-detail-list pk=parent.pk %}{% else %}{% url dashboard:catalogue-category-list %}{% endif %}">{% trans "cancel" %}</a>
+        <button type="submit" class="btn btn-danger">{% trans "Delete" %}</button>
+        {% trans "or" %} <a href="{% if parent %}{% url dashboard:catalogue-category-detail-list pk=parent.pk %}{% else %}{% url dashboard:catalogue-category-list %}{% endif %}">{% trans "cancel" %}</a>
     </div>
 </form>
 {% endblock %}

--- a/oscar/templates/oscar/dashboard/catalogue/category_form.html
+++ b/oscar/templates/oscar/dashboard/catalogue/category_form.html
@@ -8,15 +8,15 @@
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">	  	
-    <li>	  	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li>	  	
-        <a href="{% url dashboard:catalogue-category-list %}">{% trans "Categories" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
+<ul class="breadcrumb">     
+    <li>        
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li>        
+        <a href="{% url dashboard:catalogue-category-list %}">{% trans "Categories" %}</a>      
+        <span class="divider">/</span>      
+    </li>       
     <li class="active">{{ title }}</li>
 </ul>
 {% endblock %}

--- a/oscar/templates/oscar/dashboard/catalogue/category_list.html
+++ b/oscar/templates/oscar/dashboard/catalogue/category_list.html
@@ -35,30 +35,30 @@
     <p>{% trans "You are editing:" %}
     <strong><a href="{% url dashboard:catalogue-category-list %}">Home</a></strong>
     {% if ancestors %}
-    	&gt;
-    	{% for ancestor in ancestors %}
+        &gt;
+        {% for ancestor in ancestors %}
             <strong><a href="{% url dashboard:catalogue-category-detail-list pk=ancestor.pk %}">{{ ancestor.name }}</a></strong>{% if not forloop.last %} > {% endif %}
-    	{% endfor %}
+        {% endfor %}
     {% endif %}
     </p>
 </div>
 
 <table class="table table-striped table-bordered table-hover">
     <caption><i class="icon-sitemap icon-large"></i>{% trans 'Categories' %}</caption>
-	<thead>
-		<tr>
-			<th>{% trans "Name" %}</th>
-			<th>{% trans "Description" %}</th>
-			<th>{% trans "Number of child categories" %}</th>
-			<th></th>
-		</tr>
-	</thead>
-	<tbody>
+    <thead>
+        <tr>
+            <th>{% trans "Name" %}</th>
+            <th>{% trans "Description" %}</th>
+            <th>{% trans "Number of child categories" %}</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
     {% for category in child_categories %}
         <tr>
             <td>{{ category.name }}</td>
-			<td>{{ category.description|default:""|striptags|cut:"&nbsp;"|truncatewords:6 }}</td>
-			<td>{{ category.get_num_children }}</td>
+            <td>{{ category.description|default:""|striptags|cut:"&nbsp;"|truncatewords:6 }}</td>
+            <td>{{ category.get_num_children }}</td>
             <td>
                 <div class="btn-toolbar">
                     <div class="btn-group">
@@ -68,16 +68,16 @@
                       </a>
                       <ul class="nav dropdown-menu pull-right">
                          <li><a href="{% url dashboard:catalogue-category-update category.id %}">{% trans "Edit category" %}</a></li>
-          				 <li class="{% if not category.has_children %}disabled{% endif %}"><a href="{% url dashboard:catalogue-category-detail-list pk=category.pk %}">{% trans "Edit children" %}</a></li>
-          				  <li><a href="{{ category.get_absolute_url }}">{% trans "View on site" %}</a></li>
-          				  <li><a href="{% url dashboard:catalogue-category-delete category.id %}">{% trans "Delete" %}</a></li>
+                         <li class="{% if not category.has_children %}disabled{% endif %}"><a href="{% url dashboard:catalogue-category-detail-list pk=category.pk %}">{% trans "Edit children" %}</a></li>
+                          <li><a href="{{ category.get_absolute_url }}">{% trans "View on site" %}</a></li>
+                          <li><a href="{% url dashboard:catalogue-category-delete category.id %}">{% trans "Delete" %}</a></li>
                       </ul>
                     </div>
                 </div>
             </td>
         </tr>
     {% endfor %}
-	</tbody>
+    </tbody>
 </table>
 
 

--- a/oscar/templates/oscar/dashboard/catalogue/product_delete.html
+++ b/oscar/templates/oscar/dashboard/catalogue/product_delete.html
@@ -32,7 +32,7 @@ create-page
 
 {% block header %}
 <div class="page-header">
-	<h1>{% trans "Delete product?" %}</h1>
+    <h1>{% trans "Delete product?" %}</h1>
 </div>
 {% endblock header%}
 

--- a/oscar/templates/oscar/dashboard/catalogue/product_list.html
+++ b/oscar/templates/oscar/dashboard/catalogue/product_list.html
@@ -27,11 +27,11 @@
 
 {% block dashboard_content %}
 <div class="table-header">
-	<h3><i class="icon-search icon-large"></i>{% trans "Search Products" %}</h3>
+    <h3><i class="icon-search icon-large"></i>{% trans "Search Products" %}</h3>
 </div>
 <div class="well">
     <form action="." method="get" class="form-inline">
-		{% include "partials/form_fields_inline.html" with form=form %}
+        {% include "partials/form_fields_inline.html" with form=form %}
         <button type="submit" class="btn btn-primary">{% trans "Search" %}</button>
     </form>
 </div>
@@ -60,8 +60,8 @@
 </div>
 <form action="." method="post">
     {% csrf_token %}
-	<table class="table table-striped table-bordered">
-	    <tr>
+    <table class="table table-striped table-bordered">
+        <tr>
             <th>{% trans "UPC" %}</th>
             <th>{% trans "Image" %}</th>
             <th>{% trans "Title" %}</th>
@@ -75,10 +75,10 @@
             <th>{% trans "Number allocated" %}</th>
             <th>{% trans "Parent" %}</th>
             <th>{% trans "Children" %}</th>
-	        <th></th>
-	    </tr>
-	    {% for product in products %}
-	    <tr>
+            <th></th>
+        </tr>
+        {% for product in products %}
+        <tr>
                 <td>{{ product.upc|default:"-" }}</td>
                 <td>
                 {% if product.primary_image.original.url %}
@@ -139,10 +139,10 @@
                         </div>
                     </div>
                 </td>
-	    </tr>
-	    {% endfor %}
-	</table>
-	{% include "partials/pagination.html" %}
+        </tr>
+        {% endfor %}
+    </table>
+    {% include "partials/pagination.html" %}
 </form>
 
 {% else %}

--- a/oscar/templates/oscar/dashboard/catalogue/stockalert_list.html
+++ b/oscar/templates/oscar/dashboard/catalogue/stockalert_list.html
@@ -45,7 +45,7 @@
 </div>
 
 <div class="table-header">
-	<h2><i class="icon-sitemap icon-large"></i>{{ description }}</h2>
+    <h2><i class="icon-sitemap icon-large"></i>{{ description }}</h2>
 </div>
 
 <table class="table table-striped table-bordered table-hover">

--- a/oscar/templates/oscar/dashboard/comms/detail.html
+++ b/oscar/templates/oscar/dashboard/comms/detail.html
@@ -9,16 +9,16 @@ create-page default
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">   	
+<ul class="breadcrumb">     
     <li>
         <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>
         <span class="divider">/</span>
     </li>
     <li>
         <a href="{% url dashboard:comms-list %}">{% trans "Emails" %}</a>
-        <span class="divider">/</span>  	
-    </li>  	
-    <li class="active"><a href=".">{{ commtype.name }}</a></li>  	
+        <span class="divider">/</span>      
+    </li>   
+    <li class="active"><a href=".">{{ commtype.name }}</a></li>     
 </ul>
 {% endblock %}
 
@@ -53,18 +53,18 @@ create-page default
                 <h3>{% trans "Email content" %}</h3>
              </div>
              <div class="well">
-				 <p>{% trans "These fields are rendered using Django's template system." %}</p>
-				 <p>{% trans "You can use the following variables:" %}</p>
+                 <p>{% trans "These fields are rendered using Django's template system." %}</p>
+                 <p>{% trans "You can use the following variables:" %}</p>
                  <dl>
                      <dt><code>{% templatetag openvariable %} user.get_full_name {% templatetag closevariable %}</code></dt>
-					 <dd>{% trans "The full name of the user (if they have one)" %}</dd>
+                     <dd>{% trans "The full name of the user (if they have one)" %}</dd>
                      <dt><code>{% templatetag openvariable %} user.email {% templatetag closevariable %}</code></dt>
-					 <dd>{% trans "The user's email address" %}</dd>
+                     <dd>{% trans "The user's email address" %}</dd>
                      <dt><code>{% templatetag openvariable %} site.name {% templatetag closevariable %}</code></dt>
-					 <dd>{% trans "The name of the site (eg example.com)" %}</dd>
+                     <dd>{% trans "The name of the site (eg example.com)" %}</dd>
                      {% if commtype.is_order_related %}
                         <dt><code>{% templatetag openvariable %} order.number {% templatetag closevariable %}</code></dt>
-						<dd>{% trans "Order number" %}</dd>
+                        <dd>{% trans "Order number" %}</dd>
                      {% endif %}
                  </dl>
              </div>
@@ -76,11 +76,11 @@ create-page default
              </div>
              <div class="well">
                  {% if commtype.is_order_related %}
-				 <p>{% trans "View a preview of this email using order:" %}</p>
+                 <p>{% trans "View a preview of this email using order:" %}</p>
                  {% include 'partials/form_field.html' with field=form.preview_order_number %}
                  {% endif %}
                  <button type="submit" class="btn btn-primary btn-large" name="show_preview">{% trans "View preview" %}</button>
-				 <p>{% trans "or send a preview to:" %}</p>
+                 <p>{% trans "or send a preview to:" %}</p>
                  {% include 'partials/form_field.html' with field=form.preview_email %}
                  <button type="submit" class="btn" name="send_preview">{% trans "Send preview email" %}</button>
              </div>

--- a/oscar/templates/oscar/dashboard/comms/list.html
+++ b/oscar/templates/oscar/dashboard/comms/list.html
@@ -2,21 +2,21 @@
 {% load i18n %}
 
 {% block title %}
-	{% trans "Emails" %} | {{ block.super }}
+    {% trans "Emails" %} | {{ block.super }}
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">	  	
-    <li>	  	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li class="active"><a href=".">{% trans "Emails" %}</a></li>	  	
+<ul class="breadcrumb">     
+    <li>        
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li class="active"><a href=".">{% trans "Emails" %}</a></li>        
 </ul>
 {% endblock %}
 
 {% block header %}
-<div class="page-header"> 	
+<div class="page-header">   
     <h1>{% trans "Emails" %}</h1>
 </div>
 {% endblock header %}
@@ -25,28 +25,28 @@
 <table class="table table-striped table-bordered table-hover">
     <caption><i class="icon-envelope icon-large"></i>{% trans "Emails" %}</caption>
     {% if commtypes %}
-	<thead>
-		<tr>
-			<th>{% trans "Code" %}</th>
-			<th>{% trans "Name" %}</th>
-			<th>{% trans "Category" %}</th>
-			<th></th>
-		</tr>
-	</thead>
-	<tbody>
-		{% for commtype in commtypes %}
-		<tr>
-			<td>{{ commtype.code }}</td>
-			<td>{{ commtype.name }}</td>
-			<td>{{ commtype.category }}</td>
-			<td>
-				<a class="btn btn-success" href="{% url dashboard:comms-update commtype.code|lower %}">{% trans "Edit" %}</a>
-			</td>
-		</tr>
-		{% endfor %}
-	</tbody>
-	
-	{% else %}
+    <thead>
+        <tr>
+            <th>{% trans "Code" %}</th>
+            <th>{% trans "Name" %}</th>
+            <th>{% trans "Category" %}</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for commtype in commtypes %}
+        <tr>
+            <td>{{ commtype.code }}</td>
+            <td>{{ commtype.name }}</td>
+            <td>{{ commtype.category }}</td>
+            <td>
+                <a class="btn btn-success" href="{% url dashboard:comms-update commtype.code|lower %}">{% trans "Edit" %}</a>
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+    
+    {% else %}
     <tbody>
         <tr><td>{% trans "There are no defined emails to edit." %}</td></tr>
     </tbody>

--- a/oscar/templates/oscar/dashboard/index.html
+++ b/oscar/templates/oscar/dashboard/index.html
@@ -6,7 +6,7 @@
 
 {% block extrahead %}
     {{ block.super }}
-	<meta http-equiv="refresh" content="300">
+    <meta http-equiv="refresh" content="300">
 {% endblock %}
 
 {% block breadcrumbs %}
@@ -19,7 +19,7 @@
 {% block dashboard_content %}
 
 <div class="table-header">
-	<i class="icon-signal icon-large"></i>{% trans "Your Store Statistics" %}
+    <i class="icon-signal icon-large"></i>{% trans "Your Store Statistics" %}
 </div>
 
 <div class="content-block">
@@ -60,21 +60,21 @@
     <div class="span4">
         <table class="table table-striped table-bordered table-hover">
             <caption><i class="icon-shopping-cart icon-large"></i>{% trans "Orders - Last 24 Hours" %}</caption>
-			</tr>
+            </tr>
                 <tr>
-					<th class="span10">{% trans "Total orders" %}</th>
+                    <th class="span10">{% trans "Total orders" %}</th>
                         <td class="span2" >{{ total_orders_last_day }}</td>
                 </tr>
                 <tr>
-					<th class="span10">{% trans "Total lines" %}</th>
+                    <th class="span10">{% trans "Total lines" %}</th>
                         <td class="span2" >{{ total_lines_last_day }}</td>
                 </tr>
                 <tr>
-					<th class="span10">{% trans "Total revenue" %}</th>
+                    <th class="span10">{% trans "Total revenue" %}</th>
                         <td class="span2" >{{ total_revenue_last_day|currency }}</td>
                 </tr>
                 <tr>
-					<th class="span10">{% trans "Average order costs" %}</th>
+                    <th class="span10">{% trans "Average order costs" %}</th>
                         <td class="span2" >{{ average_order_costs|currency }}</td>
                 </tr>
         </table>
@@ -82,21 +82,21 @@
     
     <div class="span4">
         <table class="table table-striped table-bordered table-hover">
-			<caption><i class="icon-shopping-cart icon-large"></i>{% trans "Orders - All Time" %}<a href="{% url dashboard:order-list %}" class="btn pull-right"><i class="icon-shopping-cart icon-large"></i>{% trans "Manage" %}</a></caption>
+            <caption><i class="icon-shopping-cart icon-large"></i>{% trans "Orders - All Time" %}<a href="{% url dashboard:order-list %}" class="btn pull-right"><i class="icon-shopping-cart icon-large"></i>{% trans "Manage" %}</a></caption>
             <tr>
-				<th class="span10">{% trans "Total orders" %}</th>
+                <th class="span10">{% trans "Total orders" %}</th>
                     <td class="span2" >{{ total_orders }}</td>
             </tr>
             <tr>
-				<th class="span10">{% trans "Total lines" %}</th>
+                <th class="span10">{% trans "Total lines" %}</th>
                     <td class="span2" >{{ total_lines }}</td>
             </tr>
             <tr>
-				<th class="span10">{% trans "Total revenue" %}</th>
+                <th class="span10">{% trans "Total revenue" %}</th>
                     <td class="span2" >{{ total_revenue|currency }}</td>
             </tr>
             <tr>
-				<th class="span10">{% trans "Total" %} <em>{% trans "open" %}</em> {% trans "baskets" %}</th>
+                <th class="span10">{% trans "Total" %} <em>{% trans "open" %}</em> {% trans "baskets" %}</th>
                 <td class="span2" >{{ total_open_baskets }}</td>
             </tr>
         </table>
@@ -104,17 +104,17 @@
     
     <div class="span4">
         <table class="table table-striped table-bordered table-hover">
-			<caption><i class="icon-group icon-large"></i>{% trans "Customers" %}</caption>
+            <caption><i class="icon-group icon-large"></i>{% trans "Customers" %}</caption>
             <tr>
-				<th class="span10">{% trans "Total customers" %}</th>
+                <th class="span10">{% trans "Total customers" %}</th>
                 <td class="span2" >{{ total_customers }}</td>
             </tr>
             <tr>
-				<th class="span10">{% trans "New customers" %}</th>
+                <th class="span10">{% trans "New customers" %}</th>
                 <td class="span2" >{{ total_customers_last_day }}</td>
             </tr>
             <tr>
-				<th class="span10">{% trans "Total" %} <em>{% trans "open" %}</em> {% trans "baskets" %}</th>
+                <th class="span10">{% trans "Total" %} <em>{% trans "open" %}</em> {% trans "baskets" %}</th>
                 <td class="span2" >{{ total_open_baskets_last_day }}</td>
             </tr>
         </table>
@@ -124,8 +124,8 @@
 <div class='row-fluid'>
     <div class="span6">
         <table class="table table-striped table-bordered table-hover">
-			<caption>
-			    <div class="btn-toolbar pull-right">
+            <caption>
+                <div class="btn-toolbar pull-right">
                   <div class="btn-group">
                     <a href="{% url dashboard:catalogue-product-list %}" class="btn"><i class="icon-sitemap icon-large"></i>{% trans "Manage" %}</a>
                   </div>
@@ -133,18 +133,18 @@
                       <a href="{% url dashboard:stock-alert-list %}" class="btn"><i class="icon-sitemap icon-large"></i>{% trans "View Stock Alerts" %}</a>
                   </div>
                 </div>
-			    <i class="icon-sitemap icon-large"></i>{% trans "Catalogue and stock" %}
-    		</caption>
+                <i class="icon-sitemap icon-large"></i>{% trans "Catalogue and stock" %}
+            </caption>
             <tr>
-				<th class="span10">{% trans "Total products" %}</th>
+                <th class="span10">{% trans "Total products" %}</th>
                     <td class="span2" >{{ total_products }}</td>
             </tr>
             <tr>
-				<th class="span10"><em>{% trans "Open" %}</em> {% trans "stock alerts" %}</th>
+                <th class="span10"><em>{% trans "Open" %}</em> {% trans "stock alerts" %}</th>
                     <td class="span2" >{{ total_open_stock_alerts }}</td>
             </tr>
             <tr>
-				<th class="span10"><em>{% trans "Closed" %}</em> {% trans "stock alerts" %}</th>
+                <th class="span10"><em>{% trans "Closed" %}</em> {% trans "stock alerts" %}</th>
                     <td class="span2" >{{ total_closed_stock_alerts }}</td>
             </tr>
         </table>
@@ -154,14 +154,14 @@
         <table class="table table-striped table-bordered table-hover">
             <caption><i class="icon-gift icon-large"></i>{% trans "Offers, vouchers and promotions" %}</caption>
             <tr>
-				<th class="span10">{% trans "Active" %} <em>{% trans "Site" %}</em> {% trans "Offers" %}</th>
+                <th class="span10">{% trans "Active" %} <em>{% trans "Site" %}</em> {% trans "Offers" %}</th>
                 <td class="span2" >{{ total_site_offers }}</td>
             </tr>
             <tr>
-				<th class="span10">{% trans "Active" %} <em>{% trans "Vouchers" %}</em></th>
+                <th class="span10">{% trans "Active" %} <em>{% trans "Vouchers" %}</em></th>
                 <td class="span2" >{{ total_vouchers }}</td>
             </tr>
-			<th class="span10">{% trans "Promotions" %}</th>
+            <th class="span10">{% trans "Promotions" %}</th>
                 <td class="span2" >{{ total_promotions }}</td>
             </tr>
         </table>

--- a/oscar/templates/oscar/dashboard/layout.html
+++ b/oscar/templates/oscar/dashboard/layout.html
@@ -102,7 +102,7 @@
                 </div>
             </div>
         </div>
-	{% endblock %}
+    {% endblock %}
 
     <div class="container-fluid dashboard">
         {% block breadcrumbs %}

--- a/oscar/templates/oscar/dashboard/offers/benefit_form.html
+++ b/oscar/templates/oscar/dashboard/offers/benefit_form.html
@@ -6,22 +6,22 @@
 {% endblock %}
 
 {% block form_fields %}
-	<span class="help-block">{{ form.non_field_errors }}</span>
+    <span class="help-block">{{ form.non_field_errors }}</span>
 
-	{% if form.fields.custom_benefit.choices %}
+    {% if form.fields.custom_benefit.choices %}
         <h4>{% trans "Build a new incentive" %}</h4>
     {% endif %}
-	{% include "partials/form_field.html" with field=form.range %}
-	<p>{% trans "Ranges can be created and edited from within the " %}
-		<a href="{% url dashboard:range-list %}">{% trans "range dashboard" %}</a>.</p>
-	{% include "partials/form_field.html" with field=form.type %}
-	{% include "partials/form_field.html" with field=form.value %}
-	{% include "partials/form_field.html" with field=form.max_affected_items %}
+    {% include "partials/form_field.html" with field=form.range %}
+    <p>{% trans "Ranges can be created and edited from within the " %}
+        <a href="{% url dashboard:range-list %}">{% trans "range dashboard" %}</a>.</p>
+    {% include "partials/form_field.html" with field=form.type %}
+    {% include "partials/form_field.html" with field=form.value %}
+    {% include "partials/form_field.html" with field=form.max_affected_items %}
 
-	{% if form.fields.custom_benefit.choices %}
-		<h4>{% trans "...or choose a pre-defined one" %}</h4>
-		{% include "partials/form_field.html" with field=form.custom_benefit %}
-	{% endif %}
+    {% if form.fields.custom_benefit.choices %}
+        <h4>{% trans "...or choose a pre-defined one" %}</h4>
+        {% include "partials/form_field.html" with field=form.custom_benefit %}
+    {% endif %}
 {% endblock %}
 
 {% block submittext %}{% trans "Continue to step 3" %}{% endblock %}

--- a/oscar/templates/oscar/dashboard/offers/condition_form.html
+++ b/oscar/templates/oscar/dashboard/offers/condition_form.html
@@ -10,21 +10,21 @@
 {% endblock %}
 
 {% block form_fields %}
-	<span class="help-block">{{ form.non_field_errors }}</span>
+    <span class="help-block">{{ form.non_field_errors }}</span>
 
     {% if form.fields.custom_condition.choices %}
-	<h4>{% trans "Build a new condition" %}</h4>
+    <h4>{% trans "Build a new condition" %}</h4>
     {% endif %}
-	{% include "partials/form_field.html" with field=form.range %}
-	<p>{% trans "Ranges can be created and edited from within the " %}
-		<a href="{% url dashboard:range-list %}">{% trans "range dashboard" %}</a>.</p>
-	{% include "partials/form_field.html" with field=form.type %}
-	{% include "partials/form_field.html" with field=form.value %}
+    {% include "partials/form_field.html" with field=form.range %}
+    <p>{% trans "Ranges can be created and edited from within the " %}
+        <a href="{% url dashboard:range-list %}">{% trans "range dashboard" %}</a>.</p>
+    {% include "partials/form_field.html" with field=form.type %}
+    {% include "partials/form_field.html" with field=form.value %}
 
-	{% if form.fields.custom_condition.choices %}
-		<h4>{% trans "...or choose a pre-defined one" %}</h4>
-		{% include "partials/form_field.html" with field=form.custom_condition %}
-	{% endif %}
+    {% if form.fields.custom_condition.choices %}
+        <h4>{% trans "...or choose a pre-defined one" %}</h4>
+        {% include "partials/form_field.html" with field=form.custom_condition %}
+    {% endif %}
 {% endblock %}
 
 {% block submittext %}{% trans "Continue to step 4" %}{% endblock %}

--- a/oscar/templates/oscar/dashboard/offers/offer_delete.html
+++ b/oscar/templates/oscar/dashboard/offers/offer_delete.html
@@ -11,15 +11,15 @@ create-page
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">	  	
-    <li>	  	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li>	  	
+<ul class="breadcrumb">     
+    <li>        
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li>        
         <a href="{% url dashboard:offer-list %}">{% trans "Offer management" %}</a>
-        <span class="divider">/</span>	  	
-    </li>	 	
+        <span class="divider">/</span>      
+    </li>       
     <li>
         <a href="{% url dashboard:offer-detail offer.pk %}">'{{ offer.name }}'</a>
         <span class="divider">/</span>
@@ -34,11 +34,11 @@ create-page
 
 {% block dashboard_content %}
 <form action="." method="post">
-	{% csrf_token %}
+    {% csrf_token %}
     <p>{% trans "Are you sure you want to delete this offer?" %}</p>
-	<div class="form-actions">
-		<button class="btn btn-large btn-danger" type="submit">{% trans "Delete" %}</button> or
-		<a href="{% url dashboard:offer-list %}">{% trans "cancel" %}</a>
-	</div>
+    <div class="form-actions">
+        <button class="btn btn-large btn-danger" type="submit">{% trans "Delete" %}</button> or
+        <a href="{% url dashboard:offer-list %}">{% trans "cancel" %}</a>
+    </div>
 </form>
 {% endblock dashboard_content %}

--- a/oscar/templates/oscar/dashboard/offers/offer_detail.html
+++ b/oscar/templates/oscar/dashboard/offers/offer_detail.html
@@ -8,13 +8,13 @@
 {% endblocktrans %} | {{ block.super }}
 {% endblock %}
 
-{% block breadcrumbs %} 	
-<ul class="breadcrumb">   	
-    <li>  	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>   	
-        <span class="divider">/</span>   	
-    </li>   	
-    <li>   	
+{% block breadcrumbs %}     
+<ul class="breadcrumb">     
+    <li>    
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li>    
         <a href="{% url dashboard:offer-list %}">{% trans "Offer management" %}</a>
         <span class="divider">/</span>
     </li>
@@ -102,26 +102,26 @@
         <a class="pull-right btn" href=".?format=csv">{% trans "Export to CSV" %}</a>
         <h2>{% trans "Orders that used this offer" %}</h2>
     </div>
-	<table class="table table-bordered table-striped">
-		<thead>
-			<th>{% trans "Order number" %}</th>
-			<th>{% trans "Order date" %}</th>
-			<th>{% trans "Order total" %}</th>
-			<th>{% trans "Cost" %}</th>
-		</thead>
-		<tbody>
-			{% for discount in order_discounts %}
-			{% with order=discount.order %}
-				<tr>
+    <table class="table table-bordered table-striped">
+        <thead>
+            <th>{% trans "Order number" %}</th>
+            <th>{% trans "Order date" %}</th>
+            <th>{% trans "Order total" %}</th>
+            <th>{% trans "Cost" %}</th>
+        </thead>
+        <tbody>
+            {% for discount in order_discounts %}
+            {% with order=discount.order %}
+                <tr>
                     <td><a href="{% url dashboard:order-detail order.number %}">{{ order.number }}</a></td>
-					<td>{{ order.date_placed }}</td>
-					<td>{{ order.total_incl_tax|currency }}</td>
-					<td>{{ discount.amount|currency }}</td>
-				</tr>
-			{% endwith %}
-			{% endfor %}
-		</tbody>
-	</table>
+                    <td>{{ order.date_placed }}</td>
+                    <td>{{ order.total_incl_tax|currency }}</td>
+                    <td>{{ discount.amount|currency }}</td>
+                </tr>
+            {% endwith %}
+            {% endfor %}
+        </tbody>
+    </table>
     {% include 'partials/pagination.html' %}
     {% endif %}
 

--- a/oscar/templates/oscar/dashboard/offers/offer_list.html
+++ b/oscar/templates/oscar/dashboard/offers/offer_list.html
@@ -8,19 +8,19 @@
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">	  	
-    <li>	  	
-        <a href="{% url promotions:home %}">{% trans "Dashboard" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li class="active">{% trans "Offer management" %}</li>	  	
+<ul class="breadcrumb">     
+    <li>        
+        <a href="{% url promotions:home %}">{% trans "Dashboard" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li class="active">{% trans "Offer management" %}</li>      
 </ul>
 {% endblock %}
 
 {% block header %}
-<div class="page-header">    	  	
+<div class="page-header">           
     <a href="{% url dashboard:offer-metadata %}" class="btn btn-primary btn-large pull-right"><i class="icon-plus"></i> {% trans "Create new offer" %}</a>
-    <h1>{% trans "Offer management" %}</h1>    	  	
+    <h1>{% trans "Offer management" %}</h1>         
 </div>
 {% endblock header %}
 
@@ -61,12 +61,12 @@
                     <td>{{ offer.end_date|default:"-" }}</td>
                     <td>{{ offer.benefit.description|safe }}</td>
                     <td>{{ offer.condition.description|safe }}</td>
-					<td>{% if offer.is_available %}
-						<span class="label label-success">{% trans "Yes" %}</span>
-						{% else %}
-						<span class="label label-important">{% trans "No" %}</span>
-						{% endif %}
-					</td>
+                    <td>{% if offer.is_available %}
+                        <span class="label label-success">{% trans "Yes" %}</span>
+                        {% else %}
+                        <span class="label label-important">{% trans "No" %}</span>
+                        {% endif %}
+                    </td>
                     <td>
                         {% for restriction in offer.availability_restrictions %}
                                 {% if not restriction.is_satisfied %}
@@ -103,6 +103,6 @@
                 <tr><td>{% trans "No offers found." %}</td></tr>
                 {% endif %}
             </table>
-			{% include "partials/pagination.html" %}
+            {% include "partials/pagination.html" %}
         </form>
 {% endblock dashboard_content %}

--- a/oscar/templates/oscar/dashboard/offers/step_form.html
+++ b/oscar/templates/oscar/dashboard/offers/step_form.html
@@ -14,27 +14,27 @@
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">   	
-    <li>   	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>   	
-        <span class="divider">/</span>   	
-    </li>   	
-    <li>   	
+<ul class="breadcrumb">     
+    <li>    
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li>    
         <a href="{% url dashboard:offer-list %}">{% trans "Offer management" %}</a>
-        <span class="divider">/</span>   	
-    </li>   	
+        <span class="divider">/</span>      
+    </li>       
     {% if offer.pk %}
-    <li>   	
-        <a href="{% url dashboard:offer-detail offer.pk %}">{{ offer.name }}</a>   	
-        <span class="divider">/</span>   	
-    </li>   	
+    <li>    
+        <a href="{% url dashboard:offer-detail offer.pk %}">{{ offer.name }}</a>    
+        <span class="divider">/</span>      
+    </li>       
     {% else %}
     <li>
         {% trans "Create new offer" %}
         <span class="divider">/</span>
     </li>
     {% endif %}
-    <li class="active">{{ title }}</li>   	
+    <li class="active">{{ title }}</li>     
 </ul>
 {% endblock %}
 

--- a/oscar/templates/oscar/dashboard/orders/line_detail.html
+++ b/oscar/templates/oscar/dashboard/orders/line_detail.html
@@ -9,20 +9,20 @@ Order {{ number }} - Line #{{ id }}
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">	  	
-    <li>	  	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li>	  	
-        <a href="{% url dashboard:order-list %}">{% trans "Orders" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li>	  	
-        <a href="{% url dashboard:order-detail order.number %}">#{{ order.number }}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li class="active">{% blocktrans with id=line.id %}Line #{{ id }}{% endblocktrans %}</li>	  	
+<ul class="breadcrumb">     
+    <li>        
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li>        
+        <a href="{% url dashboard:order-list %}">{% trans "Orders" %}</a>       
+        <span class="divider">/</span>      
+    </li>       
+    <li>        
+        <a href="{% url dashboard:order-detail order.number %}">#{{ order.number }}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li class="active">{% blocktrans with id=line.id %}Line #{{ id }}{% endblocktrans %}</li>       
 </ul>
 {% endblock %}
 
@@ -39,16 +39,16 @@ Order {{ number }} - Line #{{ id }}
         </div>
         <table class="table table-striped table-bordered">
             <tr>
-				<th>{% trans "Title" %}</th><td>{{ line.title }}</td>
+                <th>{% trans "Title" %}</th><td>{{ line.title }}</td>
             </tr>
             <tr>
-				<th>{% trans "Product class" %}</th><td>{{ line.product.product_class }}</td>
+                <th>{% trans "Product class" %}</th><td>{{ line.product.product_class }}</td>
             </tr>
             <tr>
-				<th>{% trans "UPC" %}</th><td>{{ line.upc|default:"-" }}</td>
+                <th>{% trans "UPC" %}</th><td>{{ line.upc|default:"-" }}</td>
             </tr>
             <tr>
-				<th>{% trans "Quantity" %}</th><td>{{ line.quantity }}</td>
+                <th>{% trans "Quantity" %}</th><td>{{ line.quantity }}</td>
             </tr>
         </table>
     </div>
@@ -58,13 +58,13 @@ Order {{ number }} - Line #{{ id }}
         </div>
         <table class="table table-striped table-bordered">
             <tr>
-				<th>{% trans "Status" %}</th><td>{{ line.status|default:"-" }}</td>
+                <th>{% trans "Status" %}</th><td>{{ line.status|default:"-" }}</td>
             </tr>
             <tr>
-				<th>{% trans "Partner" %}</th><td>{{ line.partner_name }}</td>
+                <th>{% trans "Partner" %}</th><td>{{ line.partner_name }}</td>
             </tr>
             <tr>
-				<th>{% trans "Partner SKU" %}</th><td>{{ line.partner_sku }}</td>
+                <th>{% trans "Partner SKU" %}</th><td>{{ line.partner_sku }}</td>
             </tr>
         </table>
     </div>
@@ -73,15 +73,15 @@ Order {{ number }} - Line #{{ id }}
             <h3>{% trans "Shipping details" %}</h3>
         </div>
         <table class="table table-striped table-bordered">
-        	<tr>
-				<th>{% trans "Partner reference number" %}</th><td>{{ line.partner_line_reference|default:"-" }}</td>
-        	</tr>
-        	<tr>
-				<th>{% trans "Partner notes" %}</th><td>{{ line.partner_line_notes|default:"-" }}</td>
-        	</tr>
-        	<tr>
-				<th>{% trans "Estimate dispatch date" %}</th><td>{{ line.est_dispatch_date|default:"-" }}</td>
-        	</tr>
+            <tr>
+                <th>{% trans "Partner reference number" %}</th><td>{{ line.partner_line_reference|default:"-" }}</td>
+            </tr>
+            <tr>
+                <th>{% trans "Partner notes" %}</th><td>{{ line.partner_line_notes|default:"-" }}</td>
+            </tr>
+            <tr>
+                <th>{% trans "Estimate dispatch date" %}</th><td>{{ line.est_dispatch_date|default:"-" }}</td>
+            </tr>
         </table>
     </div>
 </div>

--- a/oscar/templates/oscar/dashboard/orders/order_list.html
+++ b/oscar/templates/oscar/dashboard/orders/order_list.html
@@ -9,12 +9,12 @@
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">	  	
-    <li>	  	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li class="active">{% trans "Order management" %}</li>	  	
+<ul class="breadcrumb">     
+    <li>        
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li class="active">{% trans "Order management" %}</li>      
 </ul>
 {% endblock %}
 
@@ -80,9 +80,9 @@
         <h3 class="pull-left"><i class="icon-shopping-cart icon-large"></i>{{ queryset_description }}</h3>
         <div class="pull-right">
             <div class="form-inline">
-            	<label>{% trans "Download selected orders as a CSV" %}</label>
-            	<input type="hidden" name="action" value="download_selected_orders" />
-            	<button type="submit" class="btn btn-primary">{% trans "Download" %}</button>
+                <label>{% trans "Download selected orders as a CSV" %}</label>
+                <input type="hidden" name="action" value="download_selected_orders" />
+                <button type="submit" class="btn btn-primary">{% trans "Download" %}</button>
             </div>
         </div>
     </caption>
@@ -91,15 +91,15 @@
         <tr>
             <th>
                 {% trans "Select all" %}
-    		</th>
+            </th>
             <th>{% anchor 'number' _("Order number") %}</th>
-    		<th>{% trans "Total inc tax" %}</th>
-    		<th>{% trans "Date of purchase" %}</th>
-    		<th>{% trans "Number of items" %}</th>
-    		<th>{% trans "Status" %}</th>
-    		<th>{% trans "Customer" %}</th>
-    		<th>{% trans "Shipping address" %}</th>
-    		<th>{% trans "Billing address" %}</th>
+            <th>{% trans "Total inc tax" %}</th>
+            <th>{% trans "Date of purchase" %}</th>
+            <th>{% trans "Number of items" %}</th>
+            <th>{% trans "Status" %}</th>
+            <th>{% trans "Customer" %}</th>
+            <th>{% trans "Shipping address" %}</th>
+            <th>{% trans "Billing address" %}</th>
             <th></th>
         </tr>
     </thead>
@@ -108,14 +108,14 @@
         <td><input type="checkbox" name="selected_order" class="selected_order" value="{{ order.id }}"/>
         <td>{{ order.number }}</td>
         <td>{{ order.total_incl_tax|currency }}</td>
-		<td>{{ order.date_placed }}</td>
-		<td>{{ order.num_items }}</td>
+        <td>{{ order.date_placed }}</td>
+        <td>{{ order.num_items }}</td>
         <td>{{ order.status|default:"-" }}</td>
         <td>{{ order.email }}</td>
         <td>{{ order.shipping_address|default:"-" }}</td>
         <td>{{ order.billing_address|default:"-" }}</td>
         <td>
-			<a class="btn btn-info" href="{% url dashboard:order-detail order.number %}">{% trans "View" %}</a>
+            <a class="btn btn-info" href="{% url dashboard:order-detail order.number %}">{% trans "View" %}</a>
         </td>
     </tr>
     {% endfor %}

--- a/oscar/templates/oscar/dashboard/orders/shippingaddress_form.html
+++ b/oscar/templates/oscar/dashboard/orders/shippingaddress_form.html
@@ -6,36 +6,36 @@
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">   	
-    <li> 	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>   	
-        <span class="divider">/</span>   	
-    </li>   	
-    <li>   	
-        <a href="{% url dashboard:order-list %}">{% trans "Orders" %}</a>  	
-        <span class="divider">/</span>  	
-    </li>  	
-    <li>   	
-        <a href="{% url dashboard:order-detail order.number %}">{{ order.number }}</a>   	
-        <span class="divider">/</span>   	
-    </li>   	
-    <li class="active">{% trans "Edit shipping address" %}</li>  	
+<ul class="breadcrumb">     
+    <li>    
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li>    
+        <a href="{% url dashboard:order-list %}">{% trans "Orders" %}</a>   
+        <span class="divider">/</span>      
+    </li>   
+    <li>    
+        <a href="{% url dashboard:order-detail order.number %}">{{ order.number }}</a>      
+        <span class="divider">/</span>      
+    </li>       
+    <li class="active">{% trans "Edit shipping address" %}</li>     
 </ul>
 {% endblock %}
 
 {% block headertext %}
-	{% blocktrans %}Edit shipping address for order {{ order.number }}{% endblocktrans %}
+    {% blocktrans %}Edit shipping address for order {{ order.number }}{% endblocktrans %}
 {% endblock  %}
 
 {% block content %}
 
 <form action="." method="post" class="well form-horizontal">
-	{% csrf_token %}
-	{% include "partials/form_fields.html" with form=form %}
-	<div class="form-actions">
-		<button type="submit" class="btn btn-primary">{% trans "Update address" %}</button>
-		or <a href="{% url dashboard:order-detail order.number %}">{% trans "cancel" %}</a>
-	</div>
+    {% csrf_token %}
+    {% include "partials/form_fields.html" with form=form %}
+    <div class="form-actions">
+        <button type="submit" class="btn btn-primary">{% trans "Update address" %}</button>
+        or <a href="{% url dashboard:order-detail order.number %}">{% trans "cancel" %}</a>
+    </div>
 </form>
 
 {% endblock content %}

--- a/oscar/templates/oscar/dashboard/orders/statistics.html
+++ b/oscar/templates/oscar/dashboard/orders/statistics.html
@@ -9,16 +9,16 @@
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">   	
-    <li>   	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>   	
-        <span class="divider">/</span>   	
-    </li>   	
-    <li>   	
-        <a href="{% url dashboard:order-list %}">{% trans "Orders" %}</a>  	
-        <span class="divider">/</span>   	
-    </li>   	
-    <li class="active">{% trans "Statistics" %}</li>  	
+<ul class="breadcrumb">     
+    <li>    
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li>    
+        <a href="{% url dashboard:order-list %}">{% trans "Orders" %}</a>   
+        <span class="divider">/</span>      
+    </li>       
+    <li class="active">{% trans "Statistics" %}</li>    
 </ul>
 {% endblock %}
 
@@ -31,40 +31,40 @@
 <div class="well">
     <form method="get" action="{% url dashboard:order-stats %}" class="form-inline">
         {% include "partials/form_fields_inline.html" with form=form %}
-		<button type="submit" class="btn btn-primary">{% trans "Filter result" %}</button>
-		<a href="{% url dashboard:order-stats %}" class="btn">{% trans "Reset" %}</a>
+        <button type="submit" class="btn btn-primary">{% trans "Filter result" %}</button>
+        <a href="{% url dashboard:order-stats %}" class="btn">{% trans "Reset" %}</a>
     </form>
 </div>
 
 <table class="table table-striped table-bordered table-hover">
     <caption><i class="icon-shopping-cart icon-large"></i>{% trans "Summary" %}</caption>
-	<tr>
-		<th>{% trans "Total orders" %}</th>
-		<td>{{ total_orders }}</td>
-	</tr>
-	<tr>
-		<th>{% trans "Total lines" %}</th>
-		<td>{{ total_lines }}</td>
-	</tr>
-	<tr>
-		<th>{% trans "Total revenue" %}</th>
-		<td>{{ total_revenue|currency }}</td>
-	</tr>
+    <tr>
+        <th>{% trans "Total orders" %}</th>
+        <td>{{ total_orders }}</td>
+    </tr>
+    <tr>
+        <th>{% trans "Total lines" %}</th>
+        <td>{{ total_lines }}</td>
+    </tr>
+    <tr>
+        <th>{% trans "Total revenue" %}</th>
+        <td>{{ total_revenue|currency }}</td>
+    </tr>
 </table>
 
 {% if order_status_breakdown %}
 <table class="table table-striped table-bordered table-hover">
-	<caption><i class="icon-shopping-cart icon-large"></i>{% trans "Order status breakdown" %}</caption>
-	<tr>
-		<th>{% trans "Status" %}</th>
-		<th>{% trans "Frequency" %}</th>
-	</tr>
-	{% for dict in order_status_breakdown %}
-	<tr>
-		<td><a href="{% url dashboard:order-list %}?order_status={{ dict.status }}">{{ dict.status }}</a></td>
-		<td>{{ dict.freq }}</td>
-	</tr>
-	{% endfor %}
+    <caption><i class="icon-shopping-cart icon-large"></i>{% trans "Order status breakdown" %}</caption>
+    <tr>
+        <th>{% trans "Status" %}</th>
+        <th>{% trans "Frequency" %}</th>
+    </tr>
+    {% for dict in order_status_breakdown %}
+    <tr>
+        <td><a href="{% url dashboard:order-list %}?order_status={{ dict.status }}">{{ dict.status }}</a></td>
+        <td>{{ dict.freq }}</td>
+    </tr>
+    {% endfor %}
 </table>
 {% endif %}
 

--- a/oscar/templates/oscar/dashboard/pages/delete.html
+++ b/oscar/templates/oscar/dashboard/pages/delete.html
@@ -11,16 +11,16 @@ create-page
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb"> 	
-    <li>	  	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li>	  	
-        <a href="{% url dashboard:page-list %}">{% trans "Pages" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li class="active">{% blocktrans with title=object.title %}Delete page '{{ title }}'?{% endblocktrans %}</li>	  	
+<ul class="breadcrumb">     
+    <li>        
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li>        
+        <a href="{% url dashboard:page-list %}">{% trans "Pages" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li class="active">{% blocktrans with title=object.title %}Delete page '{{ title }}'?{% endblocktrans %}</li>       
 </ul>
 {% endblock %}
 
@@ -33,12 +33,12 @@ create-page
     <h2>{% trans "Delete page" %}</h2>
 </div>
 <form action="." method="post" class="well">
-	{% csrf_token %}
-	{{ form }}
-	<p>{% blocktrans with title=object.title %}Delete page <strong>{{ title }}</strong> - are you sure?{% endblocktrans %}</p>
-	<div class="form-actions">
-		<button type="submit" class="btn btn-danger">{% trans "Delete" %}</button>
-		{% trans "or" %} <a href="{% url dashboard:page-list %}">{% trans "cancel" %}</a>.
-	</div>
+    {% csrf_token %}
+    {{ form }}
+    <p>{% blocktrans with title=object.title %}Delete page <strong>{{ title }}</strong> - are you sure?{% endblocktrans %}</p>
+    <div class="form-actions">
+        <button type="submit" class="btn btn-danger">{% trans "Delete" %}</button>
+        {% trans "or" %} <a href="{% url dashboard:page-list %}">{% trans "cancel" %}</a>.
+    </div>
 </form>
 {% endblock %}

--- a/oscar/templates/oscar/dashboard/pages/index.html
+++ b/oscar/templates/oscar/dashboard/pages/index.html
@@ -9,12 +9,12 @@
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">   	
-    <li>       	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>       	
-        <span class="divider">/</span>       	
-    </li>       	
-    <li class="active">{% trans "Pages" %}</li>       	
+<ul class="breadcrumb">     
+    <li>        
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>         
+        <span class="divider">/</span>          
+    </li>           
+    <li class="active">{% trans "Pages" %}</li>         
 </ul>
 {% endblock %}
 

--- a/oscar/templates/oscar/dashboard/pages/update.html
+++ b/oscar/templates/oscar/dashboard/pages/update.html
@@ -31,7 +31,7 @@
 </div>
 
 <form action="." method="post" class="well form-stacked wysiwyg" enctype="multipart/form-data">
-	{% csrf_token %}
+    {% csrf_token %}
     {% include 'partials/form.html' %}
 </form>
 

--- a/oscar/templates/oscar/dashboard/partials/stock_info.html
+++ b/oscar/templates/oscar/dashboard/partials/stock_info.html
@@ -4,7 +4,7 @@
     {{ field }}
     {% for error in field.errors %}
         <ul class="help-block">
-	    <li>{{ error }}</li>
+        <li>{{ error }}</li>
         </ul>
     {% endfor %}
     </div>

--- a/oscar/templates/oscar/dashboard/promotions/delete.html
+++ b/oscar/templates/oscar/dashboard/promotions/delete.html
@@ -11,16 +11,16 @@ create-page
 {% endblock  %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">	  	
-    <li>	  	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li>	  	
-        <a href="{% url dashboard:promotion-list %}">{% trans "Content block management" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li class="active">{% blocktrans with name=object.name %}Delete content block '{{ name }}'?"{% endblocktrans %}</li>	  	
+<ul class="breadcrumb">     
+    <li>        
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li>        
+        <a href="{% url dashboard:promotion-list %}">{% trans "Content block management" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li class="active">{% blocktrans with name=object.name %}Delete content block '{{ name }}'?"{% endblocktrans %}</li>        
 </ul>
 {% endblock %}
 
@@ -33,12 +33,12 @@ create-page
     {% trans "Delete content block" %}
 </div>
 <form action="." method="post" class="well">
-	{% csrf_token %}
-	{{ form }}
-	<p>{% blocktrans %}Delete {{ object.type }} content block <strong>{{ object.name }}</strong> - are you sure?{% endblocktrans %}</p>
-	<div class="form-actions">
-		<button type="submit" class="btn btn-danger">{% trans "Delete" %}</button>
-		{% trans "or" %} <a href="{% url dashboard:promotion-list %}">{% trans "cancel" %}</a>
-	</div>
+    {% csrf_token %}
+    {{ form }}
+    <p>{% blocktrans %}Delete {{ object.type }} content block <strong>{{ object.name }}</strong> - are you sure?{% endblocktrans %}</p>
+    <div class="form-actions">
+        <button type="submit" class="btn btn-danger">{% trans "Delete" %}</button>
+        {% trans "or" %} <a href="{% url dashboard:promotion-list %}">{% trans "cancel" %}</a>
+    </div>
 </form>
 {% endblock %}

--- a/oscar/templates/oscar/dashboard/promotions/delete_pagepromotion.html
+++ b/oscar/templates/oscar/dashboard/promotions/delete_pagepromotion.html
@@ -6,16 +6,16 @@ create-page
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">        	
-    <li>        	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>    	  	
-        <span class="divider">/</span>    	  	
-    </li>    	  	
-    <li>    	  	
-        <a href="{% url dashboard:promotion-list %}">{% trans "Content block management" %}</a>    	  	
-        <span class="divider">/</span>    	  	
-    </li>    	  	
-    <li class="active">{% trans "Remove promotion from page?" %}</li>    	  	
+<ul class="breadcrumb">         
+    <li>            
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>         
+        <span class="divider">/</span>          
+    </li>           
+    <li>            
+        <a href="{% url dashboard:promotion-list %}">{% trans "Content block management" %}</a>         
+        <span class="divider">/</span>          
+    </li>           
+    <li class="active">{% trans "Remove promotion from page?" %}</li>           
 </ul>
 {% endblock %}
 
@@ -28,12 +28,12 @@ create-page
     {% trans "Remove promotion" %}
 </div>
 <form action="." method="post" class="well">
-	{% csrf_token %}
-	<p>{% blocktrans %}Remove {{ object.content_object.type }} content block <strong>{{ object.name }}</strong> from page <strong>{{ object.page_url }}</strong> - are you sure?{% endblocktrans %}</p>
+    {% csrf_token %}
+    <p>{% blocktrans %}Remove {{ object.content_object.type }} content block <strong>{{ object.name }}</strong> from page <strong>{{ object.page_url }}</strong> - are you sure?{% endblocktrans %}</p>
     
-	<div class="form-actions">
-		<button type="submit" class="btn btn-danger">{% trans "Remove" %}</button>
-		{% trans "or" %} <a href="{% url dashboard:promotion-list-by-url object.page_url  %}">{% trans "cancel" %}</a>
-	</div>
+    <div class="form-actions">
+        <button type="submit" class="btn btn-danger">{% trans "Remove" %}</button>
+        {% trans "or" %} <a href="{% url dashboard:promotion-list-by-url object.page_url  %}">{% trans "cancel" %}</a>
+    </div>
 </form>
 {% endblock %}

--- a/oscar/templates/oscar/dashboard/promotions/form.html
+++ b/oscar/templates/oscar/dashboard/promotions/form.html
@@ -4,16 +4,16 @@
 {% block body_class %}create-page promotions{% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">        	
-    <li>        	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>    	  	
-        <span class="divider">/</span>    	  	
-    </li>    	  	
-    <li>    	  	
-        <a href="{% url dashboard:promotion-list %}">{% trans "Content block management" %}</a>    	  	
-        <span class="divider">/</span>    	  	
-    </li>    	  	
-    <li class="active">{{ heading }}</li>    	  	
+<ul class="breadcrumb">         
+    <li>            
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>         
+        <span class="divider">/</span>          
+    </li>           
+    <li>            
+        <a href="{% url dashboard:promotion-list %}">{% trans "Content block management" %}</a>         
+        <span class="divider">/</span>          
+    </li>           
+    <li class="active">{{ heading }}</li>           
 </ul>
 {% endblock %}
 
@@ -29,14 +29,14 @@
 </div>
 
 <form action="." method="post" enctype="multipart/form-data" class="well form-stacked wysiwyg">
-	{% csrf_token %}
-	{% include "partials/form_fields.html" with form=form %}
+    {% csrf_token %}
+    {% include "partials/form_fields.html" with form=form %}
 
     {% block inlines %} {% endblock %}
 
     <div class="form-actions">
         <button type="submit" class="btn btn-primary">{% trans "Save" %}</button>
-		{% trans "or" %} <a href="{% url dashboard:promotion-list %}">{% trans "cancel" %}</a>
+        {% trans "or" %} <a href="{% url dashboard:promotion-list %}">{% trans "cancel" %}</a>
     </div>
 </form>
 
@@ -46,32 +46,32 @@
 <table class="table table-striped table-bordered table-hover">
     <caption>{% trans "Pages displaying this content blocks" %}</caption>
     {% if links %}
-	    <thead>
-    		<tr>
-				<th>{% trans "Page URL" %}</th>
-				<th>{% trans "Position on page" %}</th>
-				<th>{% trans "Actions" %}</th>
-    		</tr>
-    	</thead>
-    	<tbody>
-    		{% for link in links %}
-    		<tr>
-    			<td>{{ link.page_url }}</td>
-    			<td>{{ link.position }}</td>
-    			<td>
+        <thead>
+            <tr>
+                <th>{% trans "Page URL" %}</th>
+                <th>{% trans "Position on page" %}</th>
+                <th>{% trans "Actions" %}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for link in links %}
+            <tr>
+                <td>{{ link.page_url }}</td>
+                <td>{{ link.position }}</td>
+                <td>
                     <form action="." method="post" >
-    					{% csrf_token %}
-    					<input type="hidden" name="action" value="remove_from_page" />
-    					<input type="hidden" name="pagepromotion_id" value="{{ link.id }}" />
-						<a href="{% url dashboard:promotion-list-by-url link.page_url|urlencode:"" %}" class="btn btn-info">{% trans "View all blocks on this page" %}</a>
-						<button class="btn" type="submit">{% trans "Remove from page" %}</button>
-    				</form>
-    			</td>
-    		</tr>
-    		{% endfor %}
-    	</tbody>
-	{% else %}
-	    <tr><td>{% trans "This promotion is not displayed anywhere at the moment." %}</td></tr>
+                        {% csrf_token %}
+                        <input type="hidden" name="action" value="remove_from_page" />
+                        <input type="hidden" name="pagepromotion_id" value="{{ link.id }}" />
+                        <a href="{% url dashboard:promotion-list-by-url link.page_url|urlencode:"" %}" class="btn btn-info">{% trans "View all blocks on this page" %}</a>
+                        <button class="btn" type="submit">{% trans "Remove from page" %}</button>
+                    </form>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    {% else %}
+        <tr><td>{% trans "This promotion is not displayed anywhere at the moment." %}</td></tr>
     {% endif %}
 </table>
 <div class="table-header">
@@ -79,10 +79,10 @@
 </div>
 <div class="well">
     <form action="." method="post" class="form-stacked">
-    	{% csrf_token %}
-    	<input type="hidden" name="action" value="add_to_page" />
-    	{% include "partials/form_fields.html" with form=link_form %}
-		<button type="submit" class="btn btn-success">{% trans "Add to page" %}</button>
+        {% csrf_token %}
+        <input type="hidden" name="action" value="add_to_page" />
+        {% include "partials/form_fields.html" with form=link_form %}
+        <button type="submit" class="btn btn-success">{% trans "Add to page" %}</button>
     </form>
 </div>
 {% endif %}

--- a/oscar/templates/oscar/dashboard/promotions/handpickedproductlist_form.html
+++ b/oscar/templates/oscar/dashboard/promotions/handpickedproductlist_form.html
@@ -5,6 +5,6 @@
 <h2>{% trans "Products" %}</h2>
 {{ product_formset.management_form }}
 {% for form in product_formset %}
-	{% include "partials/form_fields.html" with form=form %}
+    {% include "partials/form_fields.html" with form=form %}
 {% endfor %}
 {% endblock %}

--- a/oscar/templates/oscar/dashboard/promotions/page_detail.html
+++ b/oscar/templates/oscar/dashboard/promotions/page_detail.html
@@ -8,16 +8,16 @@
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">	  	
-    <li>	  	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li>	  	
-        <a href="{% url dashboard:promotion-list %}">{% trans "Content block management" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li class="active">{% blocktrans %}Content blocks on page '{{ page_url }}'{% endblocktrans %}</li>	  	
+<ul class="breadcrumb">     
+    <li>        
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li>        
+        <a href="{% url dashboard:promotion-list %}">{% trans "Content block management" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li class="active">{% blocktrans %}Content blocks on page '{{ page_url }}'{% endblocktrans %}</li>      
 </ul>
 {% endblock %}
 
@@ -31,20 +31,20 @@
 <table class="table table-striped table-bordered table-hover">
     <caption>{% blocktrans with name=position.name %}Edit promotions in position '{{ name }}'{% endblocktrans %}</caption>
     {% if position.promotions %}
-	<thead>
-		<tr>
-			<th>{% trans "Promotion Name" %}</th>
-			<th>{% trans "Type" %}</th>
-			<th>{% trans "Actions" %}</th>
-		</tr>
-	</thead>
-	<tbody class="promotion_list">
-		{% for promotion in position.promotions %}
-		<tr id="promo_{{ promotion.pk }}">
-			<td>{{ promotion.content_object.name }}</td>
-			<td>{{ promotion.content_object.type }}</td>
-			<td>
-			    <div class="btn-toolbar">
+    <thead>
+        <tr>
+            <th>{% trans "Promotion Name" %}</th>
+            <th>{% trans "Type" %}</th>
+            <th>{% trans "Actions" %}</th>
+        </tr>
+    </thead>
+    <tbody class="promotion_list">
+        {% for promotion in position.promotions %}
+        <tr id="promo_{{ promotion.pk }}">
+            <td>{{ promotion.content_object.name }}</td>
+            <td>{{ promotion.content_object.type }}</td>
+            <td>
+                <div class="btn-toolbar">
                     <div class="btn-group">
                       <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
                         Actions
@@ -52,17 +52,17 @@
                       </a>
                       <ul class="dropdown-menu pull-right">
                         <li><a href="{% url dashboard:promotion-update promotion.content_object.code promotion.content_object.id %}">{% trans "Edit" %}</a></li>
-          				<li><a href="{% url dashboard:pagepromotion-delete promotion.id %}">{% trans "Remove" %}</a></li>
+                        <li><a href="{% url dashboard:pagepromotion-delete promotion.id %}">{% trans "Remove" %}</a></li>
                       </ul>
                     </div>
                     <a href="#" class="btn btn-info btn-handle"><i class="icon-move icon-large"></i> {% trans "Re-order" %}</a>
                 </div>
-			</td>
-		</tr>
-		{% endfor %}
-	</tbody>
-	{% else %}
-	<tr><td>{% trans "No promotions in this position." %}</td></tr>
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+    {% else %}
+    <tr><td>{% trans "No promotions in this position." %}</td></tr>
     {% endif %}
 </table>
 {% endfor %}

--- a/oscar/templates/oscar/dashboard/promotions/pagepromotion_list.html
+++ b/oscar/templates/oscar/dashboard/promotions/pagepromotion_list.html
@@ -13,16 +13,16 @@
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">	  	
-    <li>	  	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li>    	  	
-        <a href="{% url dashboard:promotion-list %}">{% trans "Content block management" %}</a>    	  	
-        <span class="divider">/</span>    	  	
-    </li>    	  	
-    <li class="active">{% trans "Content blocks by page" %}</li>	  	
+<ul class="breadcrumb">     
+    <li>        
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li>            
+        <a href="{% url dashboard:promotion-list %}">{% trans "Content block management" %}</a>         
+        <span class="divider">/</span>          
+    </li>           
+    <li class="active">{% trans "Content blocks by page" %}</li>        
 </ul>
 {% endblock %}
 
@@ -31,37 +31,37 @@
     <h3><i class="icon-folder-open icon-large"></i>{% trans "View by page" %}</h3>
 </div>
 <div class="well">
-	<a href="{% url dashboard:promotion-list %}" class="btn btn-primary">{% trans "View all content blocks" %}</a>
-	<a href="{% url dashboard:promotion-list-by-page %}" class="btn">{% trans "View content blocks by page" %}</a>
+    <a href="{% url dashboard:promotion-list %}" class="btn btn-primary">{% trans "View all content blocks" %}</a>
+    <a href="{% url dashboard:promotion-list-by-page %}" class="btn">{% trans "View content blocks by page" %}</a>
 </div>
 
 <div class="table-header">
-	<h2><i class="icon-folder-open icon-large"></i>{% trans "Pages with content blocks on them" %}</h2>
+    <h2><i class="icon-folder-open icon-large"></i>{% trans "Pages with content blocks on them" %}</h2>
 </div>
 
 <table class="table table-striped table-bordered table-hover">
     {% if pages %}
-	<thead>
-		<tr>
-			<th>{% trans "URL" %}</th>
-			<th>{% trans "Number of content blocks" %}</th>
-			<th>{% trans "Actions" %}</th>
-		</tr>
-	</thead>
-	<tbody>
-		{% for page in pages %}
-		<tr>
-			<td>{{ page.page_url }}</td>
-			<td>{{ page.freq }}</td>
-			<td>
-				<a href="{% url dashboard:promotion-list-by-url page.page_url|urlencode:"" %}" class="btn btn-success">{% trans "Edit" %}</a>
-			</td>
-			<td> </td>
-		</tr>
-		{% endfor %}
-	</tbody>
-	
-	{% else %}
+    <thead>
+        <tr>
+            <th>{% trans "URL" %}</th>
+            <th>{% trans "Number of content blocks" %}</th>
+            <th>{% trans "Actions" %}</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for page in pages %}
+        <tr>
+            <td>{{ page.page_url }}</td>
+            <td>{{ page.freq }}</td>
+            <td>
+                <a href="{% url dashboard:promotion-list-by-url page.page_url|urlencode:"" %}" class="btn btn-success">{% trans "Edit" %}</a>
+            </td>
+            <td> </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+    
+    {% else %}
 
     <tr><td>{% trans "No content blocks found." %}</td></tr>
 

--- a/oscar/templates/oscar/dashboard/promotions/promotion_list.html
+++ b/oscar/templates/oscar/dashboard/promotions/promotion_list.html
@@ -15,12 +15,12 @@
 {% endblock header %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">	  	
-    <li>	  	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li class="active">{% trans "Content block management" %}</li> 	
+<ul class="breadcrumb">     
+    <li>        
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li class="active">{% trans "Content block management" %}</li>  
 </ul>
 {% endblock %}
 
@@ -39,23 +39,23 @@
 <table class="table table-striped table-bordered table-hover">
     <caption><i class="icon-folder-close icon-large"></i>{% trans "Content blocks" %}</caption>
     {% if num_promotions %}
-	<thead>
-		<tr>
-			<th>{% trans "Name" %}</th>
-			<th>{% trans "Type" %}</th>
-			<th>{% trans "Number of times used" %}</th>
-			<th>{% trans "Date created" %}</th>
-			<th>{% trans "Actions" %}</th>
-		</tr>
-	</thead>
-	<tbody>
-		{% for promotion in promotions %}
-		<tr>
-			<td><a href="{% url dashboard:promotion-update promotion.code promotion.id %}">{{ promotion.name }}</a></td>
-			<td>{{ promotion.type }}</td>
-			<td>{{ promotion.num_times_used }}</td>
-			<td>{{ promotion.date_created }}</td>
-			<td>
+    <thead>
+        <tr>
+            <th>{% trans "Name" %}</th>
+            <th>{% trans "Type" %}</th>
+            <th>{% trans "Number of times used" %}</th>
+            <th>{% trans "Date created" %}</th>
+            <th>{% trans "Actions" %}</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for promotion in promotions %}
+        <tr>
+            <td><a href="{% url dashboard:promotion-update promotion.code promotion.id %}">{{ promotion.name }}</a></td>
+            <td>{{ promotion.type }}</td>
+            <td>{{ promotion.num_times_used }}</td>
+            <td>{{ promotion.date_created }}</td>
+            <td>
                 <div class="btn-toolbar">
                     <div class="btn-group">
                         <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
@@ -68,13 +68,13 @@
                         </ul>
                     </div>
                 </div>
-			</td>
-		</tr>
-		{% endfor %}
-	</tbody>
-	
-	
-	{% else %}
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+    
+    
+    {% else %}
 
     <tr><td>{% trans "No content blocks found." %}<td></tr>
 

--- a/oscar/templates/oscar/dashboard/ranges/range_delete.html
+++ b/oscar/templates/oscar/dashboard/ranges/range_delete.html
@@ -11,15 +11,15 @@ create-page
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">	  	
-    <li>	  	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li>	  	
+<ul class="breadcrumb">     
+    <li>        
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li>        
         <a href="{% url dashboard:range-list %}">{% trans "Range management" %}</a>
-        <span class="divider">/</span>	  	
-    </li>	  	
+        <span class="divider">/</span>      
+    </li>       
     <li>
         <a href="{% url dashboard:range-update range.pk %}">'{{ range.name }}'</a>
         <span class="divider">/</span>
@@ -35,10 +35,10 @@ create-page
 {% block dashboard_content %}
 <form action="." method="post" class="well">
     <p>{% trans "Are you sure you want to delete this range?" %}</p>
-	{% csrf_token %}
-	<div class="form-actions">
-		<button class="btn btn-danger" type="submit">{% trans "Delete" %}</button> {% trans "or" %}
-		<a href="{% url dashboard:range-list %}">{% trans "cancel" %}</a>
-	</div>
+    {% csrf_token %}
+    <div class="form-actions">
+        <button class="btn btn-danger" type="submit">{% trans "Delete" %}</button> {% trans "or" %}
+        <a href="{% url dashboard:range-list %}">{% trans "cancel" %}</a>
+    </div>
 </form>
 {% endblock dashboard_content %}

--- a/oscar/templates/oscar/dashboard/ranges/range_form.html
+++ b/oscar/templates/oscar/dashboard/ranges/range_form.html
@@ -9,15 +9,15 @@
 {% endblock %}
 
 {% block breadcrumbs %}
-    <ul class="breadcrumb">	  	
-        <li>	  	
-            <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>	  	
-            <span class="divider">/</span>	  	
-        </li>	  	
-        <li>	  	
+    <ul class="breadcrumb">     
+        <li>        
+            <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
+            <span class="divider">/</span>      
+        </li>       
+        <li>        
             <a href="{% url dashboard:range-list %}">{% trans "Range management" %}</a>
-            <span class="divider">/</span>	  	
-        </li>	  	
+            <span class="divider">/</span>      
+        </li>       
         {% if range %}
             <li class="active">{{ range.name }}</li>
         {% else %}

--- a/oscar/templates/oscar/dashboard/ranges/range_list.html
+++ b/oscar/templates/oscar/dashboard/ranges/range_list.html
@@ -50,12 +50,12 @@
                     <span class="caret"></span>
                   </a>
                   <ul class="dropdown-menu pull-right">
-				      {% if range.is_editable %}
+                      {% if range.is_editable %}
                       <li><a href="{% url dashboard:range-update range.id %}">{% trans "Edit" %}</a></li>
                       {% if not range.includes_all_products %}
                       <li><a href="{% url dashboard:range-products range.id %}">{% trans "Edit products" %}</a></li>
                       {% endif %}
-					  {% endif %}
+                      {% endif %}
                       <li><a href="{% url dashboard:range-delete range.id %}">{% trans "Delete" %}</a></li>
                   </ul>
                 </div>

--- a/oscar/templates/oscar/dashboard/ranges/range_product_list.html
+++ b/oscar/templates/oscar/dashboard/ranges/range_product_list.html
@@ -9,20 +9,20 @@
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">	  	
-    <li>	  	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li>	  	
+<ul class="breadcrumb">     
+    <li>        
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li>        
         <a href="{% url dashboard:range-list %}">{% trans "Range management" %}</a>
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li>	  	
-        <a href="{% url dashboard:range-update range.id %}">'{{ range.name }}'</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li class="active">{% trans "Products" %}</li>	  	
+        <span class="divider">/</span>      
+    </li>       
+    <li>        
+        <a href="{% url dashboard:range-update range.id %}">'{{ range.name }}'</a>      
+        <span class="divider">/</span>      
+    </li>       
+    <li class="active">{% trans "Products" %}</li>      
 </ul>
 {% endblock %}
 
@@ -32,106 +32,106 @@
 
 {% block dashboard_content %}
 <div class="table-header">
-	<h3>{% trans "Add products" %}</h3>
+    <h3>{% trans "Add products" %}</h3>
 </div>
 
 <div class="well">
 
-	<form action="." method="post" class="form-stacked" enctype="multipart/form-data">
-		{% csrf_token %}
-		<input type="hidden" name="action" value="add_products"/>
-		{% include 'partials/form_fields.html' with form=form %}
+    <form action="." method="post" class="form-stacked" enctype="multipart/form-data">
+        {% csrf_token %}
+        <input type="hidden" name="action" value="add_products"/>
+        {% include 'partials/form_fields.html' with form=form %}
         <div class="controls">
             <button type="submit" class="btn btn-primary">{% trans "Go!" %}</button>
         </div>
-	</form>
+    </form>
 
-	{% with uploads=range.file_uploads.all %}
-		{% if uploads %}
-		<div class="table-header">
-			<h3>{% trans "Upload history" %}</h3>
-		</div>
-		<table class="table table-striped table-bordered table-hover">
-			<thead>
-			<tr>
-				<th>{% trans "Filename" %}</th>
-				<th>{% trans "New products" %}</th>
-				<th>{% trans "Duplicate products" %}</th>
-				<th>{% trans "Unknown products" %}</th>
-				<th>{% trans "Date uploaded" %}</th>
-			</tr>
-			</thead>
-			<tbody>
-			{% for upload in uploads %}
-			<tr>
-				<td>{{ upload.filename }}</td>
-				<td>{{ upload.num_new_skus }}</td>
-				<td>{{ upload.num_duplicate_skus }}</td>
-				<td>{{ upload.num_unknown_skus }}</td>
-				<td>{{ upload.date_uploaded }}</td>
-			</tr>
-			{% endfor %}
-			</tbody>
-		</table>
-		{% endif %}
-	{% endwith %}
+    {% with uploads=range.file_uploads.all %}
+        {% if uploads %}
+        <div class="table-header">
+            <h3>{% trans "Upload history" %}</h3>
+        </div>
+        <table class="table table-striped table-bordered table-hover">
+            <thead>
+            <tr>
+                <th>{% trans "Filename" %}</th>
+                <th>{% trans "New products" %}</th>
+                <th>{% trans "Duplicate products" %}</th>
+                <th>{% trans "Unknown products" %}</th>
+                <th>{% trans "Date uploaded" %}</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for upload in uploads %}
+            <tr>
+                <td>{{ upload.filename }}</td>
+                <td>{{ upload.num_new_skus }}</td>
+                <td>{{ upload.num_duplicate_skus }}</td>
+                <td>{{ upload.num_unknown_skus }}</td>
+                <td>{{ upload.date_uploaded }}</td>
+            </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+        {% endif %}
+    {% endwith %}
 
 
-	{% if products.count %}
-		<form action="." method="post">
-			{% csrf_token %}
-			<table class="table table-striped table-bordered table-hover">
+    {% if products.count %}
+        <form action="." method="post">
+            {% csrf_token %}
+            <table class="table table-striped table-bordered table-hover">
                 <caption>
                     <h3 class="pull-left">{% trans "Products in Range" %}</h3>
                     <div class="pull-right">
-        				<input type="hidden" name="action" value="remove_selected_products" />
-        				<button type="submit" class="btn">{% trans "Remove selected products" %}</button>
-        			</div>
+                        <input type="hidden" name="action" value="remove_selected_products" />
+                        <button type="submit" class="btn">{% trans "Remove selected products" %}</button>
+                    </div>
                 </caption>
-				<tr>
-					<th></th>
-					<th>{% trans "UPC" %}</th>
-					<th>{% trans "Title" %}</th>
-					<th>{% trans "Partner" %}</th>
-					<th>{% trans "Partner SKU" %}</th>
-					<th>{% trans "Price" %}</th>
-					<th>{% trans "Is product discountable?" %}</th>
-					<th></th>
-				</tr>
-				{% for product in products %}
-				<tr>
-					<td>
-						<input type="checkbox" name="selected_product" value="{{ product.id }}" />
-					</td>
-					<td>{{ product.upc|default:"-" }}</td>
-					<td>{{ product.get_title }}</td>
-					<td>{{ product.stockrecord.partner.display_name }}</td>
-					<td>{{ product.stockrecord.partner_sku }}</td>
-					<td>{{ product.stockrecord.price_incl_tax|currency }}</td>
-					<td>{% if product.is_discountable %}{% trans "Yes" %}{% else %}{% trans "No" %}{% endif %}</td>
-					<td>
-						<a class="btn btn-danger" href="#" data-behaviours="remove">{% trans "Remove" %}</a>
-					</td>
-				</tr>
-				{% endfor %}
-			</table>
+                <tr>
+                    <th></th>
+                    <th>{% trans "UPC" %}</th>
+                    <th>{% trans "Title" %}</th>
+                    <th>{% trans "Partner" %}</th>
+                    <th>{% trans "Partner SKU" %}</th>
+                    <th>{% trans "Price" %}</th>
+                    <th>{% trans "Is product discountable?" %}</th>
+                    <th></th>
+                </tr>
+                {% for product in products %}
+                <tr>
+                    <td>
+                        <input type="checkbox" name="selected_product" value="{{ product.id }}" />
+                    </td>
+                    <td>{{ product.upc|default:"-" }}</td>
+                    <td>{{ product.get_title }}</td>
+                    <td>{{ product.stockrecord.partner.display_name }}</td>
+                    <td>{{ product.stockrecord.partner_sku }}</td>
+                    <td>{{ product.stockrecord.price_incl_tax|currency }}</td>
+                    <td>{% if product.is_discountable %}{% trans "Yes" %}{% else %}{% trans "No" %}{% endif %}</td>
+                    <td>
+                        <a class="btn btn-danger" href="#" data-behaviours="remove">{% trans "Remove" %}</a>
+                    </td>
+                </tr>
+                {% endfor %}
+            </table>
 
-			{% include "partials/pagination.html" %}
-		</form>
+            {% include "partials/pagination.html" %}
+        </form>
 
-	{% else %}
-	<table class="table table-striped table-bordered table-hover">
+    {% else %}
+    <table class="table table-striped table-bordered table-hover">
         <caption>
             {% trans "Products in Range" %}
         </caption>
-	    <tr><td>{% trans "No products found." %}</td></tr>
-	</table>
-	{% endif %}
+        <tr><td>{% trans "No products found." %}</td></tr>
+    </table>
+    {% endif %}
 
-	<div class="form-actions">
-		<a href="{% url dashboard:range-update range.id %}" class="btn btn-large btn-primary">{% trans "Edit range" %}</a> {% trans "or" %}
-		<a href="{% url dashboard:range-list %}" class="">{% trans "return to range list" %}</a>
-	</div>
+    <div class="form-actions">
+        <a href="{% url dashboard:range-update range.id %}" class="btn btn-large btn-primary">{% trans "Edit range" %}</a> {% trans "or" %}
+        <a href="{% url dashboard:range-list %}" class="">{% trans "return to range list" %}</a>
+    </div>
 
 </div>
 

--- a/oscar/templates/oscar/dashboard/reports/index.html
+++ b/oscar/templates/oscar/dashboard/reports/index.html
@@ -8,12 +8,12 @@
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">	  	
-    <li>	  	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li class="active">{% trans "Reporting Dashboard" %}</li>	  	
+<ul class="breadcrumb">     
+    <li>        
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li class="active">{% trans "Reporting Dashboard" %}</li>       
 </ul>
 {% endblock %}
 
@@ -36,7 +36,7 @@
 
 {% if description %}
 <div class="table-header">
-	<h3><i class="icon-bar-chart icon-large"></i>{{ description }}</h3>
+    <h3><i class="icon-bar-chart icon-large"></i>{{ description }}</h3>
 </div>
 {% endif %}
 

--- a/oscar/templates/oscar/dashboard/reports/partials/open_basket_report.html
+++ b/oscar/templates/oscar/dashboard/reports/partials/open_basket_report.html
@@ -5,13 +5,13 @@
 {% block report %}
 <table class="table table-striped table-bordered table-hover">
     <tr>
-		<th>{% trans "Email" %}</th>
-		<th>{% trans "Name" %}</th>
-		<th>{% trans "Num lines" %}</th>
-		<th>{% trans "Num items" %}</th>
-		<th>{% trans "Value" %}</th>
-		<th>{% trans "Date of creation" %}</th>
-		<th>{% trans "Time since creation" %}</th>
+        <th>{% trans "Email" %}</th>
+        <th>{% trans "Name" %}</th>
+        <th>{% trans "Num lines" %}</th>
+        <th>{% trans "Num items" %}</th>
+        <th>{% trans "Value" %}</th>
+        <th>{% trans "Date of creation" %}</th>
+        <th>{% trans "Time since creation" %}</th>
     </tr>
     {% for basket in objects %}
     <tr>

--- a/oscar/templates/oscar/dashboard/reports/partials/order_report.html
+++ b/oscar/templates/oscar/dashboard/reports/partials/order_report.html
@@ -5,25 +5,25 @@
 {% block report %}
 <table class="table table-striped table-bordered table-hover">
     {% if objects %}
-	<tr>
-		<th>{% trans "Order number" %}</th>
-		<th>{% trans "User" %}</th>
-		<th>{% trans "Total incl. tax" %}</th>
-		<th>{% trans "Date placed" %}</th>
-		<th></th>
-	</tr>
-	{% for order in objects %}
-	<tr>
-		<td>{{ order.number }}</td>
-		<td>{{ order.user|default:"-" }}</td>
-		<td>{{ order.total_incl_tax|currency }}</td>
-		<td>{{ order.date_placed }}</td>
-		<td>
-			<a class="btn btn-info" href="{% url dashboard:order-detail order.number %}">{% trans "View" %}</a>
-		</td>
-	</tr>
-	{% endfor %}
-	{% else %}
+    <tr>
+        <th>{% trans "Order number" %}</th>
+        <th>{% trans "User" %}</th>
+        <th>{% trans "Total incl. tax" %}</th>
+        <th>{% trans "Date placed" %}</th>
+        <th></th>
+    </tr>
+    {% for order in objects %}
+    <tr>
+        <td>{{ order.number }}</td>
+        <td>{{ order.user|default:"-" }}</td>
+        <td>{{ order.total_incl_tax|currency }}</td>
+        <td>{{ order.date_placed }}</td>
+        <td>
+            <a class="btn btn-info" href="{% url dashboard:order-detail order.number %}">{% trans "View" %}</a>
+        </td>
+    </tr>
+    {% endfor %}
+    {% else %}
     <tr><td>{% trans "No results found." %}</td></tr>
     {% endif %}
 </table>

--- a/oscar/templates/oscar/dashboard/reports/partials/product_report.html
+++ b/oscar/templates/oscar/dashboard/reports/partials/product_report.html
@@ -5,10 +5,10 @@
 {% block report %}
 <table class="table table-striped table-bordered table-hover">
     <tr>
-		<th>{% trans "Product" %}</th>
-		<th>{% trans "Views" %}</th>
-		<th>{% trans "Basket additions" %}</th>
-		<th>{% trans "Purchases" %}</th>
+        <th>{% trans "Product" %}</th>
+        <th>{% trans "Views" %}</th>
+        <th>{% trans "Basket additions" %}</th>
+        <th>{% trans "Purchases" %}</th>
     </tr>
     {% for product in objects %}
     <tr>

--- a/oscar/templates/oscar/dashboard/reports/partials/submitted_basket_report.html
+++ b/oscar/templates/oscar/dashboard/reports/partials/submitted_basket_report.html
@@ -5,13 +5,13 @@
 {% block report %}
 <table class="table table-striped table-bordered table-hover">
     <tr>
-		<th>{% trans "Email" %}</th>
-		<th>{% trans "Name" %}</th>
-		<th>{% trans "Num lines" %}</th>
-		<th>{% trans "Num items" %}</th>
-		<th>{% trans "Value" %}</th>
-		<th>{% trans "Date created" %}</th>
-		<th>{% trans "Time between creation and submission" %}</th>
+        <th>{% trans "Email" %}</th>
+        <th>{% trans "Name" %}</th>
+        <th>{% trans "Num lines" %}</th>
+        <th>{% trans "Num items" %}</th>
+        <th>{% trans "Value" %}</th>
+        <th>{% trans "Date created" %}</th>
+        <th>{% trans "Time between creation and submission" %}</th>
     </tr>
     {% for basket in objects %}
     <tr>

--- a/oscar/templates/oscar/dashboard/reports/partials/user_report.html
+++ b/oscar/templates/oscar/dashboard/reports/partials/user_report.html
@@ -5,16 +5,16 @@
 {% block report %}
 <table class="table table-striped table-bordered table-hover">
     <tr>
-		<th>{% trans "Email" %}</th>
-		<th>{% trans "Name" %}</th>
-		<th>{% trans "Date registered" %}</th>
-		<th>{% trans "Product views" %}</th>
-		<th>{% trans "Basket additions" %}</th>
-		<th>{% trans "Orders" %}</th>
-		<th>{% trans "Order lines" %}</th>
-		<th>{% trans "Order items" %}</th>
-		<th>{% trans "Total spent" %}</th>
-		<th>{% trans "Date of last order" %}</th>
+        <th>{% trans "Email" %}</th>
+        <th>{% trans "Name" %}</th>
+        <th>{% trans "Date registered" %}</th>
+        <th>{% trans "Product views" %}</th>
+        <th>{% trans "Basket additions" %}</th>
+        <th>{% trans "Orders" %}</th>
+        <th>{% trans "Order lines" %}</th>
+        <th>{% trans "Order items" %}</th>
+        <th>{% trans "Total spent" %}</th>
+        <th>{% trans "Date of last order" %}</th>
     </tr>
     {% for user in objects %}
     <tr>

--- a/oscar/templates/oscar/dashboard/reports/partials/voucher_report.html
+++ b/oscar/templates/oscar/dashboard/reports/partials/voucher_report.html
@@ -6,10 +6,10 @@
 <table class="table table-striped table-bordered table-hover">
     {% if objects %}
         <tr>
-    		<th>{% trans "Voucher code" %}</th>
-    		<th>{% trans "Added to a basket" %}</th>
-    		<th>{% trans "Used in an order" %}</th>
-    		<th>{% trans "Total discount" %}</th>
+            <th>{% trans "Voucher code" %}</th>
+            <th>{% trans "Added to a basket" %}</th>
+            <th>{% trans "Used in an order" %}</th>
+            <th>{% trans "Total discount" %}</th>
         </tr>
         {% for voucher in objects %}
         <tr>

--- a/oscar/templates/oscar/dashboard/reviews/review_delete.html
+++ b/oscar/templates/oscar/dashboard/reviews/review_delete.html
@@ -11,21 +11,21 @@ create-page
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb"> 	
+<ul class="breadcrumb">     
     <li>
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li>	  	
-        <a href="{% url dashboard:reviews-list %}">{% trans "Reviews" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li class="active">{% blocktrans with title=review.title|truncatechars:30 %}Delete review "{{ title }}"?{% endblocktrans %}</li>	  	
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a> 
+        <span class="divider">/</span>      
+    </li>       
+    <li>        
+        <a href="{% url dashboard:reviews-list %}">{% trans "Reviews" %}</a>        
+        <span class="divider">/</span>      
+    </li>       
+    <li class="active">{% blocktrans with title=review.title|truncatechars:30 %}Delete review "{{ title }}"?{% endblocktrans %}</li>        
 </ul>
 {% endblock %}
 
 {% block headertext %}
-	{% blocktrans with title=review.title|truncatechars:30 %}Delete review "{{ title }}"?{% endblocktrans %}
+    {% blocktrans with title=review.title|truncatechars:30 %}Delete review "{{ title }}"?{% endblocktrans %}
 {% endblock %}
 
 {% block dashboard_content %}
@@ -33,23 +33,23 @@ create-page
     <h2>Review</h2>
 </div>
 <form action="." method="post" class="well">
-	{% csrf_token %}
+    {% csrf_token %}
 
-	<table class="table table-striped table-bordered table-hover">
+    <table class="table table-striped table-bordered table-hover">
             <tbody> 
-				<tr><th>{% trans "Review Title" %}</th><td>{{ review.title }}</td></tr>
-				<tr><th>{% trans "Product" %}</th><td>{{ review.product.title }}</td></tr>
-				<tr><th>{% trans "User" %}</th><td>{{ review.user.get_reviewer_name|default:"-" }}</td></tr>
-				<tr><th>{% trans "Score" %}</th><td>{{ review.score|floatformat:1 }}</td></tr>
-				<tr><th>{% trans "Votest" %}</th><td>{{ review.total_votes }}</td></tr>
-				<tr><th>{% trans "Status" %}</th><td>{{ review.status }}</td></tr>
-				<tr><th>{% trans "Date created" %}</th><td>{{ review.date_created }}</td></tr>
+                <tr><th>{% trans "Review Title" %}</th><td>{{ review.title }}</td></tr>
+                <tr><th>{% trans "Product" %}</th><td>{{ review.product.title }}</td></tr>
+                <tr><th>{% trans "User" %}</th><td>{{ review.user.get_reviewer_name|default:"-" }}</td></tr>
+                <tr><th>{% trans "Score" %}</th><td>{{ review.score|floatformat:1 }}</td></tr>
+                <tr><th>{% trans "Votest" %}</th><td>{{ review.total_votes }}</td></tr>
+                <tr><th>{% trans "Status" %}</th><td>{{ review.status }}</td></tr>
+                <tr><th>{% trans "Date created" %}</th><td>{{ review.date_created }}</td></tr>
             </tbody>
-	</table>
+    </table>
 
-	<div class="form-actions">
-		<button class="btn btn-danger" type="submit">{% trans "Delete" %}</button> {% trans "or" %}
-		<a href="{% url dashboard:reviews-list %}">{% trans "cancel" %}</a>
-	</div>
+    <div class="form-actions">
+        <button class="btn btn-danger" type="submit">{% trans "Delete" %}</button> {% trans "or" %}
+        <a href="{% url dashboard:reviews-list %}">{% trans "cancel" %}</a>
+    </div>
 </form>
 {% endblock dashboard_content %}

--- a/oscar/templates/oscar/dashboard/reviews/review_list.html
+++ b/oscar/templates/oscar/dashboard/reviews/review_list.html
@@ -8,12 +8,12 @@
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">       	
-    <li>       	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>       	
-        <span class="divider">/</span>       	
-    </li>       	
-    <li class="active">{% trans "Reviews" %}</li>      	
+<ul class="breadcrumb">         
+    <li>        
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>         
+        <span class="divider">/</span>          
+    </li>           
+    <li class="active">{% trans "Reviews" %}</li>       
 </ul>
 {% endblock %}
 
@@ -31,7 +31,7 @@
 <div class="well">
     <form action="." method="get" class="form-inline">
         {% include 'partials/form_fields_inline.html' with form=form %}
-    	<button type="submit" class="btn btn-primary top-spacer">{% trans "Search" %}</button>
+        <button type="submit" class="btn btn-primary top-spacer">{% trans "Search" %}</button>
     </form>
 </div>
 
@@ -53,37 +53,37 @@
         </caption>
         <tr>
             <th></th>
-			<th>{% trans "Review Title" %}</th>
-			<th>{% trans "Review For Product" %}</th>
-			<th>{% trans "User" %}</th>
-			<th>{% trans "Score" %}</th>
-			<th>{% trans "Votes" %}</th>
-			<th>{% trans "Status" %}</th>
-			<th>{% trans "Date created" %}</th>
+            <th>{% trans "Review Title" %}</th>
+            <th>{% trans "Review For Product" %}</th>
+            <th>{% trans "User" %}</th>
+            <th>{% trans "Score" %}</th>
+            <th>{% trans "Votes" %}</th>
+            <th>{% trans "Status" %}</th>
+            <th>{% trans "Date created" %}</th>
             <th></th>
         </tr>
         {% for review in review_list %}
         <tr>
             <td><input type="checkbox" name="selected_review" class="selected_review" value="{{ review.id }}"/>
                 <td>
-					{% if review.product %}
-						<a href="{% url catalogue:reviews-detail review.product.slug review.product.id review.id %}">{{ review.title }}</a>
-					{% else %}
-						{{ review.title }}
-					{% endif %}
+                    {% if review.product %}
+                        <a href="{% url catalogue:reviews-detail review.product.slug review.product.id review.id %}">{{ review.title }}</a>
+                    {% else %}
+                        {{ review.title }}
+                    {% endif %}
                 </td>
             <td>
-				{% if review.product %}
-					<a href='{% url catalogue:detail review.product.slug review.product.id %}'>{{ review.product.title }}</a> </td>
-				{% else %}
-					[Product deleted]
-				{% endif %}
+                {% if review.product %}
+                    <a href='{% url catalogue:detail review.product.slug review.product.id %}'>{{ review.product.title }}</a> </td>
+                {% else %}
+                    [Product deleted]
+                {% endif %}
             <td>
-				{% if review.user %}
+                {% if review.user %}
                 <a href="{% url dashboard:user-detail review.user.id %}">{{ review.get_reviewer_name }}</a>
-				{% else %}
-				{{ review.name }}
-				{% endif %}
+                {% else %}
+                {{ review.name }}
+                {% endif %}
             </td>
             <td>
                 {{ review.score|floatformat:1 }} / {{ 5.0|floatformat:1 }}

--- a/oscar/templates/oscar/dashboard/reviews/review_update.html
+++ b/oscar/templates/oscar/dashboard/reviews/review_update.html
@@ -9,28 +9,28 @@
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">	  	
-    <li>	  	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li>	  	
-        <a href="{% url dashboard:reviews-list %}">{% trans "Reviews" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li class="active">{% blocktrans %}Review #{{ review.id }}{% endblocktrans %}</li>	  	
+<ul class="breadcrumb">     
+    <li>        
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li>        
+        <a href="{% url dashboard:reviews-list %}">{% trans "Reviews" %}</a>        
+        <span class="divider">/</span>      
+    </li>       
+    <li class="active">{% blocktrans %}Review #{{ review.id }}{% endblocktrans %}</li>      
 </ul>
 {% endblock %}
 
 {% block headertext %}
-	{% blocktrans %}Review #{{ review.id }}{% endblocktrans %}
+    {% blocktrans %}Review #{{ review.id }}{% endblocktrans %}
 {% endblock %}
 
 {% block dashboard_content %}
 <form action="." method="post" class="form-stacked" enctype="multipart/form-data">
-	{% csrf_token %}
-	<div class="table-header">
-		<h3>{% trans "Review information" %}</h3>
+    {% csrf_token %}
+    <div class="table-header">
+        <h3>{% trans "Review information" %}</h3>
     </div>
     <div class="well">
         <div class="clearfix">
@@ -66,20 +66,20 @@
                         <span class="control-group {% if field.errors %}error{% endif %}">
                             {{ field.label_tag }}
                             {{ field }}
-    						{% for error in field.errors %}
-    								<ul class="help-block">
-    										<li>{{ error|escape }}</li>
-    								</ul>
-    						{% endfor %}
-        				</span>
+                            {% for error in field.errors %}
+                                    <ul class="help-block">
+                                            <li>{{ error|escape }}</li>
+                                    </ul>
+                            {% endfor %}
+                        </span>
                     {% endif %}
-            	</div>
+                </div>
             {% endif %}
         {% endfor %}
         </div>
         <div class="form-actions">
-    		<button class="btn btn-primary btn-large" type="submit">{% trans "Save" %}</button> {% trans "or" %}
-    		<a href="{% url dashboard:reviews-list %}">{% trans "cancel" %}</a>
+            <button class="btn btn-primary btn-large" type="submit">{% trans "Save" %}</button> {% trans "or" %}
+            <a href="{% url dashboard:reviews-list %}">{% trans "cancel" %}</a>
         </div>
     </div>
 </form>

--- a/oscar/templates/oscar/dashboard/users/alerts/delete.html
+++ b/oscar/templates/oscar/dashboard/users/alerts/delete.html
@@ -8,16 +8,16 @@
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">	  	
-    <li>	  	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li>	  	
-        <a href="{% url dashboard:user-alert-list %}">{% trans "Product alerts" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li class="active">{% blocktrans with id=alert.id %}Alert #{{ id }}{% endblocktrans %}</li>	  	
+<ul class="breadcrumb">     
+    <li>        
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li>        
+        <a href="{% url dashboard:user-alert-list %}">{% trans "Product alerts" %}</a>      
+        <span class="divider">/</span>      
+    </li>       
+    <li class="active">{% blocktrans with id=alert.id %}Alert #{{ id }}{% endblocktrans %}</li>     
 </ul>
 {% endblock %}
 
@@ -34,7 +34,7 @@
         <form action="." method="post" >
             {% csrf_token %}
             <div class="form-actions">
-    		<p>{% trans "Are you sure that you want to delete this alert?" %}</p>
+            <p>{% trans "Are you sure that you want to delete this alert?" %}</p>
                 <button type='submit' class="btn btn-large btn-danger">{% trans "Delete" %}</button> or
                 <a href="{% url dashboard:user-alert-list %}">{% trans "cancel" %}</a>
             </div>

--- a/oscar/templates/oscar/dashboard/users/alerts/list.html
+++ b/oscar/templates/oscar/dashboard/users/alerts/list.html
@@ -9,14 +9,14 @@
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">   	
-    <li>   	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>   	
+<ul class="breadcrumb">     
+    <li>    
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
         <span class="divider">/</span>
-    </li>   	
-    <li class="active">  	
-        <a href="{% url dashboard:user-alert-list %}">{% trans "Product alerts" %}</a>  	
-    </li>  	
+    </li>       
+    <li class="active">     
+        <a href="{% url dashboard:user-alert-list %}">{% trans "Product alerts" %}</a>      
+    </li>   
 </ul>
 {% endblock %}
 
@@ -30,10 +30,10 @@
 </div>
 <div class="well">
     <form action="." method="get" class="form-inline">
-		{% include "partials/form_fields_inline.html" with form=form %}
-	<button type="submit" class="btn btn-primary">{% trans "Search" %}</button>
-	{% trans "or" %}
-		<a href="{% url dashboard:user-alert-list %}" class="btn">{% trans "reset" %}</a>
+        {% include "partials/form_fields_inline.html" with form=form %}
+    <button type="submit" class="btn btn-primary">{% trans "Search" %}</button>
+    {% trans "or" %}
+        <a href="{% url dashboard:user-alert-list %}" class="btn">{% trans "reset" %}</a>
     </form>
 </div>
 
@@ -54,14 +54,14 @@
         {% for alert in alerts %}
         <tr>
             <td>
-				<a href="{{ alert.product.get_absolute_url }}">{{ alert.product }}</a>
+                <a href="{{ alert.product.get_absolute_url }}">{{ alert.product }}</a>
             </td>
             <td>
                 {% if alert.user %}
-				<a href="{% url dashboard:user-detail alert.user.id %}">{{ alert.user.email }}</a>
-				{% else %}
-				{{ alert.email }} {% trans "(Anonymous)" %}
-				{% endif %}
+                <a href="{% url dashboard:user-detail alert.user.id %}">{{ alert.user.email }}</a>
+                {% else %}
+                {{ alert.email }} {% trans "(Anonymous)" %}
+                {% endif %}
             </td>
             <td>
                 {{ alert.status }}
@@ -88,7 +88,7 @@
         {% endfor %}
     </table>
 
-	{% include "partials/pagination.html" %}
+    {% include "partials/pagination.html" %}
 
 {% else %}
     <table class="table table-striped table-bordered table-hover">

--- a/oscar/templates/oscar/dashboard/users/alerts/partials/alert.html
+++ b/oscar/templates/oscar/dashboard/users/alerts/partials/alert.html
@@ -1,45 +1,45 @@
 {% load i18n %}
 
 <table class="table table-striped table-bordered table-hover">
-	<tbody>
-		<tr>
-			<th>{% trans "Product" %}</th>
-			<td><a href="{{ alert.product.get_absolute_url }}">{{ alert.product }}</a></td>
-		</tr>
-		<tr>
-			<th>{% trans "User" %}</th>
-			<td>
-				{% if alert.user %}
-					{{ alert.user }}
-				{% else %}
-					{{ alert.email }}
-				{% endif %}
-			</td>
-		</tr>
-		<tr>
-			<th>{% trans "Status" %}</th>
-			<td>{{ alert.status }}</td>
-		</tr>
-		<tr>
-			<th>{% trans "Date created" %}</th>
-			<td>{{ alert.date_created }}</td>
-		</tr>
-		{% if not alert.user %}
-		<tr>
-			<th>{% trans "Date confirmed" %}</th>
-			<td>{{ alert.date_confirmed|default:"-" }}</td>
-		</tr>
-		{% endif %}
-		{% if alert.is_cancelled %}
-		<tr>
-			<th>{% trans "Date cancelled" %}</th>
-			<td>{{ alert.date_cancelled }}</td>
-		</tr>
-		{% else %}
-		<tr>
-			<th>{% trans "Date alert sent" %}</th>
-			<td>{{ alert.date_closed|default:"-" }}</td>
-		</tr>
-		{% endif %}
-	</tbody>
+    <tbody>
+        <tr>
+            <th>{% trans "Product" %}</th>
+            <td><a href="{{ alert.product.get_absolute_url }}">{{ alert.product }}</a></td>
+        </tr>
+        <tr>
+            <th>{% trans "User" %}</th>
+            <td>
+                {% if alert.user %}
+                    {{ alert.user }}
+                {% else %}
+                    {{ alert.email }}
+                {% endif %}
+            </td>
+        </tr>
+        <tr>
+            <th>{% trans "Status" %}</th>
+            <td>{{ alert.status }}</td>
+        </tr>
+        <tr>
+            <th>{% trans "Date created" %}</th>
+            <td>{{ alert.date_created }}</td>
+        </tr>
+        {% if not alert.user %}
+        <tr>
+            <th>{% trans "Date confirmed" %}</th>
+            <td>{{ alert.date_confirmed|default:"-" }}</td>
+        </tr>
+        {% endif %}
+        {% if alert.is_cancelled %}
+        <tr>
+            <th>{% trans "Date cancelled" %}</th>
+            <td>{{ alert.date_cancelled }}</td>
+        </tr>
+        {% else %}
+        <tr>
+            <th>{% trans "Date alert sent" %}</th>
+            <td>{{ alert.date_closed|default:"-" }}</td>
+        </tr>
+        {% endif %}
+    </tbody>
 </table>

--- a/oscar/templates/oscar/dashboard/users/alerts/update.html
+++ b/oscar/templates/oscar/dashboard/users/alerts/update.html
@@ -8,16 +8,16 @@
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb"> 	
-    <li>	  	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li>	  	
-        <a href="{% url dashboard:user-alert-list %}">{% trans "Product alerts" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li class="active">{% blocktrans with id=alert.id %}Alert #{{ id }}{% endblocktrans %}</li>	  	
+<ul class="breadcrumb">     
+    <li>        
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li>        
+        <a href="{% url dashboard:user-alert-list %}">{% trans "Product alerts" %}</a>      
+        <span class="divider">/</span>      
+    </li>       
+    <li class="active">{% blocktrans with id=alert.id %}Alert #{{ id }}{% endblocktrans %}</li>     
 </ul>
 {% endblock %}
 
@@ -31,8 +31,8 @@
     <div class="pull-right">
         <form action="." method="post" class="form-inline">
             {% csrf_token %}
-        	{% include 'partials/form_fields_inline.html' %}
-    		<button type='submit' class="btn btn-primary">{% trans "Save" %}</button>
+            {% include 'partials/form_fields_inline.html' %}
+            <button type='submit' class="btn btn-primary">{% trans "Save" %}</button>
             <a href="{% url dashboard:user-alert-list %}" class="btn">{% trans "cancel" %}</a>
         </form>
     </div>

--- a/oscar/templates/oscar/dashboard/users/detail.html
+++ b/oscar/templates/oscar/dashboard/users/detail.html
@@ -9,16 +9,16 @@
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">	  	
-    <li>	  	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li>	  	
-        <a href="{% url dashboard:users-index %}">{% trans "Customers" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li class="active">{% blocktrans with email=customer.email %}{{ email }}{% endblocktrans %}</li>	  	
+<ul class="breadcrumb">     
+    <li>        
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li>        
+        <a href="{% url dashboard:users-index %}">{% trans "Customers" %}</a>       
+        <span class="divider">/</span>      
+    </li>       
+    <li class="active">{% blocktrans with email=customer.email %}{{ email }}{% endblocktrans %}</li>        
 </ul>
 {% endblock %}
 
@@ -34,18 +34,18 @@
         </div>
         <div id="user_details" class="well">
             <ul>
-				<li>{% trans "Email:" %} {{ customer.email }}</li>
-				<li>{% trans "First name:" %} {{ customer.first_name|default:"-" }}</li>
-				<li>{% trans "Last name:" %} {{ customer.last_name|default:"-" }}</li>
-				<li>
-					{% if customer.is_active %}
-					{% trans "This customer is active" %}
-					{% else %}
-					{% trans "This customer is inactive" %}
-					{% endif %}
-				</li>
+                <li>{% trans "Email:" %} {{ customer.email }}</li>
+                <li>{% trans "First name:" %} {{ customer.first_name|default:"-" }}</li>
+                <li>{% trans "Last name:" %} {{ customer.last_name|default:"-" }}</li>
+                <li>
+                    {% if customer.is_active %}
+                    {% trans "This customer is active" %}
+                    {% else %}
+                    {% trans "This customer is inactive" %}
+                    {% endif %}
+                </li>
                 {% if customer.is_superuser %}
-				<li><strong>{% trans "Superuser" %}</strong></li>
+                <li><strong>{% trans "Superuser" %}</strong></li>
                 {% endif %}
             </ul>
         </div>
@@ -87,23 +87,23 @@
 
 
 <div class="tabbable dashboard">
-	<ul class="nav nav-tabs">
-		<li class="active"><a href="#user_orders" data-toggle="tab">{% trans "Orders" %}</a></li>
-		<li><a href="#user_addresses" data-toggle="tab">{% trans "Addresses" %}</a></li>
-		<li><a href="#user_reviews" data-toggle="tab">{% trans "Reviews" %}</a></li>
-	</ul>
+    <ul class="nav nav-tabs">
+        <li class="active"><a href="#user_orders" data-toggle="tab">{% trans "Orders" %}</a></li>
+        <li><a href="#user_addresses" data-toggle="tab">{% trans "Addresses" %}</a></li>
+        <li><a href="#user_reviews" data-toggle="tab">{% trans "Reviews" %}</a></li>
+    </ul>
 
-	<div class="tab-content">
+    <div class="tab-content">
         <div id="user_orders" class="tab-pane active">
              <table class="table table-striped table-bordered table-hover">
                  <caption>{% trans "Orders" %}</caption>
                  {% if customer.orders.count %}
                  <tr>
-					 <th>{% trans "Order Number" %}</th>
-					 <th>{% trans "Num items" %}</th>
-					 <th>{% trans "Total value" %}</th>
-					 <th>{% trans "Date placed" %}</th>
-					 <th>{% trans "Status" %}</th>
+                     <th>{% trans "Order Number" %}</th>
+                     <th>{% trans "Num items" %}</th>
+                     <th>{% trans "Total value" %}</th>
+                     <th>{% trans "Date placed" %}</th>
+                     <th>{% trans "Status" %}</th>
                      <th></th>
                  </tr>
                  {% for order in customer.orders.all %}
@@ -113,37 +113,37 @@
                      <td>{{ order.basket_total_incl_tax|currency }}</td>
                      <td>{{ order.date_placed|date:"d/m/y H:s" }}</td>
                      <td>{{ order.status }}</td>
-					 <td><a href="{% url dashboard:order-detail order.number %}" class="btn btn-info">{% trans "View" %}</a></td>
+                     <td><a href="{% url dashboard:order-detail order.number %}" class="btn btn-info">{% trans "View" %}</a></td>
                  </tr>
                  {% endfor %}
                  {% else %}
-     			    <tr><td>{% trans "This customer has not placed any orders yet." %}</td></tr>
+                    <tr><td>{% trans "This customer has not placed any orders yet." %}</td></tr>
                  {% endif %}
              </table>
 
         </div>
 
         <div id="user_addresses" class="tab-pane">
-			<h2>{% trans "Addresses" %}</h2>
+            <h2>{% trans "Addresses" %}</h2>
             <div class="row-fluid">
-        	{% for address in customer.addresses.all %}
+            {% for address in customer.addresses.all %}
 
                 <div class="span3">
-            	    <div class="well well-info">
-            			{% for field in address.active_address_fields %}
-            			{{ field }}<br/>
-            			{% endfor %}
-            		</div>
-            	</div>
+                    <div class="well well-info">
+                        {% for field in address.active_address_fields %}
+                        {{ field }}<br/>
+                        {% endfor %}
+                    </div>
+                </div>
                 {% if forloop.counter|divisibleby:4 %}
-					</div>
-					{% if not forloop.last %}
-					<div class="row-fluid">
-					{% endif %}
+                    </div>
+                    {% if not forloop.last %}
+                    <div class="row-fluid">
+                    {% endif %}
                 {% endif %}
-			{% empty %}
-			<p>{% trans "This customer has not saved any addresses." %}</p>
-        	{% endfor %}
+            {% empty %}
+            <p>{% trans "This customer has not saved any addresses." %}</p>
+            {% endfor %}
             </div>
         </div>
 
@@ -152,11 +152,11 @@
                 <caption>{% trans "Reviews" %}</caption>
                 {% if customer.reviews.count %}
                 <tr>
-					<th>{% trans "Product ID" %}</th>
-					<th>{% trans "Score" %}</th>
-					<th>{% trans "Title" %}</th>
-					<th>{% trans "Body" %}</th>
-					<th>{% trans "Date created" %}</th>
+                    <th>{% trans "Product ID" %}</th>
+                    <th>{% trans "Score" %}</th>
+                    <th>{% trans "Title" %}</th>
+                    <th>{% trans "Body" %}</th>
+                    <th>{% trans "Date created" %}</th>
                 </tr>
                 {% for review in customer.reviews.all %}
                 <tr>
@@ -168,7 +168,7 @@
                 </tr>
                 {% endfor %}
                 {% else %}
-    			<tr><td>{% trans "This customer has not written any reviews yet." %}</td></tr>
+                <tr><td>{% trans "This customer has not written any reviews yet." %}</td></tr>
                 {% endif %}
             </table>
 

--- a/oscar/templates/oscar/dashboard/users/index.html
+++ b/oscar/templates/oscar/dashboard/users/index.html
@@ -9,18 +9,18 @@
 {% endblock %}
 
 {% block header %}
-<div class="page-header"> 	
+<div class="page-header">   
     <h1>{% trans "Customers" %}</h1>
 </div>
 {% endblock header %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">	  	
-    <li>	  	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li class="active">{% trans "Customers" %}</li>	  	
+<ul class="breadcrumb">     
+    <li>        
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li class="active">{% trans "Customers" %}</li>     
 </ul>
 {% endblock %}
 
@@ -31,8 +31,8 @@
 <div class="well">
     <form action="." method="get" class="form-inline">
         {% include "partials/form_fields_inline.html" with form=form %}
-		<input type="submit" value="{% trans "Search" %}" class="btn btn-primary"/>
-		<a href="{% url dashboard:users-index %}" class="btn">{% trans "Reset" %}</a>
+        <input type="submit" value="{% trans "Search" %}" class="btn btn-primary"/>
+        <a href="{% url dashboard:users-index %}" class="btn">{% trans "Reset" %}</a>
     </form>
 </div>
 
@@ -67,8 +67,8 @@
             <th>{% trans "Email" %}</th>
             <th>{% trans "First name" %}</th>
             <th>{% trans "Last name" %}</th>
-	        <th>{% trans "Is active?" %}</th>
-	        <th>{% trans "Is staff user?" %}</th>
+            <th>{% trans "Is active?" %}</th>
+            <th>{% trans "Is staff user?" %}</th>
             <th>{% trans "Date registered" %}</th>
             <th>{% trans "Num Orders" %}</th>
             <th></th>
@@ -79,8 +79,8 @@
             <td>{{ user.email }}</td>
             <td>{{ user.first_name }}</td>
             <td>{{ user.last_name }}</td>
-	        <td>{{ user.is_active|yesno:_("True,False") }}</td>
-	        <td>{{ user.is_staff|yesno:_("True,False") }}</td>
+            <td>{{ user.is_active|yesno:_("True,False") }}</td>
+            <td>{{ user.is_staff|yesno:_("True,False") }}</td>
             <td>{{ user.date_joined|date:"d/m/y H:s" }}</td>
             <td>{% num_orders user %}</td>
             <td>

--- a/oscar/templates/oscar/dashboard/vouchers/voucher_delete.html
+++ b/oscar/templates/oscar/dashboard/vouchers/voucher_delete.html
@@ -11,21 +11,21 @@ create-page
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">   	
-    <li>   	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>   	
-        <span class="divider">/</span>   	
-    </li>   	
-    <li>  	
-        <a href="{% url dashboard:voucher-list %}">{% trans "Vouchers" %}</a>  	
-        <span class="divider">/</span>  	
-    </li>   	
-    <li class="active">{% blocktrans with name=voucher.name %}Delete voucher '{{ name }}'?{% endblocktrans %}</li>  	
+<ul class="breadcrumb">     
+    <li>    
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li>    
+        <a href="{% url dashboard:voucher-list %}">{% trans "Vouchers" %}</a>   
+        <span class="divider">/</span>      
+    </li>       
+    <li class="active">{% blocktrans with name=voucher.name %}Delete voucher '{{ name }}'?{% endblocktrans %}</li>      
 </ul>
 {% endblock %}
 
 {% block headertext %}
-	{% blocktrans with name=voucher.name %}Delete voucher '{{ name }}'?{% endblocktrans %}
+    {% blocktrans with name=voucher.name %}Delete voucher '{{ name }}'?{% endblocktrans %}
 {% endblock %}
 
 {% block dashboard_content %}
@@ -34,21 +34,21 @@ create-page
 </div>
 <div class="well">
     <table class="table table-striped table-bordered table-hover">
-    	<tbody>
-    		<tr><th>{% trans "Name" %}</th><td>{{ voucher.name }}</td></tr>
-    		<tr><th>{% trans "Code" %}</th><td>{{ voucher.code }}</td></tr>
-    		<tr><th>{% trans "Start date" %}</th><td>{{ voucher.start_date }}</td></tr>
-    		<tr><th>{% trans "End date" %}</th><td>{{ voucher.end_date }}</td></tr>
-    		<tr><th>{% trans "Usage" %}</th><td>{{ voucher.usage }}</td></tr>
-    		<tr><th>{% trans "Discount" %}</th><td>{{ voucher.benefit_description }}</td></tr>
-    	</tbody>
+        <tbody>
+            <tr><th>{% trans "Name" %}</th><td>{{ voucher.name }}</td></tr>
+            <tr><th>{% trans "Code" %}</th><td>{{ voucher.code }}</td></tr>
+            <tr><th>{% trans "Start date" %}</th><td>{{ voucher.start_date }}</td></tr>
+            <tr><th>{% trans "End date" %}</th><td>{{ voucher.end_date }}</td></tr>
+            <tr><th>{% trans "Usage" %}</th><td>{{ voucher.usage }}</td></tr>
+            <tr><th>{% trans "Discount" %}</th><td>{{ voucher.benefit_description }}</td></tr>
+        </tbody>
     </table>
     <form action="." method="post">
-    	{% csrf_token %}
-    	<div class="form-actions">
-    		<button class="btn btn-danger btn-large" type="submit">{% trans "Delete" %}</button> {% trans "or" %}
-    		<a href="{% url dashboard:voucher-list %}">{% trans "cancel" %}</a>
-    	</div>
+        {% csrf_token %}
+        <div class="form-actions">
+            <button class="btn btn-danger btn-large" type="submit">{% trans "Delete" %}</button> {% trans "or" %}
+            <a href="{% url dashboard:voucher-list %}">{% trans "cancel" %}</a>
+        </div>
     </form>
 </div>
 {% endblock dashboard_content %}

--- a/oscar/templates/oscar/dashboard/vouchers/voucher_detail.html
+++ b/oscar/templates/oscar/dashboard/vouchers/voucher_detail.html
@@ -7,16 +7,16 @@
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">	  	
-    <li>	  	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li>	  	
-        <a href="{% url dashboard:voucher-list %}">{% trans "Vouchers" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li class="active">{% blocktrans with name=voucher.name %}Voucher '{{ name }}'{% endblocktrans %}</li>	  	
+<ul class="breadcrumb">     
+    <li>        
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li>        
+        <a href="{% url dashboard:voucher-list %}">{% trans "Vouchers" %}</a>       
+        <span class="divider">/</span>      
+    </li>       
+    <li class="active">{% blocktrans with name=voucher.name %}Voucher '{{ name }}'{% endblocktrans %}</li>      
 </ul>
 {% endblock %}
 
@@ -30,25 +30,25 @@
   <h2>{% trans "Voucher details" %}</h2>
 </div>
 <table class="table table-striped table-bordered table-hover">
-	<tbody>
-		<tr><th>{% trans "Name" %}</th><td>{{ voucher.name }}</td></tr>
-		<tr><th>{% trans "Code" %}</th><td>{{ voucher.code }}</td></tr>
-		<tr><th>{% trans "Start date" %}</th><td>{{ voucher.start_date }}</td></tr>
-		<tr><th>{% trans "End date" %}</th><td>{{ voucher.end_date }}</td></tr>
-		<tr><th>{% trans "Usage" %}</th><td>{{ voucher.get_usage_display }}</td></tr>
-		<tr><th>{% trans "Discount" %}</th><td>{{ voucher.benefit.description|safe }}</td></tr>
-	</tbody>
+    <tbody>
+        <tr><th>{% trans "Name" %}</th><td>{{ voucher.name }}</td></tr>
+        <tr><th>{% trans "Code" %}</th><td>{{ voucher.code }}</td></tr>
+        <tr><th>{% trans "Start date" %}</th><td>{{ voucher.start_date }}</td></tr>
+        <tr><th>{% trans "End date" %}</th><td>{{ voucher.end_date }}</td></tr>
+        <tr><th>{% trans "Usage" %}</th><td>{{ voucher.get_usage_display }}</td></tr>
+        <tr><th>{% trans "Discount" %}</th><td>{{ voucher.benefit.description|safe }}</td></tr>
+    </tbody>
 </table>
 
 <div class="table-header">
   <h2>{% trans "Voucher performance" %}</h2>
 </div>
 <table class="table table-striped table-bordered table-hover">
-	<tbody>
-		<tr><th>{% trans "Number of basket additions" %}</th><td>{{ voucher.num_basket_additions }}</td></tr>
-		<tr><th>{% trans "Number of orders" %}</th><td>{{ voucher.num_orders }}</td></tr>
-		<tr><th>{% trans "Total discount" %}</th><td>{{ voucher.total_discount|currency }}</td></tr>
-	</tbody>
+    <tbody>
+        <tr><th>{% trans "Number of basket additions" %}</th><td>{{ voucher.num_basket_additions }}</td></tr>
+        <tr><th>{% trans "Number of orders" %}</th><td>{{ voucher.num_orders }}</td></tr>
+        <tr><th>{% trans "Total discount" %}</th><td>{{ voucher.total_discount|currency }}</td></tr>
+    </tbody>
 </table>
 
 <div class="table-header">
@@ -57,36 +57,36 @@
 
 <table class="table table-striped table-bordered table-hover">
     {% if not discounts %}
-	<tr><td>{% trans "No orders have been placed that use this voucher." %}</td></tr>
-	{% else %}
-	<thead>
-		<th>{% trans "Order number" %}</th>
-		<th>{% trans "Order total" %}</th>
-		<th>{% trans "Discount" %}</th>
-		<th>{% trans "Date placed" %}</th>
-		<th></th>
-	</thead>
-	<tbody>
-		{% for discount in discounts %}
-		{% with order=discount.order %}
-			<tr>
-				<td>{{ order.number }}</td>
-				<td>{{ order.total_incl_tax|currency }}</td>
-				<td>{{ discount.amount|currency }}</td>
-				<td>{{ order.date_placed }}</td>
-				<td><a href="{% url dashboard:order-detail order.number %}" class="btn btn-info">{% trans "View" %}</a></td>
-			</tr>
-		{% endwith %}
-		{% endfor %}
-	</tbody>
-	{% endif %}
+    <tr><td>{% trans "No orders have been placed that use this voucher." %}</td></tr>
+    {% else %}
+    <thead>
+        <th>{% trans "Order number" %}</th>
+        <th>{% trans "Order total" %}</th>
+        <th>{% trans "Discount" %}</th>
+        <th>{% trans "Date placed" %}</th>
+        <th></th>
+    </thead>
+    <tbody>
+        {% for discount in discounts %}
+        {% with order=discount.order %}
+            <tr>
+                <td>{{ order.number }}</td>
+                <td>{{ order.total_incl_tax|currency }}</td>
+                <td>{{ discount.amount|currency }}</td>
+                <td>{{ order.date_placed }}</td>
+                <td><a href="{% url dashboard:order-detail order.number %}" class="btn btn-info">{% trans "View" %}</a></td>
+            </tr>
+        {% endwith %}
+        {% endfor %}
+    </tbody>
+    {% endif %}
 </table>
 
 
 <div class="form-actions">
-	<a class="btn btn-primary" href="{% url dashboard:voucher-update voucher.id %}">{% trans "Edit" %}</a> {% trans "or" %}
-	<a class="btn btn-danger" href="{% url dashboard:voucher-delete voucher.id %}">{% trans "Delete" %}</a> {% trans "or" %}
-	<a href="{% url dashboard:voucher-list %}">{% trans "cancel" %}</a>
+    <a class="btn btn-primary" href="{% url dashboard:voucher-update voucher.id %}">{% trans "Edit" %}</a> {% trans "or" %}
+    <a class="btn btn-danger" href="{% url dashboard:voucher-delete voucher.id %}">{% trans "Delete" %}</a> {% trans "or" %}
+    <a href="{% url dashboard:voucher-list %}">{% trans "cancel" %}</a>
 </div>
 
 

--- a/oscar/templates/oscar/dashboard/vouchers/voucher_form.html
+++ b/oscar/templates/oscar/dashboard/vouchers/voucher_form.html
@@ -10,16 +10,16 @@ create-page default
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">   	
-    <li> 	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>   	
-        <span class="divider">/</span>   	
-    </li>   	
-    <li>   	
-        <a href="{% url dashboard:voucher-list %}">{% trans "Vouchers" %}</a>   	
-        <span class="divider">/</span>   	
-    </li>   	
-    <li class="active">{{ title }}</li>   	
+<ul class="breadcrumb">     
+    <li>    
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li>    
+        <a href="{% url dashboard:voucher-list %}">{% trans "Vouchers" %}</a>       
+        <span class="divider">/</span>      
+    </li>       
+    <li class="active">{{ title }}</li>     
 </ul>
 {% endblock %}
 
@@ -30,13 +30,13 @@ create-page default
     <h2><i class="icon-money icon-large"></i>{{ title }}</h2>
 </div>
 <form action="." method="post" class="well form-stacked">
-	{% csrf_token %}
-	{% include "partials/form_fields.html" with form=form %}
-	{% block form_actions %}
-	<div class="form-actions">
-		<button class="btn btn-primary btn-large" type="submit">{% trans "Save" %}</button> {% trans "or" %}
-		<a href="{% url dashboard:voucher-list %}">{% trans "cancel" %}</a>
-	</div>
-	{% endblock form_actions %}
+    {% csrf_token %}
+    {% include "partials/form_fields.html" with form=form %}
+    {% block form_actions %}
+    <div class="form-actions">
+        <button class="btn btn-primary btn-large" type="submit">{% trans "Save" %}</button> {% trans "or" %}
+        <a href="{% url dashboard:voucher-list %}">{% trans "cancel" %}</a>
+    </div>
+    {% endblock form_actions %}
 </form>
 {% endblock dashboard_content %}

--- a/oscar/templates/oscar/dashboard/vouchers/voucher_list.html
+++ b/oscar/templates/oscar/dashboard/vouchers/voucher_list.html
@@ -7,12 +7,12 @@
 {% endblock %}
 
 {% block breadcrumbs %}
-<ul class="breadcrumb">	  	
-    <li>	  	
-        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>	  	
-        <span class="divider">/</span>	  	
-    </li>	  	
-    <li class="active">{{ description }}</li>	  	
+<ul class="breadcrumb">     
+    <li>        
+        <a href="{% url dashboard:index %}">{% trans "Dashboard" %}</a>     
+        <span class="divider">/</span>      
+    </li>       
+    <li class="active">{{ description }}</li>       
 </ul>
 {% endblock %}
 
@@ -29,9 +29,9 @@
 </div>
 <div class="well">
     <form action="." method="get" class="form-inline">
-		{% include 'partials/form_fields_inline.html' with form=form %}
-		<button type="submit" class="btn btn-primary">{% trans "Search" %}</button>
-		<a href="{% url dashboard:voucher-list %}" class="btn">{% trans "Reset" %}</a>
+        {% include 'partials/form_fields_inline.html' with form=form %}
+        <button type="submit" class="btn btn-primary">{% trans "Search" %}</button>
+        <a href="{% url dashboard:voucher-list %}" class="btn">{% trans "Reset" %}</a>
     </form>
 </div>
 
@@ -47,24 +47,24 @@
         <caption><i class="icon-money icon-large"></i>{{ description }}</caption>
     {% endif %}
     {% if vouchers.count %}
-	<tr>
-		<th>{% trans "Name" %}</th>
-		<th>{% trans "Code" %}</th>
-		<th>{% trans "Is active?" %}</th>
-		<th>{% trans "Num baskets" %}</th>
-		<th>{% trans "Num orders" %}</th>
-		<th>{% trans "Date created" %}</th>
-		<th></th>
-	</tr>
-    	{% for voucher in vouchers %}
-    	<tr>
-    		<td>{{ voucher.name }}</td>
-    		<td>{{ voucher.code }}</td>
-		<td>{{ voucher.is_active|yesno:_("True,False") }}</td>
-    		<td>{{ voucher.num_basket_additions }}</td>
-    		<td>{{ voucher.num_orders }}</td>
-    		<td>{{ voucher.date_created }}</td>
-    		<td>
+    <tr>
+        <th>{% trans "Name" %}</th>
+        <th>{% trans "Code" %}</th>
+        <th>{% trans "Is active?" %}</th>
+        <th>{% trans "Num baskets" %}</th>
+        <th>{% trans "Num orders" %}</th>
+        <th>{% trans "Date created" %}</th>
+        <th></th>
+    </tr>
+        {% for voucher in vouchers %}
+        <tr>
+            <td>{{ voucher.name }}</td>
+            <td>{{ voucher.code }}</td>
+        <td>{{ voucher.is_active|yesno:_("True,False") }}</td>
+            <td>{{ voucher.num_basket_additions }}</td>
+            <td>{{ voucher.num_orders }}</td>
+            <td>{{ voucher.date_created }}</td>
+            <td>
                 <div class="btn-toolbar">
                     <div class="btn-group">
                       <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
@@ -78,12 +78,12 @@
                       </ul>
                     </div>
                 </div>
-    		</td>
-    	</tr>
-    	{% endfor %}
-	{% else %}
-	<tr><td>{% trans "No vouchers found." %}</td></tr>
-	{% endif %}
+            </td>
+        </tr>
+        {% endfor %}
+    {% else %}
+    <tr><td>{% trans "No vouchers found." %}</td></tr>
+    {% endif %}
 </table>
 {% include "partials/pagination.html" %}
 {% endblock dashboard_content %}

--- a/oscar/templates/oscar/error.html
+++ b/oscar/templates/oscar/error.html
@@ -10,7 +10,7 @@
         {% block error_message %}{% endblock %}
         <p>
             <a class="btn btn-primary btn-large" onclick="javascript:history.go(-1);">{% trans 'Return to previous page' %}</a>
-			<a class="btn btn-primary btn-large" href="/">{% trans "Go to homepage" %}</a>
+            <a class="btn btn-primary btn-large" href="/">{% trans "Go to homepage" %}</a>
         </p>
     </div>
 </div>

--- a/oscar/templates/oscar/layout.html
+++ b/oscar/templates/oscar/layout.html
@@ -21,7 +21,7 @@
 
     {# Main content of page - other layout templates may override this block #}
     {% block content_wrapper %}
-	<div class="container-fluid page">
+    <div class="container-fluid page">
         <div class="page_inner">
             {% block breadcrumbs %}{% endblock %}
             {% block header %}

--- a/oscar/templates/oscar/layout_3_col.html
+++ b/oscar/templates/oscar/layout_3_col.html
@@ -3,7 +3,7 @@
 
 {% block content_wrapper %}
     <div class="container-fluid page">
-        <div class="page_inner">	
+        <div class="page_inner">    
             {% block breadcrumbs %}{% endblock %}
 
             <div class="row-fluid">

--- a/oscar/templates/oscar/offer/detail.html
+++ b/oscar/templates/oscar/offer/detail.html
@@ -9,14 +9,14 @@
 {% block breadcrumbs %}
 <ul class="breadcrumb">
     <li>
-	<a href="{% url promotions:home %}">{% trans "Home" %}</a>
+    <a href="{% url promotions:home %}">{% trans "Home" %}</a>
         <span class="divider">/</span>
     </li>
     <li>
         <a href="#">{% trans "Offers" %}</a>
         <span class="divider">/</span>
     </li>
-	<li class="active">{{ offer.name }}</li>
+    <li class="active">{{ offer.name }}</li>
 </ul>
 {% endblock %}
 
@@ -24,9 +24,9 @@
 
 {% block content %}
 
-	{% if not offer.is_available %}
+    {% if not offer.is_available %}
         <div class="alert alert-error">{% trans " This offer is no longer available." %}</div>
-	{% endif %}
+    {% endif %}
 
     {% if upsell_message %}
     <div class="well">
@@ -40,18 +40,18 @@
     {% endif %}
 
     {% if products.count %}
-		<section>
-			<div class="mod">
-				{% include "partials/pagination.html" %}
-				<ol class="products five">
-					{% for product in products %}
+        <section>
+            <div class="mod">
+                {% include "partials/pagination.html" %}
+                <ol class="products five">
+                    {% for product in products %}
                     <li>{% render_product product %}</li>
-					{% endfor %}
-				</ol>
-				{% include "partials/pagination.html" %}
-			</div>
-		</section>
+                    {% endfor %}
+                </ol>
+                {% include "partials/pagination.html" %}
+            </div>
+        </section>
     {% else %}
-	<p class="nonefound">{% trans "No products found." %}</p>
+    <p class="nonefound">{% trans "No products found." %}</p>
     {% endif %}
 {% endblock content %}

--- a/oscar/templates/oscar/offer/list.html
+++ b/oscar/templates/oscar/offer/list.html
@@ -9,7 +9,7 @@
 {% block breadcrumbs %}
 <ul class="breadcrumb">
     <li>
-	<a href="{% url promotions:home %}">{% trans "Home" %}</a>
+    <a href="{% url promotions:home %}">{% trans "Home" %}</a>
         <span class="divider">/</span>
     </li>
     <li class="active">{% trans "Offers" %}</li>

--- a/oscar/templates/oscar/partials/footer.html
+++ b/oscar/templates/oscar/partials/footer.html
@@ -2,7 +2,7 @@
 <footer class="footer container-fluid">
     {% block footer %}
         <ul class="footer_links">   
-			<li><a href="/about/">{% trans "About" %}</a></li>
+            <li><a href="/about/">{% trans "About" %}</a></li>
             <li class="top_page"><a href="#top_page"><i class="icon-sort-up hidden-phone"></i> {% trans "Top of the page" %}</a></li>
         </ul>
     {% endblock %}

--- a/oscar/templates/oscar/partials/form_field.html
+++ b/oscar/templates/oscar/partials/form_field.html
@@ -10,36 +10,36 @@ checkboxes differently to other widgets.
     {% if field.is_hidden %}
         {{ field }}
     {% else %}
-		{# Check if field is a checkbox as we mark these up differently #}
-		{% if field.widget_type == 'CheckboxInput' %}
-			<div class="controls">
-			<label for="{{ field.auto_id }}" class="checkbox {% if field.field.required %}required{% endif %}">{{ field.label }}{% if field.field.required %} <span>*</span>{% endif %}
-    				{{ field }}
-    			</label>
-				{% for error in field.errors %}
+        {# Check if field is a checkbox as we mark these up differently #}
+        {% if field.widget_type == 'CheckboxInput' %}
+            <div class="controls">
+            <label for="{{ field.auto_id }}" class="checkbox {% if field.field.required %}required{% endif %}">{{ field.label }}{% if field.field.required %} <span>*</span>{% endif %}
+                    {{ field }}
+                </label>
+                {% for error in field.errors %}
                     <span class="help-block"><i class="icon-exclamation-sign"></i> {{ error }}</span>
-				{% endfor %}
-				{% if field.help_text %}
-					<span class='help-block'>
-						{# We allow HTML within form help fields #}
-						{{ field.help_text|safe }}
-					</span>
-				{% endif %}
-			</div>
-		{% else %}
-			<label for="{{ field.auto_id }}" class="control-label {% if field.field.required %}required{% endif %}">{{ field.label }}{% if field.field.required %} <span>*</span>{% endif %}</label>
-			<div class="controls">
-				{{ field }}
-				{% for error in field.errors %}
-					<span class="help-block"><i class="icon-exclamation-sign"></i> {{ error }}</span>
-				{% endfor %}
-				{% if field.help_text %}
-					<span class='help-block'>
-						{# We allow HTML within form help fields #}
-						{{ field.help_text|safe }}
-					</span>
-				{% endif %}
-			</div>
-		{% endif %}
+                {% endfor %}
+                {% if field.help_text %}
+                    <span class='help-block'>
+                        {# We allow HTML within form help fields #}
+                        {{ field.help_text|safe }}
+                    </span>
+                {% endif %}
+            </div>
+        {% else %}
+            <label for="{{ field.auto_id }}" class="control-label {% if field.field.required %}required{% endif %}">{{ field.label }}{% if field.field.required %} <span>*</span>{% endif %}</label>
+            <div class="controls">
+                {{ field }}
+                {% for error in field.errors %}
+                    <span class="help-block"><i class="icon-exclamation-sign"></i> {{ error }}</span>
+                {% endfor %}
+                {% if field.help_text %}
+                    <span class='help-block'>
+                        {# We allow HTML within form help fields #}
+                        {{ field.help_text|safe }}
+                    </span>
+                {% endif %}
+            </div>
+        {% endif %}
     {% endif %}
 </div>

--- a/oscar/templates/oscar/partials/form_fields.html
+++ b/oscar/templates/oscar/partials/form_fields.html
@@ -3,9 +3,9 @@
     {{ field }}
 {% endfor %}
 {% for field in form.visible_fields %}
-	{% comment %} 
-	We use a separate template for each field so that forms can be rendered
-	field-by-field easily #}
-	{% endcomment %}
-	{% include 'partials/form_field.html' with field=field %}
+    {% comment %} 
+    We use a separate template for each field so that forms can be rendered
+    field-by-field easily #}
+    {% endcomment %}
+    {% include 'partials/form_field.html' with field=field %}
 {% endfor %}

--- a/oscar/templates/oscar/partials/nav_accounts.html
+++ b/oscar/templates/oscar/partials/nav_accounts.html
@@ -1,10 +1,10 @@
 {% load i18n %}
 
 <div id="top_page" class="navbar navbar-static-top accounts">
-	<div class="navbar-inner">
+    <div class="navbar-inner">
 
         {# This is used in mobile view #}
-	    <a class="btn btn-navbar" data-toggle="collapse" data-target=".account-collapse">
+        <a class="btn btn-navbar" data-toggle="collapse" data-target=".account-collapse">
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
@@ -44,7 +44,7 @@
                     {% endif %}
                 </ul>
             </div>
-		</div>
+        </div>
 
     </div>
 </div>

--- a/oscar/templates/oscar/partials/pagination.html
+++ b/oscar/templates/oscar/partials/pagination.html
@@ -2,19 +2,19 @@
 {% load i18n %}
 
 {% if paginator.num_pages > 1 %}
-	<div>
-		<ul class="pager">
-			{% if page_obj.has_previous %}
-				<li class="previous"><a href="?{% get_parameters page %}page={{ page_obj.previous_page_number }}">{% trans "previous" %}</a></li>
-			{% endif %}
-			<li class="current">
-			{% blocktrans with page_num=page_obj.number total_pages=paginator.num_pages %}
-				Page {{ page_num }} of {{ total_pages }}
-			{% endblocktrans %}
-			</li>
-			{% if page_obj.has_next %}
-				<li class="next"><a href="?{% get_parameters page %}page={{ page_obj.next_page_number }}">{% trans "next" %}</a></li>
-			{% endif %}
-		</ul>
-	</div>
+    <div>
+        <ul class="pager">
+            {% if page_obj.has_previous %}
+                <li class="previous"><a href="?{% get_parameters page %}page={{ page_obj.previous_page_number }}">{% trans "previous" %}</a></li>
+            {% endif %}
+            <li class="current">
+            {% blocktrans with page_num=page_obj.number total_pages=paginator.num_pages %}
+                Page {{ page_num }} of {{ total_pages }}
+            {% endblocktrans %}
+            </li>
+            {% if page_obj.has_next %}
+                <li class="next"><a href="?{% get_parameters page %}page={{ page_obj.next_page_number }}">{% trans "next" %}</a></li>
+            {% endif %}
+        </ul>
+    </div>
 {% endif %}

--- a/oscar/templates/oscar/partials/search.html
+++ b/oscar/templates/oscar/partials/search.html
@@ -1,5 +1,5 @@
 {% load i18n %}
 <form  method="get" action="{% url search:search %}" class="navbar-form pull-right">
     {{ search_form.q }}
-	<input type="submit" value="{% trans "Search" %}" class="btn" />
+    <input type="submit" value="{% trans "Search" %}" class="btn" />
 </form>

--- a/oscar/templates/oscar/promotions/baseproductlist.html
+++ b/oscar/templates/oscar/promotions/baseproductlist.html
@@ -19,8 +19,8 @@
         </div>
     </div>
 
-	{% if block.link_url %}
+    {% if block.link_url %}
         <a href="{{ block.link_url }}">{% trans "See more" %}</a>
-	{% endif %}
+    {% endif %}
 </section>
 {% endblock %}

--- a/oscar/templates/oscar/promotions/default.html
+++ b/oscar/templates/oscar/promotions/default.html
@@ -16,7 +16,7 @@
             {{ product.stockrecord.price_incl_tax|currency }}<br/>
             {{ product.stockrecord.availability }}
         {% else %}
-		{% trans "Not available" %}
+        {% trans "Not available" %}
         {% endif %}
     {% endif %}    
 </li>

--- a/oscar/templates/oscar/promotions/singleproduct.html
+++ b/oscar/templates/oscar/promotions/singleproduct.html
@@ -5,24 +5,24 @@
 
 <article class="well promotion_single">
     <div class="sub-header">
-    	<h2>{{ promotion.name }}</h2>
+        <h2>{{ promotion.name }}</h2>
     </div>
     <div class="row-fluid">
-    	<div class="span3">
-    		<div class="image_container"> 
-				{% with image=product.primary_image %}
-				{% thumbnail image.original "400x400" upscale=False as thumb %}
+        <div class="span3">
+            <div class="image_container"> 
+                {% with image=product.primary_image %}
+                {% thumbnail image.original "400x400" upscale=False as thumb %}
                     <a href="{{ product.get_absolute_url }}"><img class="thumbnail" src="{{ thumb.url }}" alt="{{ product.get_title }}"></a>
-				{% endthumbnail %}
-				{% endwith %}
-    		</div>    
-    	</div>
-    	<div class="span9">
+                {% endthumbnail %}
+                {% endwith %}
+            </div>    
+        </div>
+        <div class="span9">
             <h3><a href="{{ product.get_absolute_url }}">{{ product.title }}</a></h3>
             <div class="product_price">
                 {% include "catalogue/partials/stock_record.html" %}
             </div>
             {{ promotion.description|safe }}
-    	</div>
+        </div>
     </div>
 </article>

--- a/oscar/templates/oscar/registration/password_reset_complete.html
+++ b/oscar/templates/oscar/registration/password_reset_complete.html
@@ -9,12 +9,12 @@
         <a href="{% url promotions:home %}">{% trans 'Home' %}</a>
         <span class="divider">/</span>
     </li>
-	<li class="active">{% trans 'Password reset complete' %}</li>
+    <li class="active">{% trans 'Password reset complete' %}</li>
 </ul>
 {% endblock %}
 
 {% block content %}
-	<h1>{% trans 'Password reset complete' %}</h1>
-	<p>{% trans "Your password has been set.  You may go ahead and log in now." %}</p>
-	<p><a href="{{ login_url }}" class="btn btn-large btn-primary">{% trans 'Log in' %}</a></p>
+    <h1>{% trans 'Password reset complete' %}</h1>
+    <p>{% trans "Your password has been set.  You may go ahead and log in now." %}</p>
+    <p><a href="{{ login_url }}" class="btn btn-large btn-primary">{% trans 'Log in' %}</a></p>
 {% endblock %}

--- a/oscar/templates/oscar/registration/password_reset_confirm.html
+++ b/oscar/templates/oscar/registration/password_reset_confirm.html
@@ -9,7 +9,7 @@
         <a href="{% url promotions:home %}">{% trans 'Home' %}</a>
         <span class="divider">/</span>
     </li>
-	<li class="active">{% trans 'Enter new password' %}</li>
+    <li class="active">{% trans 'Enter new password' %}</li>
 </ul>
 {% endblock %}
 

--- a/oscar/templates/oscar/registration/password_reset_done.html
+++ b/oscar/templates/oscar/registration/password_reset_done.html
@@ -9,7 +9,7 @@
         <a href="{% url promotions:home %}">{% trans 'Home' %}</a>
         <span class="divider">/</span>
     </li>
-	<li class="active">{% trans 'Password reset sent' %}</li>
+    <li class="active">{% trans 'Password reset sent' %}</li>
 </ul>
 {% endblock %}
 

--- a/oscar/templates/oscar/registration/password_reset_form.html
+++ b/oscar/templates/oscar/registration/password_reset_form.html
@@ -9,7 +9,7 @@
         <a href="{% url promotions:home %}">{% trans 'Home' %}</a>
         <span class="divider">/</span>
     </li>
-	<li class="active">{% trans 'Password reset' %}</li>
+    <li class="active">{% trans 'Password reset' %}</li>
 </ul>
 {% endblock %}
 
@@ -20,11 +20,11 @@
     </div>
 
     <form id="password_reset_form" action="." method="post" class="form-horizontal">
-		{% csrf_token %}
+        {% csrf_token %}
         <p>{% trans "Forgotten your password? Enter your e-mail address below, and we'll e-mail instructions for setting a new one." %}</p>
-		{% include 'partials/form_fields.html' %}
+        {% include 'partials/form_fields.html' %}
         <div class="form-actions">
-			<button type="submit" class="btn btn-primary btn-large">{% trans 'Send reset email' %}</button>
+            <button type="submit" class="btn btn-primary btn-large">{% trans 'Send reset email' %}</button>
         </div>
     </form>
 

--- a/oscar/templates/oscar/search/partials/pagination.html
+++ b/oscar/templates/oscar/search/partials/pagination.html
@@ -2,19 +2,19 @@
 {% load i18n %}
 
 {% if paginator.num_pages > 1 %}
-	<div>
-		<ul class="pager">
-			{% if page.has_previous %}
-				<li class="previous"><a href="?{% get_parameters page %}page={{ page.previous_page_number }}">{% trans "previous" %}</a></li>
-			{% endif %}
-			<li class="current">
-			{% blocktrans with page_num=page.number total_pages=paginator.num_pages %}
-				Page {{ page_num }} of {{ total_pages }}
-			{% endblocktrans %}
-			</li>
-			{% if page.has_next %}
-				<li class="next"><a href="?{% get_parameters page %}page={{ page.next_page_number }}">{% trans "next" %}</a></li>
-			{% endif %}
-		</ul>
-	</div>
+    <div>
+        <ul class="pager">
+            {% if page.has_previous %}
+                <li class="previous"><a href="?{% get_parameters page %}page={{ page.previous_page_number }}">{% trans "previous" %}</a></li>
+            {% endif %}
+            <li class="current">
+            {% blocktrans with page_num=page.number total_pages=paginator.num_pages %}
+                Page {{ page_num }} of {{ total_pages }}
+            {% endblocktrans %}
+            </li>
+            {% if page.has_next %}
+                <li class="next"><a href="?{% get_parameters page %}page={{ page.next_page_number }}">{% trans "next" %}</a></li>
+            {% endif %}
+        </ul>
+    </div>
 {% endif %}

--- a/oscar/templates/oscar/search/results.html
+++ b/oscar/templates/oscar/search/results.html
@@ -10,14 +10,14 @@
 
 {% block breadcrumbs %}
 <ul class="breadcrumb">
-	<li>
+    <li>
         <a href="{% url promotions:home %}">{% trans "Home" %}</a>
         <span class="divider">/</span>
-	</li>
-	<li>
+    </li>
+    <li>
         {% trans "Search" %}
         <span class="divider">/</span>
-	</li>
+    </li>
     <li class="active">"{{ query }}"</li>
 </ul>
 {% endblock %}
@@ -50,15 +50,15 @@
 
 {% if page.object_list %}
 <section>
-	<div class="mod">
-		{% include "search/partials/pagination.html" %}
-		<ol class="products four">
-			{% for result in page.object_list %}
+    <div class="mod">
+        {% include "search/partials/pagination.html" %}
+        <ol class="products four">
+            {% for result in page.object_list %}
                 <li>{% render_product result.object %}</li>
-			{% endfor %}
-		</ol>
-		{% include "search/partials/pagination.html" %}
-	</div>
+            {% endfor %}
+        </ol>
+        {% include "search/partials/pagination.html" %}
+    </div>
 </section>
 {% else %}
     <p>{% trans 'No search results found.' %}</p>


### PR DESCRIPTION
We mostly seem to use 4 spaces for indentation, but I kept running into tabs, which can clutter commit messages when those lines are touched.

This will impact the audit trail for quite a few files though, so I'm leaving it open for debate. 

Conversion found on [SO](http://stackoverflow.com/questions/11094383/how-can-i-convert-tabs-to-spaces-in-every-file-of-a-directory)

```
find . ! -type d ! -name _tmp_ -exec sh -c 'expand -t 4 {} > _tmp_ && mv _tmp_ {}' \;
```
