### PR TITLE
Added check for variant stockrecord

### DIFF
--- a/oscar/apps/catalogue/abstract_models.py
+++ b/oscar/apps/catalogue/abstract_models.py
@@ -383,7 +383,7 @@ class AbstractProduct(models.Model):
             # If any one of this product's variants is available, then we treat
             # this product as available.
             for variant in self.variants.select_related('stockrecord').all():
-                if variant.is_available_to_buy:
+                if variant.stockrecord and variant.is_available_to_buy:
                     return True
             return False
         if not self.get_product_class().track_stock:


### PR DESCRIPTION
Missing the check causes the is_available_to_buy method to return
false when a variant has no stock record, even when other variants have
stock.

This makes a product unpurchasable even though it may have stock for other variants.
