### PR TITLE
removed premature optimization for Product.is_group

### DIFF
--- a/oscar/apps/catalogue/abstract_models.py
+++ b/oscar/apps/catalogue/abstract_models.py
@@ -400,10 +400,7 @@ class AbstractProduct(models.Model):
         """
         Test if this is a top level product and has more than 0 variants
         """
-        # use len() instead of count() in this specific instance
-        # as variants are highly likely to be used after this
-        # which reduces the amount of SQL queries required
-        return self.is_top_level and len(self.variants.all()) > 0
+        return self.is_top_level and self.variants.count() > 0
 
     @property
     def is_variant(self):


### PR DESCRIPTION
This premature optimization causes most of the bottleneck in rendering of details page. It is not a good idea to load all variants.

Example product where you don't want to do that:
Levi's Men's 501 Jean
http://www.amazon.com/gp/product/B0018OR118

Colors: 37
Sizes: 87

Total Variants: 3,219
