### PR TITLE
Ignore textarea.no-wysiwyg elements for tinymce in dashboard

### DIFF
--- a/oscar/static/oscar/js/oscar/dashboard.js
+++ b/oscar/static/oscar/js/oscar/dashboard.js
@@ -148,7 +148,7 @@ var oscar = (function(o, $) {
         },
         initWYSIWYG: function() {
             // Use TinyMCE by default
-            $('form.wysiwyg textarea, textarea.wysiwyg').tinymce(o.dashboard.options.tinyConfig);
+            $('form.wysiwyg textarea, textarea.wysiwyg').not('textarea.no-wysiwyg').tinymce(o.dashboard.options.tinyConfig);
         },
         offers: {
             init: function() {


### PR DESCRIPTION
We don't want to force all textarea's to tinymce widgets
