### PR TITLE
Make sure all BasketLine instances have a strategy set.

### DIFF
--- a/oscar/apps/basket/forms.py
+++ b/oscar/apps/basket/forms.py
@@ -17,6 +17,8 @@ class BasketLineForm(forms.ModelForm):
 
     def __init__(self, strategy, *args, **kwargs):
         self.strategy = strategy
+        if 'instance' in kwargs:
+            kwargs['instance'].strategy = strategy
         super(BasketLineForm, self).__init__(*args, **kwargs)
 
     def clean_quantity(self):


### PR DESCRIPTION
When building the formset for the basket lines the lines are first fetched
directly from the database and without a strategy when django determines
how many forms it has to create. It is these basket line instances that are
used later in the template, where they need a strategy to display price
information.

The comment in AbstractBasket.all_lines() specifically mentions a similar case, however the case we stumbled upon is different.

I'm not really sure if this is the right place to fix this, so I'd appreciate someone familiar with that code to have a look.

Thanks

Markus
