### PR TITLE
Injecting the basket into the template context can cause issues

### DIFF
--- a/oscar/apps/basket/middleware.py
+++ b/oscar/apps/basket/middleware.py
@@ -70,8 +70,8 @@ class BasketMiddleware(object):
         # If a basket has had products added to it, but the user is anonymous
         # then we need to assign it to a cookie
         if (hasattr(request, 'basket') and request.basket.id > 0
-            and not request.user.is_authenticated()
-            and settings.OSCAR_BASKET_COOKIE_OPEN not in request.COOKIES):
+                and not request.user.is_authenticated()
+                and settings.OSCAR_BASKET_COOKIE_OPEN not in request.COOKIES):
             cookie = "%s_%s" % (
                 request.basket.id, self.get_basket_hash(request.basket.id))
             response.set_cookie(settings.OSCAR_BASKET_COOKIE_OPEN,
@@ -84,8 +84,18 @@ class BasketMiddleware(object):
         if hasattr(response, 'context_data'):
             if response.context_data is None:
                 response.context_data = {}
-            # setdefault allows passing in other baskets
-            response.context_data.setdefault('basket', request.basket)
+            if 'basket' not in response.context_data:
+                response.context_data['basket'] = request.basket
+            else:
+                # Occasionally, a view will want to pass an alternative basket
+                # to be rendered.  This can happen as part of checkout
+                # processes where the submitted basket is frozen when the
+                # customer is redirected to another site (eg PayPal).  When the
+                # customer returns and we want to show the order preview
+                # template, we need to ensure that the frozen basket gets
+                # rendered (not request.basket).  We still keep a reference to
+                # the request basket (just in case).
+                response.context_data['request_basket'] = request.basket
         return response
 
     def get_cookie_basket(self, cookie_key, request, manager):


### PR DESCRIPTION
The basket middleware injects the current open basket into the template context, which can cause issues if you are trying to re-use the checkout templates to render a different frozen basket.  Eg a basket that was submitted to a payment gateway.  

Not 100% on the solution.  We should probably only inject the basket if a basket variable is not there already.
