### PR TITLE
Links are broken when renaming categories

### DIFF
--- a/oscar/apps/catalogue/abstract_models.py
+++ b/oscar/apps/catalogue/abstract_models.py
@@ -146,8 +146,8 @@ class AbstractCategory(MP_Node):
 
     @models.permalink
     def get_absolute_url(self):
-        return ('catalogue:category', (), {
-                'category_slug': self.slug})
+        return ('catalogue:category', (),
+                {'category_slug': self.slug, 'pk': self.pk})
 
     class Meta:
         abstract = True

--- a/oscar/apps/catalogue/app.py
+++ b/oscar/apps/catalogue/app.py
@@ -17,6 +17,8 @@ class BaseCatalogueApplication(Application):
             url(r'^$', self.index_view.as_view(), name='index'),
             url(r'^(?P<product_slug>[\w-]*)_(?P<pk>\d+)/$',
                 self.detail_view.as_view(), name='detail'),
+            url(r'^(?P<category_slug>[\w-]+(/[\w-]+)*)_(?P<pk>\d+)/$',
+                self.category_view.as_view(), name='category'),
             url(r'^(?P<category_slug>[\w-]+(/[\w-]+)*)/$',
                 self.category_view.as_view(), name='category'))
         return self.post_process_urls(urlpatterns)


### PR DESCRIPTION
I've reviewed Oscar's URLs and how they break if objects are renamed. Luckily, there's only three places that potentially allow breaking links. Product slugs get changed when the product name changes, but because the matching happens on the product id as well, that is handled well. Offer's slugs don't change when renaming the offer. So the only issue are that category links will break when renaming the category.

Given that there's only one weak point, I'm leaning against a general solution using `django.contrib.redirects` or similar. I'll add some code to fix category links in a backwards-compatible way.
