### PR TITLE
Extend bank number field to allow card types to be specified

### DIFF
--- a/oscar/apps/payment/forms.py
+++ b/oscar/apps/payment/forms.py
@@ -3,6 +3,7 @@ from calendar import monthrange
 import re
 
 from django import forms
+from django.core.exceptions import ImproperlyConfigured
 from django.db.models import get_model
 from django.utils.translation import ugettext_lazy as _
 
@@ -15,6 +16,9 @@ Country = get_model('address', 'Country')
 BillingAddress = get_model('order', 'BillingAddress')
 Bankcard = get_model('payment', 'Bankcard')
 
+# List of card names for all the card types supported in payment.bankcards
+VALID_CARDS = [card_type[0] for card_type in bankcards.CARD_TYPES]
+
 
 class BankcardNumberField(forms.CharField):
 
@@ -24,6 +28,12 @@ class BankcardNumberField(forms.CharField):
             'widget': forms.TextInput(attrs={'autocomplete': 'off'}),
             'label': _("Card number")
         }
+        if 'types' in kwargs:
+            self.accepted_cards = kwargs.pop('types')
+            if not all([card_type in VALID_CARDS for card_type in self.accepted_cards]):
+                raise ImproperlyConfigured('One or more of the accepted_cards is '
+                                           'not in the list of valid_cards')
+
         _kwargs.update(kwargs)
         super(BankcardNumberField, self).__init__(*args, **_kwargs)
 
@@ -38,6 +48,13 @@ class BankcardNumberField(forms.CharField):
         if value and not bankcards.luhn(value):
             raise forms.ValidationError(
                 _("Please enter a valid credit card number."))
+
+        if hasattr(self, 'accepted_cards'):
+            card_type = bankcards.bankcard_type(value)
+            if card_type not in self.accepted_cards:
+                raise forms.ValidationError(
+                    _("%s cards are not accepted." % card_type))
+
         return super(BankcardNumberField, self).clean(value)
 
 
@@ -198,8 +215,13 @@ class BankcardCCVField(forms.RegexField):
             value = value.strip()
         return super(BankcardCCVField, self).clean(value)
 
-
 class BankcardForm(forms.ModelForm):
+    # By default, this number field will accept any number. The only validation
+    # is whether it passes the luhn check. If you wish to only accept certain
+    # types of card, you can pass a types kwarg to BankcardNumberField, e.g.
+    #
+    # BankcardNumberField(types=[bankcards.VISA, bankcards.VISA_ELECTRON,]
+
     number = BankcardNumberField()
     ccv = BankcardCCVField()
     start_month = BankcardStartingMonthField()


### PR DESCRIPTION
It should be possible to specify which bankcards are permitted when using the `BankcardNumberField`, eg:

``` python
class BankcardForm(forms.Form):
    number = BankcardNumberField(types=[VISA_DEBIT, MASTERCARD])
```

The main use-case I've come across is excluding Amex so make sure that use-case works. 
