### PR TITLE
Add `blank=True` to `date_read` in Notification model

### DIFF
--- a/oscar/apps/customer/abstract_models.py
+++ b/oscar/apps/customer/abstract_models.py
@@ -229,7 +229,7 @@ class AbstractNotification(models.Model):
                                 default=INBOX)
 
     date_sent = models.DateTimeField(auto_now_add=True)
-    date_read = models.DateTimeField(null=True)
+    date_read = models.DateTimeField(blank=True, null=True)
 
     class Meta:
         ordering = ('-date_sent',)


### PR DESCRIPTION
Since `date_read` looks like it's meant to be optional, it couldn't hurt to have `blank=True` in there - to un-break partial updates in django-rest-framework.

tomchristie/django-rest-framework#949
