### PR TITLE
Allow shipping_address being 'None' for an order

### DIFF
--- a/oscar/apps/checkout/mixins.py
+++ b/oscar/apps/checkout/mixins.py
@@ -145,6 +145,10 @@ class OrderPlacementMixin(CheckoutSessionMixin):
         Compared to self.get_shipping_address(), ShippingAddress is saved and
         makes sure that appropriate UserAddress exists.
         """
+        # For an order that only contains items that don't require shipping we
+        # won't have a shipping address, so we have to check for it.
+        if not shipping_address:
+            return None
         shipping_address.save()
         if user.is_authenticated():
             self.update_address_book(user, shipping_address)

--- a/tests/unit/checkout/mixins_tests.py
+++ b/tests/unit/checkout/mixins_tests.py
@@ -1,0 +1,13 @@
+import mock
+
+from django.test import TestCase
+
+from oscar.apps.checkout.mixins import OrderPlacementMixin
+
+
+class TestOrderPlacementMixin(TestCase):
+
+    def test_can_create_shipping_address_for_empty_address(self):
+        address = OrderPlacementMixin().create_shipping_address(
+            user=mock.Mock(), shipping_address=None)
+        self.assertEquals(address, None)


### PR DESCRIPTION
I've had an issue with orders that contain only items that don't require
shipping. In this case, the shipping address could be `None` which
breaks the `create_shipping_address` method.

I've added a test case for it and provided a simple fix. I wasn't quit
sure if the check should be in `create_shipping_address` or in
`place_order` and only call it for an address that is not `None`.
I've decided to go with the first because it is also simpler to test
this in isolation but am not fussed about moving it up.
