### PR TITLE
Save applies_to_tax_exclusive_prices flag

### DIFF
--- a/oscar/apps/dashboard/offers/views.py
+++ b/oscar/apps/dashboard/offers/views.py
@@ -194,6 +194,8 @@ class OfferWizardStepView(FormView):
         session_offer = self._fetch_session_offer()
         offer.name = session_offer.name
         offer.description = session_offer.description
+        offer.applies_to_tax_exclusive_prices = \
+            session_offer.applies_to_tax_exclusive_prices
 
         # Working around a strange Django issue where saving the related model
         # in place does not register it correctly and so it has to be saved and


### PR DESCRIPTION
OfferWizard forgets to save applies_to_tax_exclusive_prices flag at the
end.
