### PR TITLE
Default value for HTTP_REFERER in BulkEditMixin

### DIFF
--- a/oscar/apps/dashboard/partners/views.py
+++ b/oscar/apps/dashboard/partners/views.py
@@ -10,14 +10,13 @@ from django.views import generic
 
 from oscar.apps.dashboard.partners.forms import UserEmailForm, ExistingUserForm, NewUserForm
 from oscar.core.loading import get_classes
-from oscar.views.generic import BulkEditMixin
 
 Partner = get_model('partner', 'Partner')
 PartnerSearchForm, PartnerCreateForm = get_classes(
     'dashboard.partners.forms', ['PartnerSearchForm', 'PartnerCreateForm'])
 
 
-class PartnerListView(generic.ListView, BulkEditMixin):
+class PartnerListView(generic.ListView):
     model = Partner
     context_object_name = 'partners'
     template_name = 'dashboard/partners/partner_list.html'

--- a/oscar/views/generic.py
+++ b/oscar/views/generic.py
@@ -52,10 +52,10 @@ class BulkEditMixin(object):
         pass
 
     def get_error_url(self, request):
-        return request.META['HTTP_REFERER']
+        return request.META.get('HTTP_REFERER', '.')
 
     def get_success_url(self, request):
-        return request.META['HTTP_REFERER']
+        return request.META('HTTP_REFERER', '.')
 
     def post(self, request, *args, **kwargs):
         # Dynamic dispatch pattern - we forward POST requests onto a method


### PR DESCRIPTION
Avoids a key error when a referer is not available.

Also removed BulkEditMixin from the PartnerListView as it was not used.
