### PR TITLE
Run tox tests in parallel with detox

### DIFF
--- a/docs/source/internals/contributing/running-tests.rst
+++ b/docs/source/internals/contributing/running-tests.rst
@@ -32,14 +32,17 @@ To run an individual test, use one of::
 Testing against different setups
 --------------------------------
 
-To run all tests against multiple versions of Django and Python, use tox_::
+To run all tests against multiple versions of Django and Python, use detox_::
 
-    $ tox
+    $ detox
 
 You need to have all Python interpreters to test against installed on your 
 system. All other requirements are downloaded automatically.
+detox_ is a wrapper around tox_, creating the environments and running the tests
+in parallel. This greatly speeds up the process.
 
 .. _tox: http://tox.readthedocs.org/en/latest/
+.. _detox: https://pypi.python.org/pypi/detox
 
 Kinds of tests
 --------------

--- a/docs/source/releases/v0.6.rst
+++ b/docs/source/releases/v0.6.rst
@@ -82,6 +82,14 @@ Order processing changes
 
 There are changes to order processing methods
 
+Minor changes
+~~~~~~~~~~~~~
+
+* detox_ is a new dependency, which allows running `tox` tests in parallel.
+
+.. _detox: https://pypi.python.org/pypi/detox
+
+
 Upgrading 
 =========
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ nose-progressive>=1.5,<1.6
 spec>=0.11.1,<0.12
 WebTest>=2.0,<2.1
 django-webtest>=1.5.7,<1.6
-tox>=1.4.3,<1.5
+detox==0.9.2
 coveralls>=0.1.1,<0.2
 purl>=0.4
 


### PR DESCRIPTION
I always thought the tox tests are too slow to be of much use. [detox](https://pypi.python.org/pypi/detox) runs both creating the environment and running the tests in parallel, makings things go zoom.
