### PR TITLE
Show error messages on the ImageField itself.

### DIFF
--- a/oscar/templates/oscar/dashboard/partials/product_images.html
+++ b/oscar/templates/oscar/dashboard/partials/product_images.html
@@ -2,8 +2,13 @@
     {% for field in form %}
         {% if field.is_hidden %}
             {{ field }}
-            {% elif "original" in field.id_for_label %}
+        {% elif "original" in field.id_for_label %}
             <div>{{ field }}</div>
+            {% for error in field.errors %}
+                <ul class="help-block">
+                    <li>{{ error }}</li>
+                </ul>
+            {% endfor %}
         {% else %}
             {{ field.label_tag }}
             {{ field }}


### PR DESCRIPTION
This is relevant when you want to require an image for the product by
passing empty_permitted=False to the ProductImageForm.

The result is not particularly pleasing visually but right now the caption field is unintentionally not visible either.
![after](https://f.cloud.github.com/assets/133575/1524476/b90de9ee-4bc6-11e3-87db-e10e67484032.png)
