### PR TITLE
Dashboard customer list is always empty with a custom user model.

### DIFF
--- a/oscar/apps/dashboard/users/views.py
+++ b/oscar/apps/dashboard/users/views.py
@@ -29,6 +29,7 @@ class IndexView(BulkEditMixin, ListView):
     form_class = UserSearchForm
     desc_template = _('%(main_filter)s %(email_filter)s %(name_filter)s')
     description = ''
+    context_object_name = 'user_list'
 
     def get_queryset(self):
         queryset = self.model.objects.all().order_by('-date_joined')


### PR DESCRIPTION
The template is expecting 'user_list' so if I'm using a custom user model the list will always be empty. We can solve this adding:

```
context_object_name = 'user_list'
```
