### PR TITLE
Mark all strings in templates translatable

### DIFF
--- a/oscar/templates/oscar/basket/partials/basket_content.html
+++ b/oscar/templates/oscar/basket/partials/basket_content.html
@@ -95,7 +95,7 @@
                     {% include "partials/form_fields.html" with form=voucher_form %}
                     <div class="form-actions">
                             <button type="submit" class="btn btn-info">{% trans "Add voucher" %}</button>
-                            or <a href="#" id="voucher_form_cancel">{% trans "cancel" %}</a>
+                            {% trans "or" %} <a href="#" id="voucher_form_cancel">{% trans "cancel" %}</a>
                     </div>
                 </form>
                 </div>

--- a/oscar/templates/oscar/catalogue/partials/add_to_basket_form.html
+++ b/oscar/templates/oscar/catalogue/partials/add_to_basket_form.html
@@ -9,7 +9,7 @@
             {% csrf_token %}
             {% include "partials/form_fields.html" with form=basket_form %}
             <div class="form-actions">
-                <button type="submit" class="btn btn-large btn-primary btn-full" value="Add to basket">{% trans "Add to basket" %}</button>
+                <button type="submit" class="btn btn-large btn-primary btn-full" value="{% trans "Add to basket" %}">{% trans "Add to basket" %}</button>
             </div>
         </form>
     {% else %}

--- a/oscar/templates/oscar/catalogue/reviews/review_list.html
+++ b/oscar/templates/oscar/catalogue/reviews/review_list.html
@@ -52,7 +52,7 @@
                             <option value="score">{% trans "Score" %}</option>
                             <option value="recency">{% trans "Recency" %}</option>
                         </select>
-                        <input type="submit" value="Go" />
+                        <input type="submit" value="{% trans "Go" %}" />
                     </form>
 
                     {% for review in reviews %}

--- a/oscar/templates/oscar/checkout/payment_details.html
+++ b/oscar/templates/oscar/checkout/payment_details.html
@@ -18,7 +18,7 @@
 
 {% block payment_details %}
     <div class="sub-header">
-        <h2>Enter payment details</h2>
+        <h2>{% trans "Enter payment details" %}</h2>
     </div>
 
 	{% block payment_details_content %}

--- a/oscar/templates/oscar/customer/address_list.html
+++ b/oscar/templates/oscar/customer/address_list.html
@@ -45,7 +45,7 @@
     <table class="table table-striped table-condensed table-bordered">
         <tbody>
             <tr>
-                <th>Address</th>
+                <th>{% trans "Address" %}</th>
                 <th></th>
             </tr>
             {% for address in addresses %}

--- a/oscar/templates/oscar/customer/anon_order.html
+++ b/oscar/templates/oscar/customer/anon_order.html
@@ -56,7 +56,7 @@
             <th>{% trans 'Product' %}</th>
             <th>{% trans 'Availability' %}</th>
             <th>{% trans 'Quantity' %}</th>
-            <th>{% trans 'Line price excl. tax' %} tax</th>
+            <th>{% trans 'Line price excl. tax' %}</th>
             <th>{% trans 'Line price incl. tax' %}</th>
             <th>{% trans 'Status' %}</th>
             <th></th>

--- a/oscar/templates/oscar/customer/profile.html
+++ b/oscar/templates/oscar/customer/profile.html
@@ -39,7 +39,7 @@
                     <span class="icon-bar"></span>
                 </a>
 
-                <span class="brand visible-phone" href="#">Account</span>
+                <span class="brand visible-phone" href="#">{% trans "Account" %}</span>
 
                 <div class="nav-collapse profile-collapse">
                     <ul class="nav nav-tabs">

--- a/oscar/templates/oscar/dashboard/catalogue/category_list.html
+++ b/oscar/templates/oscar/dashboard/catalogue/category_list.html
@@ -33,7 +33,7 @@
 
     <div class="alert alert-info">
         <p>{% trans "You are editing:" %}
-            <strong><a href="{% url 'dashboard:catalogue-category-list' %}">Home</a></strong>
+            <strong><a href="{% url 'dashboard:catalogue-category-list' %}">{% trans "Home" %}</a></strong>
             {% if ancestors %}
                 &gt;
                 {% for ancestor in ancestors %}
@@ -63,7 +63,7 @@
                         <div class="btn-toolbar">
                             <div class="btn-group">
                                 <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
-                                    Actions
+                                    {% trans "Actions" %}
                                     <span class="caret"></span>
                                 </a>
                                 <ul class="nav dropdown-menu pull-right">

--- a/oscar/templates/oscar/dashboard/catalogue/product_update.html
+++ b/oscar/templates/oscar/dashboard/catalogue/product_update.html
@@ -196,7 +196,7 @@
                         <div class="control-group">
                             <label class="control-label">{% trans "Parent" %}</label>
                             <div class="controls">
-                                <a href="{% url 'dashboard:catalogue-product' parent.id %}" title="Edit {{ parent.title }}">{{ parent.title }}</a>
+                                <a href="{% url 'dashboard:catalogue-product' parent.id %}" title="{% blocktrans %}Edit {{ parent.title }}{% endblocktrans %}">{{ parent.title }}</a>
                             </div>
                         </div>
                         {% endif %}
@@ -217,7 +217,7 @@
                         </tr>
                         <tr>
                             <td>{{ parent.title }}</td>
-                            <td><a href="{% url 'dashboard:catalogue-product' parent.id %}" class="btn btn-primary" title="Edit {{ parent.title }}">{% trans "Edit" %}</a></td>
+                            <td><a href="{% url 'dashboard:catalogue-product' parent.id %}" class="btn btn-primary" title="{% blocktrans %}Edit {{ parent.title }}{% endblocktrans %}">{% trans "Edit" %}</a></td>
                         </tr>
                         {% endif %}
                         {% endwith %}

--- a/oscar/templates/oscar/dashboard/comms/detail.html
+++ b/oscar/templates/oscar/dashboard/comms/detail.html
@@ -44,7 +44,7 @@
                 </ul>
             {% else %}
                 <div class="table-header">
-                    <h2><i class="icon-envelope icon-large"></i>Edit email</h2>
+                    <h2><i class="icon-envelope icon-large"></i>{% trans "Edit email" %}</h2>
                 </div>
             {% endif %}
 
@@ -75,7 +75,7 @@
                 {% include 'partials/form_field.html' with field=form.email_body_template %}
                 {% include 'partials/form_field.html' with field=form.email_body_html_template %}
                 <div class="table-header">
-                    <h3>Preview</h3>
+                    <h3>{% trans "Preview" %}</h3>
                 </div>
                 <div class="well">
                     {% if commtype.is_order_related %}

--- a/oscar/templates/oscar/dashboard/offers/offer_delete.html
+++ b/oscar/templates/oscar/dashboard/offers/offer_delete.html
@@ -38,7 +38,7 @@
         {% csrf_token %}
         <p>{% trans "Are you sure you want to delete this offer?" %}</p>
         <div class="form-actions">
-            <button class="btn btn-large btn-danger" type="submit">{% trans "Delete" %}</button> or
+            <button class="btn btn-large btn-danger" type="submit">{% trans "Delete" %}</button> {% trans "or" %}
             <a href="{% url 'dashboard:offer-list' %}">{% trans "cancel" %}</a>
         </div>
     </form>

--- a/oscar/templates/oscar/dashboard/offers/offer_detail.html
+++ b/oscar/templates/oscar/dashboard/offers/offer_detail.html
@@ -56,7 +56,7 @@
     </table>
 
     <div class="table-header">
-        <div class="pull-right" style="font-weight: normal">Date created: {{ offer.date_created }}</div>
+        <div class="pull-right" style="font-weight: normal">{% trans "Date created:" %} {{ offer.date_created }}</div>
         <h2>{% trans "Offer details" %}</h2>
     </div>
     <table class="table table-striped table-bordered">
@@ -64,7 +64,7 @@
             <tr>
                 <th>{% trans "Name" %}</th>
                 <td>{{ offer.name }}</td>
-                <td rowspan="2"><a id="edit_metadata" href="{% url 'dashboard:offer-metadata' offer.pk %}" class="btn">Edit</a></td>
+                <td rowspan="2"><a id="edit_metadata" href="{% url 'dashboard:offer-metadata' offer.pk %}" class="btn">{% trans "Edit" %}</a></td>
             </tr>
             <tr>
                 <th>{% trans "Description" %}</th>
@@ -73,12 +73,12 @@
             <tr>
                 <th>{% trans "Incentive" %}</th>
                 <td>{{ offer.benefit.description|safe }}</td>
-                <td><a href="{% url 'dashboard:offer-benefit' offer.pk %}" class="btn">Edit</a></td>
+                <td><a href="{% url 'dashboard:offer-benefit' offer.pk %}" class="btn">{% trans "Edit" %}</a></td>
             </tr>
             <tr>
                 <th>{% trans "Condition" %}</th>
                 <td>{{ offer.condition.description|safe }}</td>
-                <td><a href="{% url 'dashboard:offer-condition' offer.pk %}" class="btn">Edit</a></td>
+                <td><a href="{% url 'dashboard:offer-condition' offer.pk %}" class="btn">{% trans "Edit" %}</a></td>
             </tr>
             <tr>
                 <th>{% trans "Restrictions" %}</th>
@@ -93,7 +93,7 @@
                         {% endif %}
                     {% endfor %}
                 </td>
-                <td><a href="{% url 'dashboard:offer-restrictions' offer.pk %}" class="btn">Edit</a></td>
+                <td><a href="{% url 'dashboard:offer-restrictions' offer.pk %}" class="btn">{% trans "Edit" %}</a></td>
             </tr>
         </tbody>
     </table>

--- a/oscar/templates/oscar/dashboard/offers/offer_list.html
+++ b/oscar/templates/oscar/dashboard/offers/offer_list.html
@@ -87,7 +87,7 @@
                             <div class="btn-toolbar">
                                 <div class="btn-group">
                                     <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
-                                        Actions
+                                        {% trans "Actions" %}
                                         <span class="caret"></span>
                                     </a>
                                     <ul class="dropdown-menu pull-right">

--- a/oscar/templates/oscar/dashboard/orders/line_detail.html
+++ b/oscar/templates/oscar/dashboard/orders/line_detail.html
@@ -60,7 +60,7 @@
                 </tr>
                 {% if line.attributes.exists %}
                     <tr>
-                        <th colspan="2">Product Options</th>
+                        <th colspan="2">{% trans "Product Options" %}</th>
                     </tr>
                     {% for attribute in line.attributes.all %}
                         <tr>

--- a/oscar/templates/oscar/dashboard/orders/order_detail.html
+++ b/oscar/templates/oscar/dashboard/orders/order_detail.html
@@ -365,7 +365,7 @@
             <div class="tab-pane {% if active_tab == 'shipping' %}active{% endif %}" id="shipping">
                 {% block tab_shipping %}
                     <div class="table-header">
-                        <h3>Shipping</h3>
+                        <h3>{% trans "Shipping" %}</h3>
                     </div>
                     <table class="table table-striped table-bordered table-hover">
                         <tbody>
@@ -437,7 +437,7 @@
                                 </tbody>
                             </table>
                         {% else %}
-                            <p>No payment sources found for this order.</p>
+                            <p>{% trans "No payment sources found for this order." %}</p>
                         {% endif %}
                     {% endwith %}
 
@@ -557,7 +557,7 @@
                                                     {% csrf_token %}
                                                     <input type="hidden" name="order_action" value="delete_note" />
                                                     <input type="hidden" name="note_id" value="{{ note.id }}" />
-                                                    <input type="submit" value="Delete" class="btn btn-danger" />
+                                                    <input type="submit" value="{% trans "Delete" %}" class="btn btn-danger" />
                                                 </form>
                                             {% endif %}
                                         </td>
@@ -577,7 +577,7 @@
                         {% include "partials/form_fields.html" with form=note_form %}
                         <!-- {{ note_form.as_p }} -->
                         <div class="form-actions">
-                            <input type="submit" value="Save note" class="btn btn-primary" />
+                            <input type="submit" value="{% trans "Save note" %}" class="btn btn-primary" />
                             {% trans "Notes are only editable for 5 minutes after being saved." %}
                         </div>
                     </form>

--- a/oscar/templates/oscar/dashboard/orders/shippingaddress_form.html
+++ b/oscar/templates/oscar/dashboard/orders/shippingaddress_form.html
@@ -35,7 +35,7 @@
         {% include "partials/form_fields.html" with form=form %}
         <div class="form-actions">
             <button type="submit" class="btn btn-primary">{% trans "Update address" %}</button>
-            or <a href="{% url 'dashboard:order-detail' order.number %}">{% trans "cancel" %}</a>
+            {% trans "or" %} <a href="{% url 'dashboard:order-detail' order.number %}">{% trans "cancel" %}</a>
         </div>
     </form>
 

--- a/oscar/templates/oscar/dashboard/pages/index.html
+++ b/oscar/templates/oscar/dashboard/pages/index.html
@@ -27,7 +27,7 @@
 
 {% block dashboard_content %}
     <div class="table-header">
-        <h3><i class="icon-search icon-large"></i>Search</h3>
+        <h3><i class="icon-search icon-large"></i>{% trans "Search" %}</h3>
     </div>
     <div class="well">
         <form action="." method="get" class="form-inline">
@@ -37,7 +37,7 @@
     </div>
 
     <div class="table-header">
-        <h3><i class="icon-file icon-large"></i>Create new page</h3>
+        <h3><i class="icon-file icon-large"></i>{% trans "Create new page" %}</h3>
     </div>
     <div class="well">
         <form action="{% url 'dashboard:page-create' %}" method="get" class="form-inline">
@@ -70,7 +70,7 @@
                                 <div class="btn-toolbar">
                                     <div class="btn-group">
                                         <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
-                                            Actions
+                                            {% trans "Actions" %}
                                             <span class="caret"></span>
                                         </a>
                                         <ul class="dropdown-menu pull-right">

--- a/oscar/templates/oscar/dashboard/partners/partner_delete.html
+++ b/oscar/templates/oscar/dashboard/partners/partner_delete.html
@@ -37,7 +37,7 @@
         {% csrf_token %}
         <p>{% trans "Are you sure you want to delete this partner?" %}</p>
         <div class="form-actions">
-            <button class="btn btn-large btn-danger" type="submit">{% trans "Delete" %}</button> or
+            <button class="btn btn-large btn-danger" type="submit">{% trans "Delete" %}</button> {% trans "or" %}
             <a href="{% url 'dashboard:partner-list' %}">{% trans "cancel" %}</a>
         </div>
     </form>

--- a/oscar/templates/oscar/dashboard/partners/partner_list.html
+++ b/oscar/templates/oscar/dashboard/partners/partner_list.html
@@ -73,7 +73,7 @@
                             <div class="btn-toolbar">
                                 <div class="btn-group">
                                     <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
-                                        Actions
+                                        {% trans "Actions" %}
                                         <span class="caret"></span>
                                     </a>
                                     <ul class="dropdown-menu pull-right">

--- a/oscar/templates/oscar/dashboard/partners/partner_user_select.html
+++ b/oscar/templates/oscar/dashboard/partners/partner_user_select.html
@@ -37,7 +37,7 @@
             {% if form.is_bound %}
                 <a class="btn" href="{% url 'dashboard:partner-user-select' partner.id %}" >{% trans "Reset" %}</a>
             {% endif %}
-            <div style="margin-top:5px">A partial email address can be entered (eg '@example.com') to match multiple addresses.</div>
+            <div style="margin-top:5px">{% trans "A partial email address can be entered (eg '@example.com') to match multiple addresses." %}</div>
         </form>
     </div>
 

--- a/oscar/templates/oscar/dashboard/promotions/form.html
+++ b/oscar/templates/oscar/dashboard/promotions/form.html
@@ -26,7 +26,7 @@
 
 {% block promotion_form %}
 <div class="table-header">
-    <h2>Content block</h2>
+    <h2>{% trans "Content block" %}</h2>
 </div>
 
 <form action="." method="post" enctype="multipart/form-data" class="well form-stacked wysiwyg">

--- a/oscar/templates/oscar/dashboard/promotions/page_detail.html
+++ b/oscar/templates/oscar/dashboard/promotions/page_detail.html
@@ -50,7 +50,7 @@
                                 <div class="btn-toolbar">
                                     <div class="btn-group">
                                         <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
-                                            Actions
+                                            {% trans "Actions" %}
                                             <span class="caret"></span>
                                         </a>
                                         <ul class="dropdown-menu pull-right">

--- a/oscar/templates/oscar/dashboard/promotions/promotion_list.html
+++ b/oscar/templates/oscar/dashboard/promotions/promotion_list.html
@@ -59,7 +59,7 @@
                             <div class="btn-toolbar">
                                 <div class="btn-group">
                                     <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
-                                        Actions
+                                        {% trans "Actions" %}
                                         <span class="caret"></span>
                                     </a>
                                     <ul class="dropdown-menu pull-right">

--- a/oscar/templates/oscar/dashboard/ranges/messages/range_products_saved.html
+++ b/oscar/templates/oscar/dashboard/ranges/messages/range_products_saved.html
@@ -6,13 +6,13 @@
 
 <ul>
     {% if upload.num_new_skus %}
-    <li><strong>{{ upload.num_new_skus }}</strong> products added</li>
+    <li>{% blocktrans %}<strong>{{ upload.num_new_skus }}</strong> products added{% endblocktrans %}</li>
     {% endif %}
     {% if upload.num_duplicate_skus %}
-    <li>There were <strong>{{ upload.num_duplicate_skus }}</strong> duplicate products in the file</li>
+    <li>{% blocktrans %}There were <strong>{{ upload.num_duplicate_skus }}</strong> duplicate products in the file{% endblocktrans %}</li>
     {% endif %}
     {% if upload.num_unknown_skus %}
-    <li>There were <strong>{{ upload.num_unknown_skus }}</strong> products in the file that couldn't be found in the catalogue</li>
+    <li>{% blocktrans %}There were <strong>{{ upload.num_unknown_skus }}</strong> products in the file that couldn't be found in the catalogue{% endblocktrans %}</li>
     {% endif %}
 </ul>
 <p>

--- a/oscar/templates/oscar/dashboard/reviews/review_delete.html
+++ b/oscar/templates/oscar/dashboard/reviews/review_delete.html
@@ -31,7 +31,7 @@
 
 {% block dashboard_content %}
     <div class="table-header">
-        <h2>Review</h2>
+        <h2>{% trans "Review" %}</h2>
     </div>
     <form action="." method="post" class="well">
         {% csrf_token %}

--- a/oscar/templates/oscar/dashboard/reviews/review_list.html
+++ b/oscar/templates/oscar/dashboard/reviews/review_list.html
@@ -20,7 +20,7 @@
 
 {% block header %}
     <div class="page-header">
-        <h1>Reviews</h1>
+        <h1>{% trans "Reviews" %}</h1>
     </div>
 {% endblock header %}
 
@@ -77,7 +77,7 @@
                             {% if review.product %}
                                 <a href='{% url 'catalogue:detail' review.product.slug review.product.id %}'>{{ review.product.title }}</a> </td>
                         {% else %}
-                            [Product deleted]
+                            {% trans "[Product deleted]" %}
                         {% endif %}
                         <td>
                             {% if review.user %}

--- a/oscar/templates/oscar/dashboard/users/alerts/delete.html
+++ b/oscar/templates/oscar/dashboard/users/alerts/delete.html
@@ -37,7 +37,7 @@
             {% csrf_token %}
             <div class="form-actions">
                 <p>{% trans "Are you sure that you want to delete this alert?" %}</p>
-                <button type='submit' class="btn btn-large btn-danger">{% trans "Delete" %}</button> or
+                <button type='submit' class="btn btn-large btn-danger">{% trans "Delete" %}</button> {% trans "or" %}
                 <a href="{% url 'dashboard:user-alert-list' %}">{% trans "cancel" %}</a>
             </div>
         </form>

--- a/oscar/templates/oscar/dashboard/users/alerts/list.html
+++ b/oscar/templates/oscar/dashboard/users/alerts/list.html
@@ -74,7 +74,7 @@
                         <div class="btn-toolbar">
                             <div class="btn-group">
                                 <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
-                                    Actions
+                                    {% trans "Actions" %}
                                     <span class="caret"></span>
                                 </a>
                                 <ul class="dropdown-menu pull-right">

--- a/oscar/templates/oscar/dashboard/vouchers/voucher_delete.html
+++ b/oscar/templates/oscar/dashboard/vouchers/voucher_delete.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block title %}
-    {% blocktrans with name=voucher.name %}Delete voucher '{{ name }}'?{% endblocktrans %} | Vouchers | {{ block.super }}
+    {% blocktrans with name=voucher.name %}Delete voucher '{{ name }}'?{% endblocktrans %} | {% trans "Vouchers" %} | {{ block.super }}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/oscar/templates/oscar/dashboard/vouchers/voucher_detail.html
+++ b/oscar/templates/oscar/dashboard/vouchers/voucher_detail.html
@@ -4,7 +4,7 @@
 {% load i18n %}
 
 {% block title %}
-    {% blocktrans with name=voucher.name %}Voucher '{{ name }}'{% endblocktrans %} | Vouchers | {{ block.super }}
+    {% blocktrans with name=voucher.name %}Voucher '{{ name }}'{% endblocktrans %} | {% trans "Vouchers" %} | {{ block.super }}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/oscar/templates/oscar/partials/image_input_widget.html
+++ b/oscar/templates/oscar/partials/image_input_widget.html
@@ -1,9 +1,9 @@
 {% load i18n %}
 <div id="{{ image_id }}" class="image-input">
     {% if image_url %}
-    <img src="{{ image_url }}" alt="thumbnail" />
+    <img src="{{ image_url }}" alt="{% trans "thumbnail" %}" />
     {% else %}
-    <img alt="thumbnail"
+    <img alt="{% trans "thumbnail" %}"
         onload="jQuery(this).next().hide()"
         onerror="jQuery(this).next().show(); alert('{% trans 'Unrecognized image type!' %}')" />
     <button class="btn btn-primary">{% trans "Upload Image" %}</button>

--- a/oscar/templates/oscar/partials/nav_accounts.html
+++ b/oscar/templates/oscar/partials/nav_accounts.html
@@ -21,7 +21,7 @@
                             <option value="{{ language.0 }}" {% if LANGUAGE_CODE == language.0 %}selected="selected"{% endif %}>{{ language.1 }}</option>
                             {% endfor %}
                         </select>
-                        <button class="btn" type="submit">Go</button>
+                        <button class="btn" type="submit">{% trans "Go" %}</button>
                     </form>
                 {% endif %}
                 <ul class="nav pull-right">

--- a/oscar/templates/oscar/promotions/default.html
+++ b/oscar/templates/oscar/promotions/default.html
@@ -10,7 +10,7 @@
 <li>
     <a href="{{ product.get_absolute_url }}">{{ product.get_title }}</a><br/>
     {% if product.is_group %}
-        From {{ product.min_variant_price_incl_tax|currency }}
+        {% blocktrans with price=product.min_variant_price_incl_tax|currency %}From {{ price }}{% endblocktrans %}
     {% else %}
         {% if product.has_stockrecord %} 
             {{ product.stockrecord.price_incl_tax|currency }}<br/>

--- a/sites/demo/templates/basket/partials/basket_content.html
+++ b/sites/demo/templates/basket/partials/basket_content.html
@@ -97,7 +97,7 @@
         <div>
             <a href="https://www.verisign.com.au" target="_blank" title="https://www.verisign.com.au"><i class="verisign"></i></a>
             <span>{% trans "We accept" %} <br><i class="credit-cards"></i></span>
-            <a href="{% url checkout:index %}" class="btn btn-large btn-primary">Proceed to checkout</a>
+            <a href="{% url checkout:index %}" class="btn btn-large btn-primary">{% trans "Proceed to checkout" %}</a>
         </div>
         <strong>{% trans "or" %}</strong>
         <a href="{% url paypal-redirect %}"><img src="https://www.paypal.com/en_US/i/btn/btn_xpressCheckout.gif"></a>

--- a/sites/demo/templates/catalogue/detail.html
+++ b/sites/demo/templates/catalogue/detail.html
@@ -90,7 +90,7 @@
                                         <form action="{% url basket:add %}" method="post" class="form-inline">
                                             {% csrf_token %}
                                             {% include "partials/form_fields_inline.html" with form=basket_form %}
-                                            <button type="submit" class="btn btn-primary" value="Add to basket">Add to bag</button>
+                                            <button type="submit" class="btn btn-primary" value="Add to basket">{% trans "Add to bag" %}</button>
                                         </form>
                                         <span itemprop="availability" content="in_stock"></span>
                                         {% else %}

--- a/sites/demo/templates/catalogue/partials/variant_stock_record.html
+++ b/sites/demo/templates/catalogue/partials/variant_stock_record.html
@@ -5,5 +5,5 @@
         {{ product.stockrecord.price_incl_tax|currency }}
     </p>
 {% else %}
-   <p class="price_color">Not available</p>
+   <p class="price_color">{% trans "Not available" %}</p>
 {% endif %}

--- a/sites/demo/templates/checkout/payment_details.html
+++ b/sites/demo/templates/checkout/payment_details.html
@@ -3,11 +3,11 @@
 
 {% block payment_details %}
     <div class="page-header">
-        <h1>Enter payment details</h1>
+        <h1>{% trans "Enter payment details" %}</h1>
     </div>
 
     {% block payment_details_content %}
-    <h3>Pay with a bankcard</h3>
+    <h3>{% trans "Pay with a bankcard" %}</h3>
     <form action="{% url checkout:preview %}" class="form-horizontal" method="post">
         <div class="well well-info">
             {% csrf_token %}

--- a/sites/demo/templates/checkout/shipping_address.html
+++ b/sites/demo/templates/checkout/shipping_address.html
@@ -11,7 +11,7 @@
     {% if request.user.is_authenticated %}
         {% if addresses %}
         <div class="span6">   
-            <h3>An address from your addressbook?</h3>
+            <h3>{% trans "An address from your addressbook?" %}</h3>
             <div class="choose-block">
                 <ul>
                     {% for address in addresses %}

--- a/sites/demo/templates/checkout/user_address_delete.html
+++ b/sites/demo/templates/checkout/user_address_delete.html
@@ -4,7 +4,7 @@
 
 {% block shipping_address %}
 <div class="page-header">
-    <h1>Delete address?</h1>
+    <h1>{% trans "Delete address?" %}</h1>
 </div>
 <form action="." method="post" class="well">
     {% csrf_token %}

--- a/sites/demo/templates/partials/footer.html
+++ b/sites/demo/templates/partials/footer.html
@@ -29,7 +29,7 @@
     </div>
     <div class="footer-disclaimer">
         <div class="container-fluid">
-            <a href="#" class="pull-right">Site by Tangent Snowball Australia</a>
+            <a href="#" class="pull-right">{% trans "Site by Tangent Snowball Australia" %}</a>
             <p>
                 <a href="https://www.verisign.com.au" title="https://www.verisign.com.au" target="_blank"><i class="verisign"></i></a>
                 <i class="credit-cards"></i>

--- a/sites/demo/templates/partials/nav_accounts.html
+++ b/sites/demo/templates/partials/nav_accounts.html
@@ -20,7 +20,7 @@
                                 <option value="{{ language.0 }}" {% if LANGUAGE_CODE == language.0 %}selected="selected"{% endif %}>{{ language.1 }}</option>
                                 {% endfor %}
                             </select>
-                            <button class="btn" type="submit">Go</button>
+                            <button class="btn" type="submit">{% trans "Go" %}</button>
                         </form>
                     {% endif %}
                     <ul class="nav pull-right">

--- a/sites/demo/templates/partials/nav_primary.html
+++ b/sites/demo/templates/partials/nav_primary.html
@@ -32,7 +32,7 @@
                                     <li><a tabindex="-1" href="{{ subcategory.0.get_absolute_url }}"> {{ subcategory.0.name }} <i class="icon-arrow-right"></i></a></li>
                                 {% endfor %}
                                 <li class="divider"></li>
-                                <li><a tabindex="-1" href="{{ category.0.get_absolute_url }}">All {{ category.0.name }} <i class="icon-arrow-right"></i></a></li>
+                                <li><a tabindex="-1" href="{{ category.0.get_absolute_url }}">{% blocktrans %}All {{ category.0.name }}{% endblocktrans %} <i class="icon-arrow-right"></i></a></li>
                             </ul>
                         {% else %}
                             <a tabindex="-1" href="{{ category.0.get_absolute_url }}">{{ category.0.name }}</a>

--- a/sites/demo/templates/shipping/express.html
+++ b/sites/demo/templates/shipping/express.html
@@ -1,8 +1,9 @@
 {% load currency_filters %}
+{% load i18n %}
+{% blocktrans with cost=1.50%}
 This is express shipping.  Should reach you within 48 hours.
 
 <p>
-    {% with cost=1.50 %}
     It costs {{ cost|currency }} per item.
-    {% endwith %}
 </p>
+{% endblocktrans %}

--- a/sites/demo/templates/shipping/standard.html
+++ b/sites/demo/templates/shipping/standard.html
@@ -1,9 +1,10 @@
 {% load currency_filters %}
+{% load i18n %}
+{% blocktrans with cost=0.99 total=12.00 %}
 This is standard shipping.
 
 <p>
-    {% with cost=0.99 total=12.00 %}
     It costs {{ cost|currency }} per item but is free for orders over
     {{ total|currency }}.
-    {% endwith %}
 </p>
+{% endblocktrans %}

--- a/sites/sandbox/templates/gateway/email.txt
+++ b/sites/sandbox/templates/gateway/email.txt
@@ -1,3 +1,5 @@
+{% load i18n %}
+{% blocktrans %}
 A dashboard user has been created for you with credentials:
 
 - Email: {{ email }}
@@ -11,3 +13,4 @@ public-facing pages.
 
 Best wishes,
 Oscar Team, Tangent Labs
+{% endblocktrans %}

--- a/sites/sandbox/templates/gateway/form.html
+++ b/sites/sandbox/templates/gateway/form.html
@@ -1,17 +1,17 @@
 {% extends 'layout.html' %}
 
 {% block headertext %}
-Dashboard access
+{% trans "Dashboard access" %}
 {% endblock %}
 
 {% block content %}
 
 <form action="." method="post">
-	<p>Let us know your email address and we'll create a dashboard user for you and email you
-	the details.</p>
+	<p>{% trans "Let us know your email address and we'll create a dashboard user for you and email you
+	the details." %}</p>
 	{% csrf_token %}
 	{% include 'partials/form_fields.html' with form=form %}
-	<button type="submit" class="btn btn-large btn-primary">Send email</button>
+	<button type="submit" class="btn btn-large btn-primary">{% trans "Send email" %}</button>
 </form>
 
 {% endblock %}

--- a/tests/_site/templates/base.html
+++ b/tests/_site/templates/base.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="{% block language %}en-gb{% endblock %}">
     <head>
-        <title>{% block title %}Oscar :: Flexible ecommerce for Django{% endblock %}</title>
+        <title>{% block title %}{% trans "Oscar :: Flexible ecommerce for Django" %}{% endblock %}</title>
         <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
         <meta name="created" content='{% now "jS M Y h:i" %}' />
         <meta name="description" content="{% block description %}{% endblock %}" />

--- a/tests/_site/templates/layout.html
+++ b/tests/_site/templates/layout.html
@@ -7,22 +7,22 @@
 {% block layout %}
     <div id="container">
         <div id="header">
-            <p><a href="{% url promotions:home %}">Oscar // Flexible e-commerce for Django</a></p>
+            <p><a href="{% url promotions:home %}">{% trans "Oscar // Flexible e-commerce for Django" %}</a></p>
 
             <form method="get" action="{% url search:search %}">
                 {{ search_form.as_p }}
-                <input type="submit" value="Go!" />
+                <input type="submit" value="{% trans "Go!" %}" />
             </form>
 
             {% if user.is_authenticated %}
-                <a href="{% url customer:summary %}">Profile</a>
-                <a href="{% url customer:logout %}">Logout</a>
+                <a href="{% url customer:summary %}">{% trans "Profile" %}</a>
+                <a href="{% url customer:logout %}">{% trans "Logout" %}</a>
             {% else %}
-                <a href="{% url customer:login %}">Login</a>
+                <a href="{% url customer:login %}">{% trans "Login" %}</a>
             {% endif %}
 
-            Basket total: {{ basket.total_incl_tax|currency }}
-            <a href="{% url basket:summary %}">View basket</a>
+            {% blocktrans with total=basket.total_incl_tax|currency %}Basket total: {{ total }}{% endblocktrans %}
+            <a href="{% url basket:summary %}">{% trans "View basket" %}</a>
 
 			{% category_tree depth=2 as categories %}
 


### PR DESCRIPTION
Review can be automated using https://github.com/rory/django-template-i18n-lint 

It doesn't do recursive search, so

```
find . -name '*.html' -o -name '*.txt' | xargs -I {} ./django-template-i18n-lint.py {}
```

does the trick. It finds quite a few false positives, but there's still at least a dozen unmarked strings in there. 
