### PR TITLE
Strip html tags from category and product meta descriptions.

### DIFF
--- a/oscar/templates/oscar/catalogue/browse.html
+++ b/oscar/templates/oscar/catalogue/browse.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block description %}
-    {{ category.description }}
+    {{ category.description|striptags }}
 {% endblock %}
 
 {% block headertext %}{{ summary }}{% endblock %}

--- a/oscar/templates/oscar/catalogue/detail.html
+++ b/oscar/templates/oscar/catalogue/detail.html
@@ -15,7 +15,7 @@
 {% endblock %}
 
 {% block description %}
-    {{ product.description }}
+    {{ product.description|striptags }}
 {% endblock %}
 
 {% block breadcrumbs %}


### PR DESCRIPTION
So we can avoid raw tags displayed in search results on google, bing etc..

``` HTML
        <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
        <meta name="created" content="3rd Gen 2014 10:47" />
        <meta name="description" content="
    &lt;p&gt;BUSTA A SACCO AVANA CON SOFFIETTI LATERALI 4CM + FONDO AD INVITO. ADESIVO STRIP.&lt;/p&gt;
" />

    <link rel="shortcut icon" href="/static/favicon.ico" />
```
