### PR TITLE
Add 'Processed' as a final status in order status pipeline

### DIFF
--- a/sites/sandbox/settings.py
+++ b/sites/sandbox/settings.py
@@ -377,6 +377,7 @@ OSCAR_ORDER_STATUS_PIPELINE = {
     'Pending': ('Being processed', 'Cancelled',),
     'Being processed': ('Processed', 'Cancelled',),
     'Cancelled': (),
+    'Processed': (),
 }
 
 


### PR DESCRIPTION
Without this, it's not possible to search for processed orders from the dashboard, since the 'Processed' status doesn't come up as an option in the status select box.
