### PR TITLE
Product search in dashboard doesn't strip whitespaces

### DIFF
--- a/oscar/apps/dashboard/catalogue/forms.py
+++ b/oscar/apps/dashboard/catalogue/forms.py
@@ -67,6 +67,12 @@ class ProductSearchForm(forms.Form):
     upc = forms.CharField(max_length=16, required=False, label=_('UPC'))
     title = forms.CharField(max_length=255, required=False, label=_('Title'))
 
+    def clean(self):
+        cleaned_data = super(ProductSearchForm, self).clean()
+        cleaned_data['upc'] = cleaned_data['upc'].strip()
+        cleaned_data['title'] = cleaned_data['title'].strip()
+        return cleaned_data
+
 
 class StockRecordForm(forms.ModelForm):
 


### PR DESCRIPTION
The product search form at /dashboard/catalogue/ won't strip whitespaces and will fail to find a product if title or UPC has a space at start or at the end.
