### PR TITLE
Add "dashboard/base.html" which extends "base.html"

### DIFF
--- a/oscar/templates/oscar/dashboard/base.html
+++ b/oscar/templates/oscar/dashboard/base.html
@@ -1,0 +1,1 @@
+{% extends "base.html" %}

--- a/oscar/templates/oscar/dashboard/layout.html
+++ b/oscar/templates/oscar/dashboard/layout.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "dashboard/base.html" %}
 
 {% load url from future %}
 {% load category_tags %}


### PR DESCRIPTION
This adds more flexibiltiy to override the default base.html while 
keeping the oscar base.html for the dashboard.

This  can be done by overriding "dashboard/base.html" and then extend
"oscar/base.html" instead of "base.html"
