### PR TITLE
Updated dependencies for south migrations

### DIFF
--- a/oscar/apps/address/migrations/0001_initial.py
+++ b/oscar/apps/address/migrations/0001_initial.py
@@ -7,7 +7,7 @@ from django.db import models
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
-        
+
         # Adding model 'UserAddress'
         db.create_table('address_useraddress', (
             ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
@@ -47,7 +47,7 @@ class Migration(SchemaMigration):
 
 
     def backwards(self, orm):
-        
+
         # Deleting model 'UserAddress'
         db.delete_table('address_useraddress')
 

--- a/oscar/apps/basket/migrations/0001_initial.py
+++ b/oscar/apps/basket/migrations/0001_initial.py
@@ -8,6 +8,7 @@ class Migration(SchemaMigration):
     depends_on = (
         ('catalogue', '0001_initial'),
         ('voucher', '0001_initial'),
+        ('offer', '0001_initial'),
     )
 
     def forwards(self, orm):

--- a/oscar/apps/customer/migrations/0003_auto__add_productalert.py
+++ b/oscar/apps/customer/migrations/0003_auto__add_productalert.py
@@ -6,6 +6,10 @@ from django.db import models
 
 class Migration(SchemaMigration):
 
+    depends_on = (
+        ('catalogue', '0001_initial'),
+    )
+
     def forwards(self, orm):
 
         # Adding model 'ProductAlert'

--- a/oscar/apps/dashboard/ranges/migrations/0001_initial.py
+++ b/oscar/apps/dashboard/ranges/migrations/0001_initial.py
@@ -6,6 +6,11 @@ from django.db import models
 
 class Migration(SchemaMigration):
 
+    depends_on = (
+        ('catalogue', '0001_initial'),
+        ('offer', '0001_initial'),
+    )
+
     def forwards(self, orm):
 
         # Adding model 'RangeProductFileUpload'

--- a/oscar/apps/partner/migrations/0001_initial.py
+++ b/oscar/apps/partner/migrations/0001_initial.py
@@ -6,6 +6,10 @@ from django.db import models
 
 class Migration(SchemaMigration):
 
+    depends_on = (
+        ('catalogue', '0001_initial'),
+    )
+
     def forwards(self, orm):
         
         # Adding model 'Partner'

--- a/oscar/apps/payment/migrations/0001_initial.py
+++ b/oscar/apps/payment/migrations/0001_initial.py
@@ -6,8 +6,11 @@ from django.db import models
 
 class Migration(SchemaMigration):
 
+    depends_on = (
+        ('order', '0001_initial'),
+    )
+
     def forwards(self, orm):
-        
         # Adding model 'Transaction'
         db.create_table('payment_transaction', (
             ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
@@ -56,7 +59,7 @@ class Migration(SchemaMigration):
 
 
     def backwards(self, orm):
-        
+
         # Deleting model 'Transaction'
         db.delete_table('payment_transaction')
 

--- a/oscar/apps/promotions/migrations/0001_initial.py
+++ b/oscar/apps/promotions/migrations/0001_initial.py
@@ -6,6 +6,10 @@ from django.db import models
 
 class Migration(SchemaMigration):
 
+    depends_on = (
+        ('catalogue', '0001_initial'),
+    )
+
     def forwards(self, orm):
         
         # Adding model 'PagePromotion'

--- a/oscar/apps/shipping/migrations/0005_auto.py
+++ b/oscar/apps/shipping/migrations/0005_auto.py
@@ -7,6 +7,10 @@ from django.db import models
 
 class Migration(SchemaMigration):
 
+    depends_on = (
+        ('address', '0001_initial'),
+    )
+
     def forwards(self, orm):
         # Adding M2M table for field countries on 'OrderAndItemCharges'
         db.create_table('shipping_orderanditemcharges_countries', (

--- a/oscar/apps/voucher/migrations/0001_initial.py
+++ b/oscar/apps/voucher/migrations/0001_initial.py
@@ -7,6 +7,7 @@ from django.db import models
 class Migration(SchemaMigration):
     depends_on = (
         ('offer', '0001_initial'),
+        ('order', '0001_initial'),
     )
 
     def forwards(self, orm):


### PR DESCRIPTION
Working on [django-oscar-fancypages](https://github.com/tangentlabs/django-oscar-fancypages) I had some issues with not specifying the migration dependencies correctly. Fixing this caused some issues with Oscar's migrations because it was missing `depends_on` declarations. I went through and (hopefully) fix all the missing dependencies.

I ran a fresh database setup with the new migrations and it all ran through fine so it doesn't seem to have introduced any issues. Let's see what Travis says :wink: 

This might also fix #551. 

In case you are interested, the current dependency graph (incl. the changes in this PR) looks like this:

![migrations](https://f.cloud.github.com/assets/1236629/876691/08d3c72a-f8d7-11e2-9a60-45cb3b169272.png)

Generated using: `./manage.py graphmigrations | dot -Tpng -omigrations.png`
