### PR TITLE
Fix disappearing mobile menu

### DIFF
--- a/oscar/static/oscar/less/dashboard.less
+++ b/oscar/static/oscar/less/dashboard.less
@@ -974,3 +974,11 @@ textarea.plain {
     background:#222;
   }
 }
+
+// OVERRIDE bootstrap 2.3.1/2.3.2
+// Fix disappearing menu in mobile Android Chrome
+@media (max-width: 480px) {
+  .nav-collapse {
+    -webkit-transform: none;
+  }
+}

--- a/oscar/static/oscar/less/page/responsive-767px-max.less
+++ b/oscar/static/oscar/less/page/responsive-767px-max.less
@@ -127,3 +127,11 @@
 	}
 
 }
+
+// OVERRIDE bootstrap 2.3.1/2.3.2
+// Fix disappearing menu in mobile Android Chrome
+@media (max-width: 480px) {
+	.nav-collapse {
+		-webkit-transform: none;
+	}
+}


### PR DESCRIPTION
Here is the issue on the bootstrap repo
https://github.com/twbs/bootstrap/issues/11145
Can't seem to duplicate the bug via Chrome Dev Tools emulation and Browserstack only tests the Android browser not Chrome. It definitely fixes it on my Galaxy SII Chrome browser. 
I didn't commit the compiled css since running 'make css' creates additional changes to font-awesome paths, not sure why. Sorry.

Comments mention specific versions of bootstrap so it can be easily removable when the switch to v3 takes place.
