### PR TITLE
Fixed the display of children categories in the primary site navigation

### DIFF
--- a/oscar/templates/oscar/partials/nav_primary.html
+++ b/oscar/templates/oscar/partials/nav_primary.html
@@ -33,7 +33,7 @@
                     {% if tree_categories %}
                         <li class="divider"></li>
                         {% for tree_category, info in tree_categories %}
-                            {% if info.children %}
+                            {% if info.has_children %}
                                 <li class="dropdown-submenu">
                                 <a tabindex="-1" href="{{ tree_category.get_absolute_url }}">{{ tree_category.name }}</a>
                                 <ul class="dropdown-menu">
@@ -41,7 +41,7 @@
                                 <li><a tabindex="-1" href="{{ tree_category.get_absolute_url }}">{{ tree_category.name }}</a></li>
                             {% endif %}
 
-                            {% for close in info.close %}
+                            {% for close in info.num_to_close %}
                                 </ul></li>
                             {% endfor %}
                         {% endfor %}


### PR DESCRIPTION
Fixed the display of children categories in the primary site navigation.

Primary site navigation wasn't displaying the child categories in a hierarchal way, ie dropdown list within a dropdown list.

![screen shot 2013-09-25 at 4 38 41 pm](https://f.cloud.github.com/assets/726265/1207164/299b0e1a-25ae-11e3-9ee4-371c7bf1d22f.png)
