### PR TITLE
Display the additional profile fields

### DIFF
--- a/oscar/templates/oscar/customer/profile/profile.html
+++ b/oscar/templates/oscar/customer/profile/profile.html
@@ -15,7 +15,7 @@
                 <td>{{ user.email }}</td>
             </tr>
             {% block profile_fields %}
-                {% for field in profile_fields %}
+                {% for field in profile %}
                     <tr>
                         <th>{{ field.name }}</th>
                         <td>{{ field.value|default:"-" }}</td>
@@ -33,4 +33,3 @@
     <a href="{% url 'customer:profile-update' %}" class="btn btn-primary">{% trans 'Edit profile' %}</a>
 
 {% endblock %}
-


### PR DESCRIPTION
Oscar sets `profile` ([code](https://github.com/tangentlabs/django-oscar/blob/master/oscar/apps/customer/views.py#L206)) with the list of the additional profile fields but
templates expects `profile_fields` in the context.

I decided to stick with `profile` as somebody might already have had fixed their own template. I can change it the other way around to `profile_fields` if we don't want this micro-compatibility.
