### PR TITLE
Use LANGUAGE_CODE provided by Django's i18n

### DIFF
--- a/oscar/templates/oscar/base.html
+++ b/oscar/templates/oscar/base.html
@@ -1,10 +1,10 @@
 {% load i18n compress %}
 {% load staticfiles %}
 <!DOCTYPE html>
-<!--[if lt IE 7]>      <html lang="{{ lang|default:"en-gb" }}" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html lang="{{ lang|default:"en-gb" }}" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>         <html lang="{{ lang|default:"en-gb" }}" class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html lang="{{ lang|default:"en-gb" }}" class="no-js"> <!--<![endif]-->
+<!--[if lt IE 7]>      <html lang="{{ LANGUAGE_CODE|default:"en-gb" }}" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html lang="{{ LANGUAGE_CODE|default:"en-gb" }}" class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html lang="{{ LANGUAGE_CODE|default:"en-gb" }}" class="no-js lt-ie9"> <![endif]-->
+<!--[if gt IE 8]><!--> <html lang="{{ LANGUAGE_CODE|default:"en-gb" }}" class="no-js"> <!--<![endif]-->
     <head>
         <title>{% if display_version %}[{% trans "Build" %} {{ version }}] {% endif %}{% block title %}{{ shop_name }} - {{ shop_tagline }}{% endblock %}</title>
 


### PR DESCRIPTION
In `base.html`, the `lang` variable always shows `en-gb` even though language/locale settings are set in the config.

This fix only requires that `django.core.context_processors.i18n` is added to the `TEMPLATE_CONTEXT_PROCESSORS` setting (which I found was almost always set in the Oscar projects I've seen). If it isn't, then it defaults to `en-gb`.
