### PR TITLE
remove also '\r' from the message subject

### DIFF
--- a/oscar/apps/customer/abstract_models.py
+++ b/oscar/apps/customer/abstract_models.py
@@ -192,7 +192,7 @@ class AbstractCommunicationEventType(models.Model):
             messages[name] = template.render(Context(ctx)) if template else ''
 
         # Ensure the email subject doesn't contain any newlines
-        messages['subject'] = messages['subject'].replace("\n", "")
+        messages['subject'] = messages['subject'].replace("\n", "").replace("\r", "")
 
         return messages
 


### PR DESCRIPTION
a "\r" in the "order placed" message subject, raises a "Header values can't contain newlines" exception.
