### PR TITLE
Remove hard-wired logout URL

### DIFF
--- a/oscar/apps/customer/views.py
+++ b/oscar/apps/customer/views.py
@@ -2,7 +2,7 @@ from django.shortcuts import get_object_or_404
 from django.views.generic import (TemplateView, ListView, DetailView,
                                   CreateView, UpdateView, DeleteView,
                                   FormView, RedirectView)
-from django.core.urlresolvers import reverse
+from django.core.urlresolvers import reverse, reverse_lazy
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import HttpResponseRedirect, Http404
 from django.contrib import messages
@@ -39,7 +39,7 @@ User = get_user_model()
 
 
 class LogoutView(RedirectView):
-    url = '/'
+    url = reverse_lazy('promotions:home')
     permanent = False
 
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
If Oscar is installed at a different URI prefix (e.g. `/shop/`), logout does not redirect to correct URI (i.e. redirection to `/` instead of `/shop/`).
