### PR TITLE
It's not possible to add a product to a Wish List after activating an alert for that product.

### DIFF
--- a/oscar/templates/oscar/catalogue/partials/add_to_basket_form.html
+++ b/oscar/templates/oscar/catalogue/partials/add_to_basket_form.html
@@ -23,6 +23,6 @@
             {% include "partials/form_fields.html" with form=alert_form %}
             <button type="submit" class="btn btn-large btn-info btn-block">{% trans "Notify me" %}</button>
         </form>
-        {% include "catalogue/partials/add_to_wishlist.html" %}
     {% endif %}
+    {% include "catalogue/partials/add_to_wishlist.html" %}
 {% endif %}


### PR DESCRIPTION
The button "Add to wish list" disappears.

![schermata del 2013-11-25 17 54 27](https://f.cloud.github.com/assets/650691/1614999/0e7fe04a-55f3-11e3-87d7-3a68570fd67b.png)
