### PR TITLE
Simplify product url tag

### DIFF
--- a/oscar/templates/oscar/catalogue/partials/product.html
+++ b/oscar/templates/oscar/catalogue/partials/product.html
@@ -36,7 +36,7 @@
         <div class="product_price">
             {% include "catalogue/partials/stock_record.html" %}
             {% if product.is_group %}
-                <a class="btn btn-block" href="{% url 'catalogue:detail' product_slug=product.slug pk=product.id %}">{% trans "View" %}</a>
+                <a class="btn btn-block" href="{{ product.get_absolute_url }}">{% trans "View" %}</a>
             {% else %}
                 {% include "catalogue/partials/add_to_basket_form_compact.html" %}
             {% endif %}


### PR DESCRIPTION
Consistently use product.get_absolute_url for product url, instead of 'category:detail' with kwargs
