### PR TITLE
ShippingEvents are not sorted.

### DIFF
--- a/oscar/apps/order/abstract_models.py
+++ b/oscar/apps/order/abstract_models.py
@@ -833,7 +833,7 @@ class AbstractShippingEvent(models.Model):
         abstract = True
         verbose_name = _("Shipping Event")
         verbose_name_plural = _("Shipping Events")
-        ordering = ['-date_created']
+        ordering = ['-date_created', '-id']
 
     def __unicode__(self):
         return _("Order #%(number)s, type %(type)s") % {


### PR DESCRIPTION
Running the tests I noticed that "shipping status after two full line events" was sometime failing.
I looked at it a bit and noticed that shipping_event_breakdown doesn't returns ordered events.
Here's a fix to make them ordered using SortedDict and ordered queryset.
