### PR TITLE
Fix .travis.yml for Django-1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   matrix:
   - DJANGO_VERSION=1.4.10
   - DJANGO_VERSION=1.5.4
-  - DJANGO_VERSION=http://github.com/django/django/tarball/stable/1.6.x
+  - DJANGO_VERSION=1.6
 install:
   - easy_install Django==$DJANGO_VERSION
 before_script:


### PR DESCRIPTION
This should make Travis CI work again.
