### PR TITLE
Remove hard-wired '/' URLs from templates

### DIFF
--- a/oscar/templates/oscar/checkout/thank_you.html
+++ b/oscar/templates/oscar/checkout/thank_you.html
@@ -206,7 +206,7 @@
 
     <div class="form-actions">
         <a onclick="window.print()" href="#" class="btn btn-primary btn-large">{% trans "Print this page" %}</a>
-        <a href="/" class="btn btn-primary btn-large pull-right">{% trans "Continue shopping" %}</a>
+        <a href="{% url 'promotions:home' %}" class="btn btn-primary btn-large pull-right">{% trans "Continue shopping" %}</a>
     </div>
 {% endblock content %}
 

--- a/oscar/templates/oscar/error.html
+++ b/oscar/templates/oscar/error.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load url from future %}
 {% load i18n %}
 
 {% block layout %}
@@ -10,7 +11,7 @@
         {% block error_message %}{% endblock %}
         <p>
             <a class="btn btn-primary btn-large" onclick="javascript:history.go(-1);">{% trans 'Return to previous page' %}</a>
-            <a class="btn btn-primary btn-large" href="/">{% trans "Go to homepage" %}</a>
+            <a class="btn btn-primary btn-large" href="{% url 'promotions:home' %}">{% trans "Go to homepage" %}</a>
         </p>
     </div>
 </div>

--- a/oscar/templates/oscar/partials/nav_checkout.html
+++ b/oscar/templates/oscar/partials/nav_checkout.html
@@ -22,7 +22,7 @@
                             </li>
                         {% endfor %}
                         <!-- Delete this if other links present -->
-                        <li><a href="/">&larr;</a></li>
+                        <li><a href="{% url 'promotions:home' %}">&larr;</a></li>
                     </ul>
                 </div><!-- /.nav-collapse -->
             </div>


### PR DESCRIPTION
From mailing list: Checkout page redirects to homepage:

![Screenshot](https://lh4.googleusercontent.com/-pwYVRWxVlJA/UjtZKx1FCoI/AAAAAAAAAVU/fmX7rxseTM0/s1600/Screen+Shot+2013-09-19+at+22.05.08+.png)
