### PR TITLE
Demo-site templates hairdressed for oscar 0.6 release

### DIFF
--- a/docs/source/topics/prices_and_availability.rst
+++ b/docs/source/topics/prices_and_availability.rst
@@ -73,7 +73,7 @@ product and returns a ``StockInfo`` instance:
         print "Selected stockrecord is %s" % stock_info.stockrecord
 
 The strategy class is accessed in several places in Oscar's codebase.  In templates, a
-``session_strategy`` template tag is used to load the price and availability
+``purchase_info_for_product`` template tag is used to load the price and availability
 information into the template context:
 
 .. code-block:: html+django
@@ -81,7 +81,7 @@ information into the template context:
    {% load purchase_info_tags %}
    {% load currency_filters %}
 
-   {% session_strategy request product as session %}
+   {% purchase_info_for_product request product as session %}
 
    <p>
    {% if session.price.is_tax_known %}

--- a/sites/demo/templates/basket/partials/basket_content.html
+++ b/sites/demo/templates/basket/partials/basket_content.html
@@ -22,7 +22,7 @@
         {{ formset.management_form }}
 
         {% for form in formset %}
-            {% session_strategy request form.instance.product as session %}
+            {% purchase_info_for_product request form.instance.product as session %}
         <div class="basket-items">
             <div class="row-fluid">
                 <div class="span1">

--- a/sites/demo/templates/catalogue/detail.html
+++ b/sites/demo/templates/catalogue/detail.html
@@ -11,7 +11,7 @@
 {% load purchase_info_tags %}
 {% load i18n %}
 
-{% session_strategy request product as session %}
+{% purchase_info_for_product request product as session %}
 
 {% block body_class %}product-page{% endblock body_class %}
 

--- a/sites/demo/templates/catalogue/partials/product.html
+++ b/sites/demo/templates/catalogue/partials/product.html
@@ -5,7 +5,7 @@
 {% load i18n %}
 {% load purchase_info_tags %}
 
-{% session_strategy request product as session %}
+{% purchase_info_for_product request product as session %}
 
 <article class="product_pod">
     {% block product_image %}

--- a/sites/demo/templates/catalogue/partials/stock_record.html
+++ b/sites/demo/templates/catalogue/partials/stock_record.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load purchase_info_tags %}
 
-{% session_strategy request product as session %}
+{% purchase_info_for_product request product as session %}
 
 {% if product.is_group %}
     <span>{% blocktrans with product.min_variant_price_incl_tax|currency as price %} <i>From</i> {{ price }}{% endblocktrans %}</span>

--- a/sites/demo/templates/checkout/checkout.html
+++ b/sites/demo/templates/checkout/checkout.html
@@ -68,7 +68,7 @@
         </div>
     </div>
     {% for line in basket.all_lines %}
-        {% session_strategy request line.product as session %}
+        {% purchase_info_for_product request line.product as session %}
         <div class="basket-items">
             <div class="row-fluid">
                 <div class="span1">

--- a/sites/demo/templates/promotions/partials/productsingle.html
+++ b/sites/demo/templates/promotions/partials/productsingle.html
@@ -4,7 +4,7 @@
 {% load i18n %}
 {% load purchase_info_tags %}
 
-{% session_strategy request product as session %}
+{% purchase_info_for_product request product as session %}
 
 <div class="row-fluid">
     <div class="span6">


### PR DESCRIPTION
_stockrecord_tags_ library renamed to _purchase_info_tags_ and _session_strategy_ tag renamed to _purchase_info_for_product_.
