### PR TITLE
Raise ValueError when product has no stockrecord

### DIFF
--- a/oscar/apps/basket/abstract_models.py
+++ b/oscar/apps/basket/abstract_models.py
@@ -186,7 +186,7 @@ class AbstractBasket(models.Model):
                     stock_info.price.currency, price_currency))
 
         if stock_info.stockrecord is None:
-            raise ValueError(_(
+            raise ValueError((
                 "Basket lines must all have stock records. Strategy hasn't "
                 "found any stock record for product %s") % product)
 


### PR DESCRIPTION
When adding product to basket, Oscar expects that strategy provides 
stockrecord. If there is no stockrecord, strange errors are raise, e.g. 
NoneType has no attributed id.

This patch provides more meaningful error.
