### PR TITLE
Make NoShippingRequired available by default.

### DIFF
--- a/oscar/apps/shipping/repository.py
+++ b/oscar/apps/shipping/repository.py
@@ -13,7 +13,7 @@ class Repository(object):
     """
     # Note, don't instantiate your shipping methods here (at class-level) as
     # that isn't thread safe.
-    methods = (methods.Free,)
+    methods = (methods.Free, methods.NoShippingRequired)
 
     def get_shipping_methods(self, user, basket, shipping_addr=None,
                              request=None, **kwargs):


### PR DESCRIPTION
When all product classes have shipping_required=False the checkout logic
automatically returns the shipping method NoShippingRequired. That shipping
method is not available in the default Repository so the checkout will
crash.

Adding NoShippingRequired allows the checkout to work in that cases without
overriding the Repository class.
