### PR TITLE
This was left over when bootstrap-wysihtml5 was removed.

### DIFF
--- a/oscar/templates/oscar/dashboard/layout.html
+++ b/oscar/templates/oscar/dashboard/layout.html
@@ -21,7 +21,6 @@
 {% block extrastyles %}
     {{ block.super }}
     {% compress css %}
-        <link rel="stylesheet" href="{% static "oscar/js/bootstrap-wysihtml5/bootstrap-wysihtml5-0.0.2.css" %}" />
         <link rel="stylesheet" href="{% static "oscar/js/select2/select2.css" %}" />
         <link rel="stylesheet" href="{% static "oscar/js/jquery/bootstrap-datepicker.css" %}" />
     {% endcompress %}


### PR DESCRIPTION
In the sandbox compress raises an exception when it can't find this CSS file.
