### PR TITLE
[CUSTOMIZATION, 0.6, LOW_RISK] Allow override of RegisterUserMixin

### DIFF
--- a/oscar/apps/customer/views.py
+++ b/oscar/apps/customer/views.py
@@ -17,8 +17,9 @@ from oscar.views.generic import PostActionMixin
 from oscar.apps.customer.utils import get_password_reset_url
 from oscar.core.loading import get_class, get_profile_class, get_classes
 from oscar.core.compat import get_user_model
-from .mixins import PageTitleMixin, RegisterUserMixin
 
+PageTitleMixin, RegisterUserMixin = get_classes(
+    'customer.mixins', ['PageTitleMixin', 'RegisterUserMixin'])
 Dispatcher = get_class('customer.utils', 'Dispatcher')
 EmailAuthenticationForm, EmailUserCreationForm, OrderSearchForm = get_classes(
     'customer.forms', ['EmailAuthenticationForm', 'EmailUserCreationForm',


### PR DESCRIPTION
The user_registered signal is not enough because we extended the
registration form with some fields that we need at user registration.
