### PR TITLE
Consider custom Oscar user models in test cases

### DIFF
--- a/oscar/test/testcases.py
+++ b/oscar/test/testcases.py
@@ -59,7 +59,9 @@ class ClientTestCase(TestCase):
 
     def create_user(self, username=None, password=None, email=None,
                     is_staff=None, is_superuser=None, permissions=None):
-        user = create_user(username, email, password)
+        user = create_user(username or self.username,
+                           email or self.email,
+                           password or self.password)
         user.is_staff = is_staff or self.is_staff
         user.is_superuser = is_superuser or self.is_superuser
         user.save()


### PR DESCRIPTION
From `AbstractUser` model in Oscar (`oscar.apps.customer.abstract_models`):

> This is basically a copy of the core AbstractUser model but without a username field

The problem is, most test cases only consider the default Django user model that contains the username field. As soon as you extend Oscar's AbstractUser model that doesn't contain a username field, tests that use `ClientTestCase` or `WebTestCase` fail.
This PR fixes this problem by making the username optional.
