### PR TITLE
Form field templates refactoring

### DIFF
--- a/oscar/templates/oscar/partials/form_field.html
+++ b/oscar/templates/oscar/partials/form_field.html
@@ -1,45 +1,33 @@
-{% load form_tags %}
-
-{% comment %}
-Make the field widget type available to templates so we can mark-up
-checkboxes differently to other widgets.
-{% endcomment %}
-{% annotate_form_field field %}
-
+{% block control-group %}
 <div class="control-group {% if field.errors %}error{% endif %}">
-    {% if field.is_hidden %}
-        {{ field }}
-    {% else %}
-        {# Check if field is a checkbox as we mark these up differently #}
-        {% if field.widget_type == 'CheckboxInput' %}
-            <div class="controls">
-            <label for="{{ field.auto_id }}" class="checkbox {% if field.field.required %}required{% endif %}">{{ field.label }}{% if field.field.required %} <span>*</span>{% endif %}
-                    {{ field }}
-                </label>
-                {% for error in field.errors %}
-                    <span class="help-block"><i class="icon-exclamation-sign"></i> {{ error }}</span>
-                {% endfor %}
-                {% if field.help_text %}
-                    <span class='help-block'>
-                        {# We allow HTML within form help fields #}
-                        {{ field.help_text|safe }}
-                    </span>
-                {% endif %}
-            </div>
-        {% else %}
-            <label for="{{ field.auto_id }}" class="control-label {% if field.field.required %}required{% endif %}">{{ field.label }}{% if field.field.required %} <span>*</span>{% endif %}</label>
-            <div class="controls">
+    {% block label %}
+        <label for="{{ field.auto_id }}"
+            class="control-label{% if field.field.required %} required{% endif %}">
+            {{ field.label }}
+            {% if field.field.required %} <span>*</span>{% endif %}
+        </label>
+    {% endblock %}
+    {% block controls %}
+        <div class="controls">
+            {% block widget %}
                 {{ field }}
+            {% endblock %}
+
+            {% block errors %}
                 {% for error in field.errors %}
                     <span class="help-block"><i class="icon-exclamation-sign"></i> {{ error }}</span>
                 {% endfor %}
+            {% endblock %}
+
+            {% block help_text %}
                 {% if field.help_text %}
                     <span class='help-block'>
                         {# We allow HTML within form help fields #}
                         {{ field.help_text|safe }}
                     </span>
                 {% endif %}
-            </div>
-        {% endif %}
-    {% endif %}
+            {% endblock %}
+        </div>
+    {% endblock %}
 </div>
+{% endblock %}

--- a/oscar/templates/oscar/partials/form_field_checkbox.html
+++ b/oscar/templates/oscar/partials/form_field_checkbox.html
@@ -1,0 +1,11 @@
+{% extends "partials/form_field.html" %}
+
+{% block label %}{% endblock %}
+
+{% block widget %}
+    <label for="{{ field.auto_id }}"
+            class="checkbox {% if field.field.required %}required{% endif %}">
+        {{ field.label }}{% if field.field.required %} <span>*</span>{% endif %}
+        {{ field }}
+    </label>
+{% endblock %}

--- a/oscar/templates/oscar/partials/form_fields.html
+++ b/oscar/templates/oscar/partials/form_fields.html
@@ -1,3 +1,5 @@
+{% load form_tags %}
+
 <span class="help-block">{{ form.non_field_errors }}</span>
 {% for field in form.hidden_fields %}
     {{ field }}
@@ -7,5 +9,16 @@
         We use a separate template for each field so that forms can be rendered
         field-by-field easily #}
     {% endcomment %}
-    {% include 'partials/form_field.html' with field=field %}
+
+    {% comment %}
+    Make the field widget type available to templates so we can mark-up
+    checkboxes differently to other widgets.
+    {% endcomment %}
+    {% annotate_form_field field %}
+
+    {% if field.widget_type == 'CheckboxInput' %}
+        {% include 'partials/form_field_checkbox.html' with field=field %}
+    {% else %}
+        {% include 'partials/form_field.html' with field=field %}
+    {% endif %}
 {% endfor %}


### PR DESCRIPTION
Check issue: https://github.com/tangentlabs/django-oscar/issues/659

Allow to extend form field template and reuse existing blocks Avoid
duplicated code in checkbox input template
