### PR TITLE
Allow non-oscar dashboard application

### DIFF
--- a/oscar/core/loading.py
+++ b/oscar/core/loading.py
@@ -73,7 +73,11 @@ def get_classes(module_label, classnames):
         # Module not in local app
         imported_local_module = {}
     oscar_app = "oscar.apps.%s" % module_label
-    imported_oscar_module = __import__(oscar_app, fromlist=classnames)
+    try:
+        imported_oscar_module = __import__(oscar_app, fromlist=classnames)
+    except ImportError:
+        # Oscar does not have this application, can't fallback to it
+        imported_oscar_module = None
 
     return _pluck_classes([imported_local_module, imported_oscar_module],
                           classnames)


### PR DESCRIPTION
After @maikhoepfel fixing of dashboard navigation, Oscar do not accept dashboard applications that are not in Oscar.

Example: If my project has a dashboard application for managing a blog (not part of Oscar), I'll get the following error:

```
ImproperlyConfigured: Please follow Oscar's default dashboard app layout or set a custom access_fn
```

This is a severe issue and it is a release blocker for 0.6
