### PR TITLE
Fix has stock record (when fetch related)

### DIFF
--- a/oscar/apps/catalogue/abstract_models.py
+++ b/oscar/apps/catalogue/abstract_models.py
@@ -393,7 +393,7 @@ class AbstractProduct(models.Model):
         except ObjectDoesNotExist:
             return False
         else:
-            return isinstance(self.stockrecord, get_class('partner.models', 'StockRecord'))
+            return self.stockrecord is not None
 
     def is_purchase_permitted(self, user, quantity):
         """


### PR DESCRIPTION
When Products wich "stockrecord" param is empty fetched with related fields (stockrecord), product.has_stockrecord return None value, because stockrecord fetched in None value.

This path fixed this problem.
