### PR TITLE
increased max_length of slug and full_name as they can grow quickly

### DIFF
--- a/oscar/apps/catalogue/abstract_models.py
+++ b/oscar/apps/catalogue/abstract_models.py
@@ -73,9 +73,9 @@ class AbstractCategory(MP_Node):
     description = models.TextField(_('Description'), blank=True, null=True)
     image = models.ImageField(_('Image'), upload_to='categories', blank=True,
                               null=True, max_length=255)
-    slug = models.SlugField(_('Slug'), max_length=255, db_index=True,
+    slug = models.SlugField(_('Slug'), max_length=1024, db_index=True,
                             editable=False)
-    full_name = models.CharField(_('Full Name'), max_length=255,
+    full_name = models.CharField(_('Full Name'), max_length=1024,
                                  db_index=True, editable=False)
 
     _slug_separator = '/'


### PR DESCRIPTION
The `slug` and `full_name` fields on the Category model can get pretty long as they accumulate the names/slugs of their parent categories. This patch increases their size by roughly 4 times.

Another option is to just change them to TextField...
