### PR TITLE
fix template references in basket_quick.html

### DIFF
--- a/oscar/templates/oscar/basket/partials/basket_quick.html
+++ b/oscar/templates/oscar/basket/partials/basket_quick.html
@@ -14,7 +14,7 @@
                 <div class="image_container">
                 {% with image=line.product.primary_image %}
                     {% thumbnail image.original "100x100" upscale=False as thumb %}
-                    <a href="{{ form.instance.product.get_absolute_url }}"><img class="thumbnail" src="{{ thumb.url }}" alt="{{ product.get_title }}"></a>
+                    <a href="{{ line.product.get_absolute_url }}"><img class="thumbnail" src="{{ thumb.url }}" alt="{{ line.product.get_title }}"></a>
                     {% endthumbnail %}
                 {% endwith %}
                 </div>


### PR DESCRIPTION
Use `{{ line.product.get_absolute_url }}` instead of `{{ form.instance.product.get_absolute_url }}`.
Use `{{ line.product.get_title }}` instead of `{{ product.get_title }}`
