### PR TITLE
Add ability for staff to reset customer passwords

### DIFF
--- a/oscar/apps/dashboard/users/app.py
+++ b/oscar/apps/dashboard/users/app.py
@@ -9,6 +9,7 @@ class UserManagementApplication(Application):
     name = None
     index_view = views.IndexView
     user_detail_view = views.UserDetailView
+    password_reset_view = views.PasswordResetView
     alert_list_view = views.ProductAlertListView
     alert_update_view = views.ProductAlertUpdateView
     alert_delete_view = views.ProductAlertDeleteView
@@ -18,6 +19,9 @@ class UserManagementApplication(Application):
             url(r'^$', self.index_view.as_view(), name='users-index'),
             url(r'^(?P<pk>\d+)/$',
                 self.user_detail_view.as_view(), name='user-detail'),
+            url(r'^(?P<pk>\d+)/password-reset/$',
+                self.password_reset_view.as_view(),
+                name='user-password-reset'),
 
             # Alerts
             url(r'^alerts/$',

--- a/oscar/templates/oscar/dashboard/users/detail.html
+++ b/oscar/templates/oscar/dashboard/users/detail.html
@@ -89,6 +89,16 @@
                     <th>{% trans "Date joined" %}</th>
                     <td>{{ customer.date_joined }}</td>
                 </tr>
+                <tr>
+                    <th>{% trans "Actions" %}</th>
+                    <td>
+                        <form id="password_reset_form" action="{% url 'dashboard:user-password-reset' pk=customer.id %}" method="post" class="form-horizontal">
+                            {% csrf_token %}
+                            {% include 'partials/form_fields.html' %}
+                            <button type="submit" class="btn btn-primary btn-large">{% trans 'Send password reset email' %}</button>
+                        </form>
+                    </td>
+                </tr>
                 {% endwith %}
             </table>
         </div>


### PR DESCRIPTION
This allows a staff member to send a password reset email on behalf of a customer within the dashboard.
- Adds a "Send password reset email" button to customer page in dashboard.
- When button is clicked, the password reset email is sent to the customer containing a confirmation link - the same way the existing "forgotten password" functionality works.
