### PR TITLE
add |safe to shipping_method.description, as it done in shipping_methods...

### DIFF
--- a/oscar/templates/oscar/checkout/checkout.html
+++ b/oscar/templates/oscar/checkout/checkout.html
@@ -60,7 +60,7 @@
                         <h4>{% trans "Shipping method" %}</h4>
                         <p>{{ shipping_method.name }}
                             {% if shipping_method.description %}
-                                - {{ shipping_method.description }}
+                                - {{ shipping_method.description|safe }}
                             {% endif %}
                         </p>
 
@@ -86,7 +86,7 @@
                     <div class="alert-actions">
                         <a href="{% url 'checkout:payment-details' %}" class="btn">{% trans "Change payment details" %}</a>
                     </div>
-                </div>    
+                </div>
             </div>
         {% endblock payment_method %}
     </div>
@@ -121,7 +121,7 @@
                     </div>
                     <div class="span2 align-right">
                         <p class="price_color">{{ line.line_price_incl_tax|currency }}</p>
-                    </div>        
+                    </div>
                 </div>
             </div>
         {% endfor %}


### PR DESCRIPTION
....html

shipping_method.description can contain html tags. In [shipping_methods.html](https://github.com/tangentlabs/django-oscar/blob/master/oscar/templates/oscar/checkout/shipping_methods.html#L36) it is respected, and in [checkout.html](https://github.com/tangentlabs/django-oscar/blob/master/oscar/templates/oscar/checkout/checkout.html#L63) it is not.
