### PR TITLE
#854 styling wish list buttons / forms on detail page

### DIFF
--- a/oscar/static/oscar/css/styles.css
+++ b/oscar/static/oscar/css/styles.css
@@ -6997,6 +6997,25 @@ a:hover .thumbnail {
 .side_categories:after {
   clear: both;
 }
+.add-to-basket {
+  width: 220px;
+  margin-bottom: 0;
+  margin-right: 10px;
+  *margin-right: 20px;
+}
+.add-to-basket,
+.btn-wishlist {
+  display: inline-block;
+  *display: inline;
+  zoom: 1;
+}
+.btn-wishlist {
+  vertical-align: bottom;
+}
+.add-to-basket .btn,
+.btn-wishlist {
+  margin-bottom: 20px;
+}
 /* Elastislide Style */
 .es-carousel-wrapper {
   padding: 1px 20px;

--- a/oscar/static/oscar/less/page/product_page.less
+++ b/oscar/static/oscar/less/page/product_page.less
@@ -82,3 +82,26 @@
 .side_categories {
   .well();
 }
+
+//Align wish list button with add to basket button
+.add-to-basket {
+  //Width of default input/select/textarea
+  width: 220px;
+  margin-bottom:0;
+  margin-right:10px;
+  *margin-right:20px;
+}
+.add-to-basket,
+.btn-wishlist {
+  display:inline-block;
+  *display:inline;
+  zoom:1;
+}
+//For responsive - when button falls under each other
+.btn-wishlist {
+  vertical-align:bottom;
+}
+.add-to-basket .btn,
+.btn-wishlist {
+  margin-bottom:@baseLineHeight;
+}

--- a/oscar/templates/oscar/catalogue/partials/add_to_basket_form.html
+++ b/oscar/templates/oscar/catalogue/partials/add_to_basket_form.html
@@ -5,10 +5,10 @@
 {% if product.is_available_to_buy %}
     {% basket_form request product as basket_form %}
     {% if basket_form.purchase_permitted %}
-        <form action="{% url 'basket:add' %}" method="post" class="form-stacked">
+        <form action="{% url 'basket:add' %}" method="post" class="form-stacked add-to-basket">
             {% csrf_token %}
             {% include "partials/form_fields.html" with form=basket_form %}
-            <button type="submit" class="btn btn-large btn-primary btn-full" value="{% trans "Add to basket" %}">{% trans "Add to basket" %}</button>
+            <button type="submit" class="btn btn-large btn-primary btn-block" value="{% trans "Add to basket" %}">{% trans "Add to basket" %}</button>
         </form>
         {% include "catalogue/partials/add_to_wishlist.html" %}
     {% else %}
@@ -18,11 +18,11 @@
     {% if has_active_alert %}
         <p>{% trans "You have an active stock alert for this product." %}</p>
     {% else %}
-        <form id="alert_form" method="post" action="{% url 'customer:alert-create' product.id %}">
+        <form id="alert_form" method="post" action="{% url 'customer:alert-create' product.id %}" class="add-to-basket">
             {% csrf_token %}
             <p>{% trans "You can get an email alert when this product is back in stock." %}</p>
             {% include "partials/form_fields.html" with form=alert_form %}
-            <button type="submit" class="btn btn-large btn-info btn-full">{% trans "Notify me" %}</button>
+            <button type="submit" class="btn btn-large btn-info btn-block">{% trans "Notify me" %}</button>
         </form>
         {% include "catalogue/partials/add_to_wishlist.html" %}
     {% endif %}

--- a/oscar/templates/oscar/catalogue/partials/add_to_wishlist.html
+++ b/oscar/templates/oscar/catalogue/partials/add_to_wishlist.html
@@ -8,9 +8,9 @@
         {% wishlists_containing_product wishlists product as product_wishlists %}
         {% if wishlists|length > 0 %}
 
-            <div class="btn-group">
-                <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">{% trans "Add to wish list" %} <span class="caret"></span></a>
-                <ul class="dropdown-menu">
+            <div class="btn-group btn-wishlist">
+                <a class="btn btn-large dropdown-toggle" data-toggle="dropdown" href="#">{% trans "Add to wish list" %} <span class="caret"></span></a>
+                <ul class="dropdown-menu pull-right">
                     {% for wishlist in wishlists %}
                         <li>
                                 <a href="{% url 'customer:wishlists-add-product' key=wishlist.key product_pk=product.pk %}">
@@ -25,9 +25,9 @@
             </div>
         {% else %}
             {# 1 or no existing wishlists - show a simple button #}
-            <form id="add_to_wishlist_form" action="{% url 'customer:wishlists-add-product' product_pk=product.pk %}" method="post">
+            <form id="add_to_wishlist_form" action="{% url 'customer:wishlists-add-product' product_pk=product.pk %}" method="post" class="btn-wishlist">
                 {% csrf_token %}
-                <button type="submit" class="btn">{% trans "Add to wish list" %}</button>
+                <button type="submit" class="btn btn-large">{% trans "Add to wish list" %}</button>
             </form>
         {% endif %}
 
@@ -35,12 +35,12 @@
             <form action="{% url 'customer:wishlists-remove-product' wishlist.key product.id %}" method="post">
                 {% csrf_token %}
                 {% blocktrans with name=wishlist.name url=wishlist.get_absolute_url %}
-                    Product is in <a href="{{ url }}">'{{ name }}'</a> wishlist.
+                    <span class="pull-left">Product is in <a href="{{ url }}">'{{ name }}'</a> wishlist.</span>
                 {% endblocktrans %}
-                <button type="submit" class="btn btn-small btn-danger">{% trans "Remove" %}</button>
+                <button type="submit" class="btn btn-small pull-right">{% trans "Remove" %}</button>
             </form>
         {% endfor %}
     {% endwith %}
 {% else %}
-    <button class="btn" disabled="disabled" title="{% trans 'Please login to add products to a wish list.' %}">{% trans 'Add to wish list' %}</button><br/>
+    <button class="btn btn-large btn-wishlist" disabled="disabled" title="{% trans 'Please login to add products to a wish list.' %}">{% trans 'Add to wish list' %}</button><br/>
 {% endif %}


### PR DESCRIPTION
#854 styling wish list buttons / forms on detail page
- Buttons "add to basket", "notify me" etc are inline with the wish list buttons - given different conditions.
- Wish list "remove" buttons are gray and aligned right
- Responsive fallback is the buttons on top of one another

![screen shot 2013-10-03 at 2 19 40 pm](https://f.cloud.github.com/assets/726265/1259415/d3b8911e-2be5-11e3-9c92-d0752016a818.png)
![screen shot 2013-10-03 at 2 20 58 pm](https://f.cloud.github.com/assets/726265/1259416/d3bc9e30-2be5-11e3-84c5-0d0aae02f9d1.png)
![screen shot 2013-10-03 at 2 21 13 pm](https://f.cloud.github.com/assets/726265/1259417/d3c10c18-2be5-11e3-95e4-45dc104df334.png)
![screen shot 2013-10-03 at 2 21 52 pm](https://f.cloud.github.com/assets/726265/1259418/d3c3be68-2be5-11e3-9741-e526d9ba86d6.png)
![screen shot 2013-10-03 at 2 22 14 pm](https://f.cloud.github.com/assets/726265/1259419/d3c63224-2be5-11e3-8c1e-05cb791fbe53.png)
