### PR TITLE
Product primary_image function calls database twice

### DIFF
--- a/oscar/apps/catalogue/abstract_models.py
+++ b/oscar/apps/catalogue/abstract_models.py
@@ -453,15 +453,16 @@ class AbstractProduct(models.Model):
 
     def primary_image(self):
         images = self.images.all()
-        if images.count():
+        try:
             return images[0]
-        # We return a dict with fields that mirror the key properties of the
-        # ProductImage class so this missing image can be used interchangably
-        # in templates.  Strategy pattern ftw!
-        return {
-            'original': self.get_missing_image(),
-            'caption': '',
-            'is_missing': True}
+        except IndexError:
+            # We return a dict with fields that mirror the key properties of the
+            # ProductImage class so this missing image can be used interchangably
+            # in templates.  Strategy pattern ftw!
+            return {
+                'original': self.get_missing_image(),
+                'caption': '',
+                'is_missing': True}
 
     # Helpers
 


### PR DESCRIPTION
The following code results in two database queries, one for getting the count of all images and one for selecting the first image:

```
def primary_image(self):
        images = self.images.all()
        if images.count():
            return images[0]
```

As this is called pretty much all over the site (mini basket, product listings etc), I suggest changing it so that the operation uses only one query to achieve the same logic.
