### PR TITLE
Changing data migration to act on frozen orm model instead of using call_command

### DIFF
--- a/oscar/apps/catalogue/migrations/0010_call_update_product_ratings.py
+++ b/oscar/apps/catalogue/migrations/0010_call_update_product_ratings.py
@@ -7,8 +7,8 @@ from django.db import models
 class Migration(DataMigration):
 
     def forwards(self, orm):
-        from django.core.management import call_command
-        call_command('oscar_update_product_ratings')
+        for product in orm['catalogue.Product'].objects.all():
+            product.update_rating()
 
     def backwards(self, orm):
         # rating field will be deleted anyway if migrating backwards


### PR DESCRIPTION
call_command doesn't work nicely within migrations as it does not enforce the use of the frozen orm.

In this particular instance the logic needed is trivial so it is moved directly into the migration.

Fixes issue #772
