### PR TITLE
#869 fed fixes to notifications area

### DIFF
--- a/oscar/templates/oscar/customer/baseaccountpage.html
+++ b/oscar/templates/oscar/customer/baseaccountpage.html
@@ -20,11 +20,11 @@
             <span class="divider">/</span>
         </li>
         {% block extra_breadcrumbs %}{% endblock %}
-        <li class="active">{{ page_title }}</li>
+        <li class="active">{{ page_title|striptags }}</li>
     </ul>
 {% endblock %}
 
-{% block headertext %}{{ page_title }}{% endblock %}
+{% block headertext %}{{ page_title|striptags }}{% endblock %}
 
 {% block column_left %}
     <ul class="nav nav-pills nav-stacked">

--- a/oscar/templates/oscar/customer/notifications/detail.html
+++ b/oscar/templates/oscar/customer/notifications/detail.html
@@ -23,7 +23,7 @@
         </tr>
         <tr>
             <th>{% trans 'Subject' %}</th>
-            <td>{{ notification.subject }}</td>
+            <td>{{ notification.subject|safe }}</td>
         </tr>
         <tr>
             <th>{% trans 'Body' %}</th>

--- a/oscar/templates/oscar/customer/notifications/list.html
+++ b/oscar/templates/oscar/customer/notifications/list.html
@@ -14,7 +14,7 @@
 
         <form action="{% url 'customer:notifications-update' %}" method="post">
             {% csrf_token %}
-            <table class="table">
+            <table class="table table-striped table-bordered">
                 <tbody>
                     {% for notification in notifications %}
                         <tr>


### PR DESCRIPTION
#869 fed fixes to notifications area
- Added the border to table in notifications (consistancy)
- Noticed html being brought through into notifications breadcrumbs,notifications page title,and subject.

![screen shot 2013-10-04 at 2 45 08 pm](https://f.cloud.github.com/assets/726265/1267274/fc056ef4-2cb1-11e3-978a-a8f166ab1b0e.png)

![screen shot 2013-10-04 at 2 43 05 pm](https://f.cloud.github.com/assets/726265/1267273/fbd6aa4c-2cb1-11e3-8633-ad1559103ab0.png)

Stripped
![screen shot 2013-10-04 at 2 52 22 pm](https://f.cloud.github.com/assets/726265/1267277/fc542878-2cb1-11e3-94f7-5fa64c50eaa4.png)
