### PR TITLE
#867 removing tabs from order detail page, tidying page a little

### DIFF
--- a/oscar/static/oscar/css/styles.css
+++ b/oscar/static/oscar/css/styles.css
@@ -6520,28 +6520,6 @@ form:after {
 #language_selector select {
   width: 100px;
 }
-.dropdown-menu .btn-link {
-  display: block;
-  padding: 3px 20px;
-  width: 100%;
-  *width: 160px;
-  text-align: left;
-  line-height: 20px;
-  color: #333333;
-  white-space: nowrap;
-}
-.dropdown-menu .btn-link:hover {
-  text-decoration: none;
-  color: #ffffff;
-  background-color: #0081c2;
-  background-image: -moz-linear-gradient(top, #0088cc, #0077b3);
-  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#0088cc), to(#0077b3));
-  background-image: -webkit-linear-gradient(top, #0088cc, #0077b3);
-  background-image: -o-linear-gradient(top, #0088cc, #0077b3);
-  background-image: linear-gradient(to bottom, #0088cc, #0077b3);
-  background-repeat: repeat-x;
-  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff0088cc', endColorstr='#ff0077b3', GradientType=0);
-}
 .basket_summary,
 .later_summary {
   padding-left: 0px;

--- a/oscar/static/oscar/less/page/account.less
+++ b/oscar/static/oscar/less/page/account.less
@@ -26,21 +26,3 @@
 #language_selector select {
   width:100px;
 }
-//buttons inside dropdowns menus to appear like links
-.dropdown-menu {
-  .btn-link {
-    display:block;
-    padding: 3px 20px;
-    width: 100%;
-    *width:160px;
-    text-align: left;
-    line-height: @baseLineHeight;
-    color: @dropdownLinkColor;
-    white-space: nowrap;
-    &:hover {
-      text-decoration: none;
-      color: @dropdownLinkColorHover;
-      #gradient > .vertical(@dropdownLinkBackgroundHover, darken(@dropdownLinkBackgroundHover, 5%));
-    }
-  }
-}

--- a/oscar/templates/oscar/customer/order/order_detail.html
+++ b/oscar/templates/oscar/customer/order/order_detail.html
@@ -27,34 +27,22 @@
         <tbody>
             {% for line in order.lines.all %}
             <tr>
-                <td><a href="{{ line.product.get_absolute_url }}">{{ line.description }}</a></td>
+                <td>
+                    <p><a href="{{ line.product.get_absolute_url }}">{{ line.description }}</a></p>
+                    {% iffeature "reviews" %}
+                        <a class="btn" href="{% url 'catalogue:reviews-add' line.product.slug line.product.id %}">{% trans 'Write a review' %}</a>
+                    {% endiffeature %}
+                </td>
                 <td>{{ line.est_dispatch_date|default:"-" }}</td>
                 <td>{{ line.quantity }}</td>
                 <td>{{ line.line_price_before_discounts_excl_tax|currency }}</td>
                 <td>{{ line.line_price_before_discounts_incl_tax|currency }}</td>
-                <td>
+                <td width="90">
                     {% if line.product %}
                     <form id="line_form_{{ line.id }}" action="{% url 'customer:order-line' order.number line.id %}" method="POST">
                         {% csrf_token %}
                         <input type="hidden" name="action" value="reorder" />
-                        
-                        <div class="btn-group">
-                            <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
-                                {% trans 'Options' %}
-                                <span class="caret"></span>
-                            </a>
-                            <ul class="dropdown-menu">
-                                <li>
-                                    <button class="btn-link" type="submit">{% trans 'Re-order' %}</button>
-                                </li>
-                                {% iffeature "reviews" %}
-                                <li>                           
-                                    <a href="{% url 'catalogue:reviews-add' line.product.slug line.product.id %}">{% trans 'Write a review' %}</a>
-                                </li>
-                                {% endiffeature %}
-                            </ul>
-                        </div>
-
+                        <button class="btn btn-success" type="submit">{% trans 'Re-order' %}</button>
                     </form>
                     {% else %}
                         {% trans 'Not available anymore' %}


### PR DESCRIPTION
#867 removing tabs from order detail page
- Removed tabs from order history detail page - content all on the same page.
- Shipping address now in a table
- Tidy of order content table: changed 'quantity' to qty
- Added drop down "options" for 're-order' and 'write a review'. Looks neater

![order 100013 account oscar sandbox](https://f.cloud.github.com/assets/726265/1267491/1fa6f5a4-2cc0-11e3-8a9e-6ab93b3cc12a.png)
