### PR TITLE
Wrong index used in FixedPriceBenefit

### DIFF
--- a/oscar/apps/offer/models.py
+++ b/oscar/apps/offer/models.py
@@ -1354,7 +1354,7 @@ class FixedPriceBenefit(Benefit):
 
         # Apply discount to the affected lines
         discount_applied = D('0.00')
-        last_line = covered_lines[-1][0]
+        last_line = covered_lines[-1][1]
         for price, line, quantity in covered_lines:
             if line == last_line:
                 # If last line, we just take the difference to ensure that

--- a/tests/integration/offer/fixed_price_benefit_tests.py
+++ b/tests/integration/offer/fixed_price_benefit_tests.py
@@ -52,3 +52,17 @@ class TestAFixedPriceDiscountAppliedWithCountCondition(TestCase):
         self.assertEqual(D('4.00'), result.discount)
         self.assertEqual(3, self.basket.num_items_with_discount)
         self.assertEqual(1, self.basket.num_items_without_discount)
+
+    def test_rounding_error_for_multiple_products(self):
+        for i in range(3):
+            product = create_product(price=D('7.00'))
+            self.basket.add_product(product, 1)
+        result = self.benefit.apply(self.basket, self.condition)
+        self.assertEqual(D('1.00'), result.discount)
+        # Make sure discount together is the same as final discount
+        # Rounding error would return 0.99 instead 1.00
+        cumulative_discount = sum(
+            line.discount_value for line in self.basket.all_lines())
+        self.assertEqual(result.discount, cumulative_discount)
+        self.assertEqual(3, self.basket.num_items_with_discount)
+        self.assertEqual(0, self.basket.num_items_without_discount)


### PR DESCRIPTION
https://github.com/tangentlabs/django-oscar/blob/master/oscar/apps/offer/models.py#L1357
should be last_line = covered_lines[-1][1] since an item in covered_lines is (price, line, quantity_affected)
