### PR TITLE
Fix SKU link to Wikipedia in documentation

### DIFF
--- a/docs/source/ref/glossary.rst
+++ b/docs/source/ref/glossary.rst
@@ -21,7 +21,7 @@ This is a work-in-progress list of commonly used terms when discussing Oscar.
        :term:`UPC`. It's stored as an attribute of
        :attr:`StockRecord <oscar.apps.partner.abstract_models.AbstractStockRecord.partner_sku>`
 
-       .. seealso:: `Wikipedia <http://http://en.wikipedia.org/wiki/Stock-keeping_unit>`_
+       .. seealso:: `Wikipedia <http://en.wikipedia.org/wiki/Stock-keeping_unit>`_
 
     UPC
     Universal Product Code


### PR DESCRIPTION
Fix for a broken link to Wikipedia in documentation (redundant `http://`)
