### PR TITLE
Missing pysqlite requirement for sandbox installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ Werkzeug>=0.8.3,<0.9
 
 # Sandbox
 Whoosh>=2.4.1,<2.5
+pysqlite==2.6.3
 
 # Docs
 Sphinx>=1.1.3,<1.2


### PR DESCRIPTION
Trying to install the django-scar sandbox will not work out of the box unless you manually run the following on your virtualenv
`pip install pysqlite`
