### PR TITLE
Different start time of offer when editing and on detail page

### DIFF
--- a/oscar/apps/dashboard/orders/views.py
+++ b/oscar/apps/dashboard/orders/views.py
@@ -7,14 +7,14 @@ from django.core.urlresolvers import reverse
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models.loading import get_model
 from django.db.models import fields, Q, Sum, Count
-from django.http import HttpResponse, HttpResponseRedirect, Http404
+from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
-from django.template.defaultfilters import date as format_date
 from django.utils.datastructures import SortedDict
 from django.views.generic import ListView, DetailView, UpdateView, FormView
 from django.conf import settings
 
 from oscar.core.loading import get_class
+from oscar.core.utils import format_datetime
 from oscar.apps.dashboard.orders import forms
 from oscar.views.generic import BulkEditMixin
 from oscar.apps.dashboard.reports.csv_utils import CsvUnicodeWriter
@@ -131,13 +131,13 @@ class OrderListView(ListView, BulkEditMixin):
 
         if data['date_from'] and data['date_to']:
             desc_ctx['date_filter'] = _(" placed between %(start_date)s and %(end_date)s") % {
-                'start_date': format_date(data['date_from']),
-                'end_date': format_date(data['date_to'])}
+                'start_date': format_datetime(data['date_from']),
+                'end_date': format_datetime(data['date_to'])}
         elif data['date_from']:
-            desc_ctx['date_filter'] = _(" placed since %s") % format_date(data['date_from'])
+            desc_ctx['date_filter'] = _(" placed since %s") % format_datetime(data['date_from'])
         elif data['date_to']:
             date_to = data['date_to'] + datetime.timedelta(days=1)
-            desc_ctx['date_filter'] = _(" placed before %s") % format_date(data['date_to'])
+            desc_ctx['date_filter'] = _(" placed before %s") % format_datetime(data['date_to'])
 
         if data['voucher']:
             desc_ctx['voucher_filter'] = _(" using voucher '%s'") % data['voucher']
@@ -286,7 +286,7 @@ class OrderListView(ListView, BulkEditMixin):
             row = columns.copy()
             row['number'] = order.number
             row['value'] = order.total_incl_tax
-            row['date'] = format_date(order.date_placed, 'DATETIME_FORMAT')
+            row['date'] = format_datetime(order.date_placed, 'DATETIME_FORMAT')
             row['num_items'] = order.num_items
             row['status'] = order.status
             row['customer'] = order.email

--- a/oscar/apps/dashboard/reports/reports.py
+++ b/oscar/apps/dashboard/reports/reports.py
@@ -1,7 +1,8 @@
-from django.template.defaultfilters import date
 from django.http import HttpResponse
 from django.utils.translation import ugettext_lazy as _
+
 from oscar.apps.dashboard.reports.csv_utils import CsvUnicodeWriter
+from oscar.core import utils
 
 
 class ReportGenerator(object):
@@ -46,10 +47,10 @@ class ReportGenerator(object):
 
 class ReportFormatter(object):
     def format_datetime(self, dt):
-        return date(dt, 'DATETIME_FORMAT')
+        return utils.format_datetime(dt, 'DATETIME_FORMAT')
 
     def format_date(self, d):
-        return date(d, 'DATE_FORMAT')
+        return utils.format_datetime(d, 'DATE_FORMAT')
 
     def filename(self):
         return self.filename_template

--- a/oscar/apps/dashboard/reviews/views.py
+++ b/oscar/apps/dashboard/reviews/views.py
@@ -5,10 +5,10 @@ from django.db.models import get_model, Q
 from django.utils.translation import ugettext_lazy as _
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
-from django.template.defaultfilters import date as format_date
 
 from oscar.views.generic import BulkEditMixin
 from oscar.apps.dashboard.reviews import forms
+from oscar.core.utils import format_datetime
 
 ProductReview = get_model('reviews', 'productreview')
 
@@ -52,17 +52,17 @@ class ReviewListView(generic.ListView, BulkEditMixin):
                 date_created__lt=date_to
             )
             self.desc_ctx['date_filter'] = _(" created between %(start_date)s and %(end_date)s") % {
-                'start_date': format_date(date_from),
-                'end_date': format_date(date_to)
+                'start_date': format_datetime(date_from),
+                'end_date': format_datetime(date_to)
             }
         elif date_from:
             queryset = queryset.filter(date_created__gte=date_from)
-            self.desc_ctx['date_filter'] =  _(" created after %s") % format_date(date_from)
+            self.desc_ctx['date_filter'] =  _(" created after %s") % format_datetime(date_from)
         elif date_to:
             # Add 24 hours to make search inclusive
             date_to = date_to + datetime.timedelta(days=1)
             queryset = queryset.filter(date_created__lt=date_to)
-            self.desc_ctx['date_filter'] = _(" created before %s") % format_date(date_to)
+            self.desc_ctx['date_filter'] = _(" created before %s") % format_datetime(date_to)
 
         return queryset
 

--- a/oscar/apps/offer/models.py
+++ b/oscar/apps/offer/models.py
@@ -2,9 +2,9 @@ from decimal import Decimal as D, ROUND_DOWN, ROUND_UP
 
 from django.core import exceptions
 from django.db.models import get_model
-from django.template.defaultfilters import date
+from django.template.defaultfilters import date as date_filter
 from django.db import models
-from django.utils.timezone import now
+from django.utils.timezone import now, get_current_timezone
 from django.utils.translation import ungettext, ugettext as _
 from django.utils.importlib import import_module
 from django.core.exceptions import ValidationError
@@ -332,26 +332,27 @@ class ConditionalOffer(models.Model):
                 'description': desc,
                 'is_satisfied': True})
 
-        def format_datetime(dt):
+        def hide_time_if_zero(dt):
             # Only show hours/minutes if they have been specified
-            if dt.hour == 0 and dt.minute == 0:
-                return date(dt, settings.DATE_FORMAT)
-            return date(dt, settings.DATETIME_FORMAT)
+            localtime = dt.astimezone(get_current_timezone())
+            if localtime.hour == 0 and localtime.minute == 0:
+                return date_filter(localtime, settings.DATE_FORMAT)
+            return date_filter(localtime, settings.DATETIME_FORMAT)
 
         if self.start_datetime or self.end_datetime:
             today = now()
             if self.start_datetime and self.end_datetime:
                 desc = _("Available between %(start)s and %(end)s") % {
-                        'start': format_datetime(self.start_datetime),
-                        'end': format_datetime(self.end_datetime)}
+                        'start': hide_time_if_zero(self.start_datetime),
+                        'end': hide_time_if_zero(self.end_datetime)}
                 is_satisfied = self.start_datetime <= today <= self.end_datetime
             elif self.start_datetime:
                 desc = _("Available from %(start)s") % {
-                    'start': format_datetime(self.start_datetime)}
+                    'start': hide_time_if_zero(self.start_datetime)}
                 is_satisfied = today >= self.start_datetime
             elif self.end_datetime:
                 desc = _("Available until %(end)s") % {
-                    'end': format_datetime(self.end_datetime)}
+                    'end': hide_time_if_zero(self.end_datetime)}
                 is_satisfied = today <= self.end_datetime
             restrictions.append({
                 'description': desc,

--- a/oscar/core/utils.py
+++ b/oscar/core/utils.py
@@ -1,5 +1,10 @@
+from __future__ import absolute_import  # for import below
+import logging
+
+from django.utils.timezone import get_current_timezone, is_naive, make_aware
 from unidecode import unidecode
 from django.conf import settings
+from django.template.defaultfilters import date as date_filter
 
 
 def slugify(value):
@@ -48,3 +53,24 @@ def compose(*functions):
                 args = fn(args)
         return args
     return _composed
+
+
+
+def format_datetime(dt, format=None):
+    """
+    Takes an instance of datetime, converts it to the current timezone and
+    formats it as a string. Use this instead of
+    django.core.templatefilters.date, which expects localtime.
+
+    :param format: Common will be settings.DATETIME_FORMAT or
+                   settings.DATE_FORMAT, or the resp. shorthands
+                   ('DATETIME_FORMAT', 'DATE_FORMAT')
+    """
+    if is_naive(dt):
+        localtime = make_aware(dt, get_current_timezone())
+        logging.warning(
+            "oscar.core.utils.format_datetime received native datetime")
+    else:
+        localtime = dt.astimezone(get_current_timezone())
+    return date_filter(localtime, format)
+


### PR DESCRIPTION
Start time on detail page of the offer:
![Detail page](https://f.cloud.github.com/assets/98588/811173/201b0fac-eecc-11e2-9df6-71dea3a05d77.png)

Start time when editing the offer
![Editing](https://f.cloud.github.com/assets/98588/811174/203c7f0c-eecc-11e2-8c05-a10e5c18e1b3.png)

Times should be the same. Difference is probably caused by time difference between BST and GMT (which is +1 hour).
