### PR TITLE
Handle missing "missing" image more gracefully

### DIFF
--- a/oscar/apps/catalogue/abstract_models.py
+++ b/oscar/apps/catalogue/abstract_models.py
@@ -949,22 +949,23 @@ class MissingProductImage(object):
             self.symlink_missing_image(media_file_path)
 
     def symlink_missing_image(self, media_file_path):
+        # Assume
         static_file_path = find('oscar/img/%s' % self.name)
         if static_file_path is not None:
             try:
                 os.symlink(static_file_path, media_file_path)
             except OSError:
-                raise ImproperlyConfigured(
-                    """Please copy/symlink the
-                    "missing image" image at %s into your MEDIA_ROOT at %s.
-                    This exception was raised because Oscar was unable to
-                    symlink it for you."""
-                    % (media_file_path, settings.MEDIA_ROOT))
+                raise ImproperlyConfigured((
+                    "Please copy/symlink the "
+                    "'missing image' image at %s into your MEDIA_ROOT at %s. "
+                    "This exception was raised because Oscar was unable to "
+                    "symlink it for you.") % (media_file_path,
+                                              settings.MEDIA_ROOT))
             else:
-                logging.info(
-                    """Symlinked the "missing image" image at %s into your
-                    MEDIA_ROOT at %s""" %
-                    (media_file_path, settings.MEDIA_ROOT))
+                logging.info((
+                    "Symlinked the 'missing image' image at %s into your "
+                    "MEDIA_ROOT at %s") % (media_file_path,
+                                           settings.MEDIA_ROOT))
 
 
 class AbstractProductImage(models.Model):


### PR DESCRIPTION
The "missing image" is a static file and really shouldn't require that hack of copying it to `MEDIA_ROOT`. This raises issues with versioning and is an additional step in project setup. 
Currently, setting up an own Oscar project and forgetting to copy the image throws a IOError. I could imagine letting `MissingProductImage` symlink the file if it's not existent, but am open for better suggestions.
