### PR TITLE
"Hello guest" in dashboard

### DIFF
--- a/oscar/templates/oscar/dashboard/layout.html
+++ b/oscar/templates/oscar/dashboard/layout.html
@@ -47,7 +47,7 @@
 
                 <div class="nav-collapse nav-accounts collapse">
                     <ul class="nav pull-right">
-                        <li><span>{% trans "Welcome" %} <em>{{ request.user.get_full_name|default:'Guest' }}</em></span></li>
+                        <li><span>{% trans "Welcome" %} <em>{{ request.user.name|default:request.user.email }}</em></span></li>
                         <li><a href="{% url 'promotions:home' %}"><i class="icon-home"></i> {% trans "Return to site" %}</a></li>
                         <li><a href="{% url 'customer:summary' %}"><i class="icon-user"></i> {% trans "Account" %}</a></li>
                         <li><a href="{% url 'customer:logout' %}"><i class="icon-signout"></i> {% trans "Log out" %}</a></li>


### PR DESCRIPTION
At https://github.com/tangentlabs/django-oscar/blob/master/oscar/templates/oscar/dashboard/layout.html#L50 there is unfortunate fallback for get_full_name - "Guest".

It's odd to display "Guest" in a place where they can't go in.
