### PR TITLE
#866 removed availability reason from template

### DIFF
--- a/oscar/templates/oscar/catalogue/partials/add_to_basket_form_compact.html
+++ b/oscar/templates/oscar/catalogue/partials/add_to_basket_form_compact.html
@@ -9,9 +9,9 @@
         {% csrf_token %}
         {{ basket_form.as_p }}
         {% if product.is_available_to_buy %}
-            <button type="submit" class="btn btn-primary btn-full">{% trans "Add to basket" %}</button>
+            <button type="submit" class="btn btn-primary btn-block">{% trans "Add to basket" %}</button>
         {% endif %}
     </form>
 {% else %}
-    {{ basket_form.reason }}
+    <span class="btn btn-block disabled">{% trans "Out of Stock" %}</span>
 {% endif %}


### PR DESCRIPTION
#866 removed availability reason from template
- {{ basket_form.reason }}  was being included in the add_to_basket_form_compact.html template - breaking the style of the product list.

Two thoughts
- Keep it in but instead of displaying the "reason" maybe incorporate a tooltip or popup to display the message.
- Maybe move it to the detail page - where there is more room.

For now a disabled button "Out of stock" is in it's place.
![screen shot 2013-10-07 at 2 39 43 pm](https://f.cloud.github.com/assets/726265/1278243/4c7c0632-2f04-11e3-84c7-014be7233fc3.png)
