### PR TITLE
#871 product with a single image

### DIFF
--- a/oscar/static/oscar/css/styles.css
+++ b/oscar/static/oscar/css/styles.css
@@ -6852,57 +6852,11 @@ a:hover .thumbnail {
   -moz-box-shadow: 0 1px 4px rgba(0, 105, 214, 0.25);
   box-shadow: 0 1px 4px rgba(0, 105, 214, 0.25);
 }
-.availability {
-  /*  text-align:center;*/
-
-}
 .availability.outofstock {
   color: #9d261d;
 }
 .availability.instock {
   color: #46a546;
-}
-/* Product View image container */
-.images img {
-  width: 100%;
-  height: auto;
-}
-.basic label {
-  width: auto;
-}
-.basic .input {
-  margin: 0px;
-}
-.basic .input input {
-  margin: 0px 10px;
-}
-.promo_related {
-  min-height: 20px;
-  padding: 19px;
-  margin-bottom: 20px;
-  background-color: #f5f5f5;
-  border: 1px solid #e3e3e3;
-  -webkit-border-radius: 4px;
-  -moz-border-radius: 4px;
-  border-radius: 4px;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
-  -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
-  *zoom: 1;
-  height: 250px;
-}
-.promo_related blockquote {
-  border-color: #ddd;
-  border-color: rgba(0, 0, 0, 0.15);
-}
-.promo_related:before,
-.promo_related:after {
-  display: table;
-  content: "";
-  line-height: 0;
-}
-.promo_related:after {
-  clear: both;
 }
 /* review styles */
 .review {
@@ -7086,6 +7040,12 @@ a:hover .thumbnail {
   position: relative;
   text-align: center;
   line-height: 0px;
+}
+.rg-image.single-image {
+  padding: 10px;
+}
+.rg-image.single-image img {
+  max-height: none;
 }
 .rg-image a {
   display: block;

--- a/oscar/static/oscar/less/page/plugins.less
+++ b/oscar/static/oscar/less/page/plugins.less
@@ -89,6 +89,12 @@
 	position:relative;
 	text-align:center;
 	line-height:0px;
+	&.single-image {
+		padding:10px;
+		img {
+			max-height: none;
+		}
+	}
 }
 .rg-image a {
 	display:block;

--- a/oscar/static/oscar/less/page/product_page.less
+++ b/oscar/static/oscar/less/page/product_page.less
@@ -1,7 +1,6 @@
 // OSCAR PRODUCTS UNIQUE STYLES
 // -----------
 .availability {
-/*  text-align:center;*/
   &.outofstock {
     color:@red;
   }
@@ -9,28 +8,7 @@
    color:@green;
   }
 }
-/* Product View image container */
-.images {
-  img {
-    width:100%;
-    height:auto;
-  }
-}
-.basic {
-  label {
-    width:auto;
-  }
-  .input {
-    margin:0px;
-    input {
-      margin:0px 10px;
-    }
-  }
-}
-.promo_related {
-  .well();
-  height:250px;
-}
+
 /* review styles */
 .review {
   border-bottom:1px solid @grayLight;

--- a/oscar/templates/oscar/catalogue/detail.html
+++ b/oscar/templates/oscar/catalogue/detail.html
@@ -186,48 +186,42 @@
         {% endblock product_review %}
     {% endiffeature %}
 
-    <div class="row-fluid">
-        {% if product.related_products.count %}
-        <div class="span6">
-            <div class="sub-header">
-                <h2>{% trans "Related items" %}</h2>
-            </div>
-            <div class="es-carousel-wrapper">
-                <div class="es-carousel">
-                    <ul>
-                        {% for product in product.related_products.all %}
-                        <li>
-                            {% render_product product %}
-                        </li>
-                        {% endfor %}
-                    </ul>
-                </div>
+    {% if product.related_products.count %}
+        <div class="sub-header">
+            <h2>{% trans "Related items" %}</h2>
+        </div>
+        <div class="es-carousel-wrapper">
+            <div class="es-carousel">
+                <ul>
+                    {% for product in product.related_products.all %}
+                    <li>
+                        {% render_product product %}
+                    </li>
+                    {% endfor %}
+                </ul>
             </div>
         </div>
-        {% endif %}
+    {% endif %}
 
-        {% if product.recommended_products.count %}
-        <div class="span6">
-            <div class="sub-header">
-                <h2>{% trans "Recommended items" %}</h2>
-            </div>
-            <div class="es-carousel-wrapper">
-                <div class="es-carousel">
-                    <ul>
-                        {% for product in product.recommended_products.all %}
-                        <li>
-                            {% render_product product %}
-                        </li>
-                        {% endfor %}
-                    </ul>
-                </div>
+    {% if product.recommended_products.count %}
+        <div class="sub-header">
+            <h2>{% trans "Recommended items" %}</h2>
+        </div>
+        <div class="es-carousel-wrapper">
+            <div class="es-carousel">
+                <ul>
+                    {% for product in product.recommended_products.all %}
+                    <li>
+                        {% render_product product %}
+                    </li>
+                    {% endfor %}
+                </ul>
             </div>
         </div>
-        {% endif %}
+    {% endif %}
+    
+    {% recently_viewed_products %}
 
-        {% recently_viewed_products %}
-
-    </div>
 </article><!-- End of product page -->
 {% endblock content %}
 

--- a/oscar/templates/oscar/catalogue/partials/gallery.html
+++ b/oscar/templates/oscar/catalogue/partials/gallery.html
@@ -49,16 +49,19 @@
     {% else %}
 
         {# Only one image to show #}
-
-        {% with image=product.primary_image %}
-            {% thumbnail image.original "400x400" upscale=False as thumb %}
-            {% if not image.is_missing %}
-                <a href="{{ image.original.url }}" rel="lightbox"><img src="{% static thumb.url %}" data-large="{{ image.original.url }}" alt="image02" data-description="{% if image.caption %}{{ image.caption }}{% endif %}" /></a>
-            {% else %}
-                <img src="{% static thumb.url %}" alt="image02" />
-            {% endif %}
-            {% endthumbnail %}
-        {% endwith %}
+        <div class="es-carousel-wrapper">
+            <div class="rg-image single-image">
+            {% with image=product.primary_image %}
+                {% thumbnail image.original "400x400" upscale=False as thumb %}
+                {% if not image.is_missing %}
+                    <a href="{{ image.original.url }}" rel="lightbox"><img src="{% static thumb.url %}" data-large="{{ image.original.url }}" alt="image02" data-description="{% if image.caption %}{{ image.caption }}{% endif %}" /></a>
+                {% else %}
+                    <img src="{% static thumb.url %}" alt="image02" />
+                {% endif %}
+                {% endthumbnail %}
+            {% endwith %}
+            </div>
+        </div>
 
     {% endif %}
 {% endwith %}


### PR DESCRIPTION
#871 product with a single image get similar treatment to a product with multiple images
- Added the same classes to single image as to multiple images to give similar appearance ( border and image centred, bottom margin )
- Found Recently viewed carousel looking broken if related product visible - ( as related is floated left with recommended ).  These are now just stacked product containers rather than divided.
- Removed some css was redundant -- couldn't find a hook in the markup.

![screen shot 2013-10-04 at 12 20 46 pm](https://f.cloud.github.com/assets/726265/1266894/ac7e8e62-2c9b-11e3-9e81-2485d81014a0.png)
