### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Development
 django-debug-toolbar==0.11
-django-debug-toolbar-template-timings
+django-debug-toolbar-template-timings==0.5.4
 django-extensions>=1.2.0,<1.3.0
 Werkzeug>=0.8.3,<0.9
 


### PR DESCRIPTION
0.5.4 of django-debug-toolbar-template-timings is the last version to support DJDT<1.0 so I've modified requirements.txt to use that version. If you do modify django-oscar to support DJDT>=1.0 then just remove this :)
