### PR TITLE
Improve product image handling

### DIFF
--- a/oscar/static/oscar/css/dashboard.css
+++ b/oscar/static/oscar/css/dashboard.css
@@ -2306,10 +2306,7 @@ caption > i,
   opacity: 0;
 }
 .upload-image .input-field input {
-  position: absolute;
-  border-width: 0 0 100px 200px;
-  filter: alpha(opacity=0);
-  -moz-transform: translate(-100px, 0) scale(1);
+  border-width: 0;
   direction: ltr;
   cursor: pointer;
   width: 200px;

--- a/oscar/static/oscar/less/dashboard.less
+++ b/oscar/static/oscar/less/dashboard.less
@@ -769,10 +769,7 @@ caption,
     opacity: 0;
   }
   .input-field input {
-    position: absolute;
-    border-width: 0 0 100px 200px;
-    filter: alpha(opacity=0);
-    -moz-transform: translate(-100px, 0) scale(1);
+    border-width: 0;
     direction: ltr;
     cursor: pointer;
     width: 200px;

--- a/oscar/templates/oscar/partials/image_input_widget.html
+++ b/oscar/templates/oscar/partials/image_input_widget.html
@@ -6,9 +6,9 @@
         <img src="{% static image_url %}" alt="{% trans "thumbnail" %}" />
     {% else %}
         <img alt="{% trans "thumbnail" %}"
-            onload="jQuery(this).next().hide()"
-            onerror="jQuery(this).next().show(); alert('{% trans 'Unrecognized image type!' %}')" />
-        <button class="btn btn-primary">{% trans "Upload Image" %}</button>
+            onload="$('#upload-button-{{ image_id }}').hide()"
+            onerror="$('#upload-button-{{ image_id }}').show(); alert('{% trans 'Unrecognized image type!' %}')" />
+        <button class="btn btn-primary" id="upload-button-{{ image_id }}">{% trans "Upload Image" %}</button>
     {% endif %}
     <div class="input-field">
         <input {{ input_attrs|safe }} accept="image/*" />


### PR DESCRIPTION
There's currently a few issues with the way the dashboard handles product images.

https://github.com/tangentlabs/django-oscar/blob/master/oscar/templates/oscar/partials/image_input_widget.html
- [ ] If no image is set, an empty `<img>` is rendered. It's not visible as it's overlaid by both a button and the <input> field, but at least in Chrome changes the mouse cursor
- [x] The inline(!) javascript uses relative addressing via `.next()` to hide or show the upload button
- [ ] Semantically, the button is never used, and merely for display purposes. Maybe one could remove it, and instead have an always visible `<img>` which looks something like this
  ![button](http://static4.depositphotos.com/1000993/391/v/450/dep_3913351-Single-Circle-upload-button.jpg)
- [ ] As everything else has an immediate reaction, it would be nice if deleting pictures would be instant as well. Or at least the image becoming grayed out when clicking 'Delete'
- [x] The input field is, at least in Chrome, 100 px to the right. That causes the mouse cursor to not display as expected in the left half of the area. This is caused by absolute positioning and some not widely supported transforming: https://github.com/tangentlabs/django-oscar/blob/master/oscar/static/oscar/less/dashboard.less#L771
- [ ] It would be nice if images could be dragged & dropped. Seems easy enough: http://djangosnippets.org/snippets/1053/
- [ ] ImageField validation errors need looking into, as per @mbertheau's comment below
- [ ] Uploaded images aren't saved if other validation fails, as reported on the [mailing list](https://groups.google.com/d/msgid/django-oscar/a1bf22d9-d674-43c9-a88b-3d6382a8c174%40googlegroups.com) and in https://github.com/tangentlabs/django-oscar/pull/1126
- [ ] Allow associating images with child products (as mentioned in https://github.com/tangentlabs/django-oscar/issues/675#issuecomment-48340506)

Possible enhancements:
- Allow image cropping with e.g. [django-image-cropping](https://github.com/jonasundderwolf/django-image-cropping)
