### PR TITLE
Bulkeditmixin use get queryset

### DIFF
--- a/oscar/views/generic.py
+++ b/oscar/views/generic.py
@@ -87,7 +87,7 @@ class BulkEditMixin(object):
         return [object_dict[id] for id in ids]
 
     def get_object_dict(self, ids):
-        return self.model.objects.in_bulk(ids)
+        return self.get_queryset().in_bulk(ids)
 
 
 class ObjectLookupView(View):


### PR DESCRIPTION
This branch introduces two changes to BulkEditMixin with the common goal to remove the empty get_queryset method to allow overriding it in the following context:

``` python
class OscarView(ListView):
    def get_queryset(self):
        ...

class CustomView(BulkEditMixin, OscarView):
    # here get_queryset resolves to BulkEditMixin.get_queryset,
    # which just returns None
```

Afaict the empty `get_queryset` method was added to allow `get_checkbox_object_name` to work if there was no `get_queryset` method elsewhere in the class hierarchy. However, if the empty `get_queryset` method was the one that ended up being called by `get_checkbox_object_name` it would return `None` which prevents BulkEditMixin from working.

However, `get_object_dict` already relies on the `model` attribute to be available, so `get_checkbox_object_name` was changed to get `object_name` from there. This allows us to delete the empty `get_queryset`.

The second change is to let `get_object_dict` get its objects from the queryset returned by `get_queryset`, if that is available. This makes sense because you wouldn't want to edit objects that weren't shown in the list view.

There's one instance in the current master where `BulkEditMixin` is used without a `ListView`, `apps.customer.notification.UpdateView`. However, that class overrides `get_object_dict` as well and therefore doesn't break. `UpdateView` could be incorporated into the `ListView`s `InboxView` `NotificationListView` to take advantage of their respective get_queryset methods, and to make it clearer that notifications can be archived only from `InboxView`, but deleted from both views.
