### PR TITLE
STATIC_URL incorrectly quoted in documentation

### DIFF
--- a/docs/source/howto/how_to_handle_statics.rst
+++ b/docs/source/howto/how_to_handle_statics.rst
@@ -54,7 +54,7 @@ this to your settings file::
 
     COMPRESS_OFFLINE_CONTEXT = {
         # this is the only default value from compressor itself
-        'STATIC_URL': 'STATIC_URL',
+        'STATIC_URL': STATIC_URL,
         'use_less': USE_LESS,
     }
 


### PR DESCRIPTION
Removed the quotes around STATIC_URL in the documentation, so that the correct value remains in the documentation's example code
