### PR TITLE
change MultiFacetedSearchForm back to always return sqs

### DIFF
--- a/oscar/apps/search/forms.py
+++ b/oscar/apps/search/forms.py
@@ -55,4 +55,4 @@ class MultiFacetedSearchForm(FacetedSearchForm):
         if hasattr(self, 'cleaned_data') and 'selected_facets' in self.cleaned_data:
             for f in self.cleaned_data['selected_facets'].split("|"):
                 sqs = sqs.narrow(f)
-                return sqs
+        return sqs


### PR DESCRIPTION
I'm not sure if this change to MultiFacetedSearchForm was intentional or not but it definitely broke my project.

This pull request is to de-dent the "return" statement back so that it will return the search results.
