### PR TITLE
Binding template tag expressions in blocktrans statements

### DIFF
--- a/sites/demo/templates/shipping/express.html
+++ b/sites/demo/templates/shipping/express.html
@@ -1,9 +1,9 @@
 {% load currency_filters %}
 {% load i18n %}
-{% blocktrans with cost=1.50%}
+{% blocktrans with cost=1.50|currency%}
 This is express shipping.  Should reach you within 48 hours.
 
 <p>
-    It costs {{ cost|currency }} per item.
+    It costs {{ cost }} per item.
 </p>
 {% endblocktrans %}

--- a/sites/demo/templates/shipping/standard.html
+++ b/sites/demo/templates/shipping/standard.html
@@ -1,10 +1,10 @@
 {% load currency_filters %}
 {% load i18n %}
-{% blocktrans with cost=0.99 total=12.00 %}
+{% blocktrans with cost=0.99|currency total=12.00|currency %}
 This is standard shipping.
 
 <p>
-    It costs {{ cost|currency }} per item but is free for orders over
-    {{ total|currency }}.
+    It costs {{ cost }} per item but is free for orders over
+    {{ total }}.
 </p>
 {% endblocktrans %}


### PR DESCRIPTION
The custom shipping templates of the demo site contains template tags within the {% transblock %} tag which does not work. Check out the live demo site http://demo.oscar.tangentlabs.co.uk/checkout/shipping-method/ to see for yourself. Screenshot:

![oscar-demo-site-template-tag](https://f.cloud.github.com/assets/3015394/1431893/64dc71d8-40d6-11e3-813b-7781798a49f8.png)

Piping the variables towards template tags within the {% blocktrans %} works, as explained here:
https://docs.djangoproject.com/en/dev/topics/i18n/translation/#std:templatetag-blocktrans
