### PR TITLE
#751 added FED fix for product update column stacking issue

### DIFF
--- a/oscar/templates/oscar/dashboard/catalogue/product_update.html
+++ b/oscar/templates/oscar/dashboard/catalogue/product_update.html
@@ -71,18 +71,18 @@
                                     <h3>{{ product.get_title }}</h3>
                                     <hr />
                                     <div class="row-fluid">
-                                        <div class="pull-left">
+                                        <div class="span4">
                                             {% if product.primary_image.original.url %}
                                                 {% with image=product.primary_image %}
-                                                    {% thumbnail image.original "240x240" upscale=False as thumb %}
-                                                    <a href="{{ image.original.url }}" rel="lightbox_{{ product.upc|default:"-" }}">
-                                                        <img src="{% static thumb.url %}" alt="{{ product.get_title }}" class="img-polaroid" data-description="{% if image.caption %}{{ image.caption }}{% endif %}">
-                                                    </a>
+                                                    {% thumbnail image.original "240" upscale=False as thumb %}
+                                                        <a href="{{ image.original.url }}" rel="lightbox_{{ product.upc|default:"-" }}" class="thumbnail">
+                                                            <img src="{% static thumb.url %}" class="row-fluid" alt="{{ product.get_title }}" data-description="{% if image.caption %}{{ image.caption }}{% endif %}">
+                                                        </a>
                                                     {% endthumbnail %}
                                                 {% endwith %}
                                             {% endif %}
                                         </div>
-                                        <div class="span9">
+                                        <div class="span8">
                                             <p><strong>{% trans "Description" %}</strong><br /> {{ product.description|safe }}</p>
 
                                             {% with stats=product.stats %}


### PR DESCRIPTION
### #751 Dashboard product update column stacking issue.

This shouldn't be a problem any more. The image will scale to the column width.

**Wide screen**
![screen shot 2013-11-12 at 10 58 59 am](https://f.cloud.github.com/assets/726265/1518048/399a0be0-4b2e-11e3-8335-54fa03f11174.png)

**Narrow screen**
![screen shot 2013-11-12 at 10 59 34 am](https://f.cloud.github.com/assets/726265/1518050/39f9b3e2-4b2e-11e3-8667-61e60ae7c65c.png)
