### PR TITLE
Fix spec-plugin argument for nose call

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -79,7 +79,7 @@ if __name__ == '__main__':
             # Default options:
             # --stop Abort on first error/failure
             # --nocapture Don't capture STDOUT
-            args.extend(['--nocapture', '--stop', '--with-specplugin'])
+            args.extend(['--nocapture', '--stop', '--with-spec'])
         else:
             # Remove options as nose will pick these up from sys.argv
             for arg in args:


### PR DESCRIPTION
Running tests with args e.g. `./runtests.py "tests/unit"` resulted in an error. `runtests.py: error: no such option: --with-specplugin`
Updated the default option to what is specified in the _Pinocchio_ [documentation](http://darcs.idyll.org/~t/projects/pinocchio/doc/).
