### PR TITLE
Fix double </td> in order_report.html

### DIFF
--- a/oscar/templates/oscar/dashboard/reports/partials/order_report.html
+++ b/oscar/templates/oscar/dashboard/reports/partials/order_report.html
@@ -19,7 +19,7 @@
                     <td><a href="{% url 'dashboard:order-detail' order.number %}">{{ order.number }}</a></td>
                     <td>
                         {% if order.user %}
-                            <a href="{% url 'dashboard:user-detail' order.user.id %}">{{ order.user|default:"-" }}</a></td>
+                            <a href="{% url 'dashboard:user-detail' order.user.id %}">{{ order.user|default:"-" }}</a>
                         {% else %}
                             -
                         {% endif %}


### PR DESCRIPTION
There is a double </td> in the `order_report.html` file,
something which my IDE highlighted.
