### PR TITLE
Upsell messages are shown even after the offer is applied to the basket

### DIFF
--- a/oscar/apps/basket/views.py
+++ b/oscar/apps/basket/views.py
@@ -112,9 +112,10 @@ class BasketView(ModelFormSetView):
 
     def get_upsell_messages(self, basket):
         offers = Applicator().get_offers(self.request, basket)
+        applied_offers = basket.offer_applications.offers.values()
         msgs = []
         for offer in offers:
-            if offer.is_condition_partially_satisfied(basket):
+            if offer.is_condition_partially_satisfied(basket) and offer not in applied_offers:
                 data = {
                     'message': offer.get_upsell_message(basket),
                     'offer': offer}


### PR DESCRIPTION
The get_upsell_messages function in oscar.apps.basket.views.BasketView loops through all potential offers and returns a list of upsell messages. 

For example, "Spend another £12.50 to get free shipping". However, this function doesn't take into account whether the potential offer has already been applied. 

This will therefore give incorrect upsell messages after the offer has been applied and more items added to the basket.

This fix gets a list of applied offers and checks if the potential offer has already been applied before adding the upsell message.
