### PR TITLE
Fix displaying transactions in the dashboard order detail page

### DIFF
--- a/oscar/templates/oscar/dashboard/orders/order_detail.html
+++ b/oscar/templates/oscar/dashboard/orders/order_detail.html
@@ -494,7 +494,7 @@
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    {% for txn in transactions %}
+                                    {% for txn in payment_transactions %}
                                         <tr>
                                             <td>{{ txn.source.source_type }}</td>
                                             <td>{{ txn.amount|currency:order.currency }}</td>


### PR DESCRIPTION
The variable is `payment_transactions` instead of `transactions`
