### PR TITLE
Dashboard Offer Validation Problem [Javascript]

### DIFF
--- a/oscar/static/oscar/js/oscar/dashboard.js
+++ b/oscar/static/oscar/js/oscar/dashboard.js
@@ -161,6 +161,7 @@ var oscar = (function(o, $) {
                 var type = $('#id_type').val(),
                     $valueContainer = $('#id_value').parents('.control-group');
                 if (type == 'Multibuy') {
+                    $('#id_value').val('');
                     $valueContainer.hide();
                 } else {
                     $valueContainer.show();


### PR DESCRIPTION
The problem appears in Dashboard Offer Form, Incentive step (step 2)

If I write a "value" and then i select in the form the Type's option "Discount is to give the cheapest product for free", some javascript (I think Igor Vaynberg's select2.js) hide the value's input, but does not delete the value inserted into it..
So i will see a validation problem because of that value : "Multibuy benefits don't require a value"
I attach some snapshot to make you better understand the problem

![step_1](https://f.cloud.github.com/assets/2088831/1704263/3de62852-60c6-11e3-815c-5085bcce5db4.png)

![step_2](https://f.cloud.github.com/assets/2088831/1704264/42da941a-60c6-11e3-8077-6d5559fe692e.png)

Best regards
