### PR TITLE
Made entire phrases translatable rather than individual words

### DIFF
--- a/oscar/templates/oscar/dashboard/index.html
+++ b/oscar/templates/oscar/dashboard/index.html
@@ -102,7 +102,7 @@
                     <td class="span2" >{{ total_revenue|currency }}</td>
             </tr>
             <tr>
-                <th class="span10">{% trans "Total" %} <em>{% trans "open" %}</em> {% trans "baskets" %}</th>
+                <th class="span10">{% trans "Total <em>open</em> baskets" %}</th>
                 <td class="span2" >{{ total_open_baskets }}</td>
             </tr>
         </table>
@@ -120,7 +120,7 @@
                 <td class="span2" >{{ total_customers_last_day }}</td>
             </tr>
             <tr>
-                <th class="span10">{% trans "Total" %} <em>{% trans "open" %}</em> {% trans "baskets" %}</th>
+                <th class="span10">{% trans "Total <em>open</em> baskets" %}</th>
                 <td class="span2" >{{ total_open_baskets_last_day }}</td>
             </tr>
         </table>
@@ -150,11 +150,11 @@
                     <td class="span2" >{{ total_products }}</td>
             </tr>
             <tr>
-                <th class="span10"><em>{% trans "Open" %}</em> {% trans "stock alerts" %}</th>
+                <th class="span10">{% trans "<em>Open</em> stock alerts" %}</th>
                     <td class="span2" >{{ total_open_stock_alerts }}</td>
             </tr>
             <tr>
-                <th class="span10"><em>{% trans "Closed" %}</em> {% trans "stock alerts" %}</th>
+                <th class="span10">{% trans "<em>Closed</em> stock alerts" %}</th>
                     <td class="span2" >{{ total_closed_stock_alerts }}</td>
             </tr>
         </table>
@@ -164,11 +164,11 @@
         <table class="table table-striped table-bordered table-hover">
             <caption><i class="icon-gift icon-large"></i>{% trans "Offers, vouchers and promotions" %}</caption>
             <tr>
-                <th class="span10">{% trans "Active" %} <em>{% trans "Site" %}</em> {% trans "Offers" %}</th>
+                <th class="span10">{% trans "Active <em>Site</em> Offers" %}</th>
                 <td class="span2" >{{ total_site_offers }}</td>
             </tr>
             <tr>
-                <th class="span10">{% trans "Active" %} <em>{% trans "Vouchers" %}</em></th>
+                <th class="span10">{% trans "Active <em>Vouchers</em>" %}</th>
                 <td class="span2" >{{ total_vouchers }}</td>
             </tr>
             <th class="span10">{% trans "Promotions" %}</th>


### PR DESCRIPTION
I made entire phrases translatable rather than individual words in the Dashboard index page.
In Italian language atm they sound like Yoda phrases :)

I had to include the em tags.
Maybe we can include some comments for translators eg

```
{% comment %}Translators: Please respect the em tag for valid HTML output{% endcomment %}
```

https://docs.djangoproject.com/en/dev/topics/i18n/translation/#comments-for-translators-in-templates
