### PR TITLE
Fix for oscar_calculate_scores command

### DIFF
--- a/oscar/apps/analytics/scores.py
+++ b/oscar/apps/analytics/scores.py
@@ -25,13 +25,13 @@ class Calculator(object):
 
         # Build the "SET ..." part of the SQL statement
         weighted_sum = " + ".join(
-            ["%s*`%s`" % (weight, field) for field, weight
+            ['%s*"%s"' % (weight, field) for field, weight
              in self.weights.items()])
 
         ctx = {'table': ProductRecord._meta.db_table,
                'weighted_total': weighted_sum,
                'total_weight': sum(self.weights.values())}
-        sql = '''UPDATE `%(table)s`
+        sql = '''UPDATE "%(table)s"
                  SET score = %(weighted_total)s / %(total_weight)s''' % ctx
 
         self.logger.debug(sql)


### PR DESCRIPTION
The result of 

```
python manage.py oscar_calculate_scores
```

with my Postgresql Database is:

```
DatabaseError: syntax error at or near "`"
LINE 1: UPDATE `analytics_productrecord`
```

Using double quotes(") instead of grave accents (`) should fix the error.
