### PR TITLE
Use line properties to display line unit and total prices

### DIFF
--- a/oscar/templates/oscar/basket/partials/basket_content.html
+++ b/oscar/templates/oscar/basket/partials/basket_content.html
@@ -78,19 +78,19 @@
                             </div>
                             <div class="span2">
                                 <p class="price_color align-right">
-                                    {% if session.price.is_tax_known %}
-                                        {{ session.price.incl_tax|currency:session.price.currency }}
+                                    {% if line.is_tax_known %}
+                                        {{ line.unit_price_incl_tax|currency:line.price_currency }}
                                     {% else %}
-                                        {{ session.price.excl_tax|currency:session.price.currency }}
+                                        {{ line.unit_price_excl_tax|currency:line.price_currency }}
                                     {% endif %}
                                 </p>
                             </div>
                             <div class="span2">
                                 <p class="price_color align-right">
-                                    {% if basket.is_tax_known %}
-                                        {{ line.line_price_incl_tax|currency:basket.currency }}
+                                    {% if line.is_tax_known %}
+                                        {{ line.line_price_incl_tax|currency:line.price_currency }}
                                     {% else %}
-                                        {{ line.line_price_excl_tax|currency:basket.currency }}
+                                        {{ line.line_price_excl_tax|currency:line.price_currency }}
                                     {% endif %}
                                 </p>
                             </div>


### PR DESCRIPTION
Using line properties/attributes everywhere rather than those of the basket or the session in some places makes the code a bit more consistent, and makes the requirement/assumption about line currency/tax being the same as basket currency/tax a bit DRYer.
