### PR TITLE
Use slug instead of id for product_class in URL

### DIFF
--- a/oscar/apps/dashboard/catalogue/app.py
+++ b/oscar/apps/dashboard/catalogue/app.py
@@ -41,7 +41,7 @@ class CatalogueApplication(Application):
             url(r'^products/create/$',
                 self.product_create_redirect_view.as_view(),
                 name='catalogue-product-create'),
-            url(r'^products/create/(?P<product_class_id>\d+)/$',
+            url(r'^products/create/(?P<product_class_slug>[\w-]+)/$',
                 self.product_createupdate_view.as_view(),
                 name='catalogue-product-create'),
             url(r'^products/(?P<pk>\d+)/delete/$',

--- a/oscar/apps/dashboard/catalogue/views.py
+++ b/oscar/apps/dashboard/catalogue/views.py
@@ -146,18 +146,18 @@ class ProductCreateRedirectView(generic.RedirectView):
     def get_product_create_url(self, product_class):
         """ Allow site to provide custom URL """
         return reverse('dashboard:catalogue-product-create',
-                       kwargs={'product_class_id': product_class.id})
+                       kwargs={'product_class_slug': product_class.slug})
 
     def get_invalid_product_class_url(self):
         messages.error(self.request, _("Please choose a product class"))
         return reverse('dashboard:catalogue-product-list')
 
     def get_redirect_url(self, **kwargs):
-        product_class_id = self.request.GET.get('product_class')
-        if product_class_id is None or not product_class_id.isdigit():
+        product_class_slug = self.request.GET.get('product_class')
+        if product_class_slug is None:
             return self.get_invalid_product_class_url()
         try:
-            product_class = ProductClass.objects.get(id=product_class_id)
+            product_class = ProductClass.objects.get(slug=product_class_slug)
         except ProductClass.DoesNotExist:
             return self.get_invalid_product_class_url()
         else:
@@ -203,9 +203,10 @@ class ProductCreateUpdateView(generic.UpdateView):
         self.creating = not 'pk' in self.kwargs
         if self.creating:
             try:
-                product_class_id = self.kwargs.get('product_class_id', None)
+                product_class_slug = self.kwargs.get('product_class_slug',
+                                                     None)
                 self.product_class = ProductClass.objects.get(
-                    id=product_class_id)
+                    slug=product_class_slug)
             except ObjectDoesNotExist:
                 raise Http404
             else:

--- a/tests/functional/dashboard/catalogue_tests.py
+++ b/tests/functional/dashboard/catalogue_tests.py
@@ -36,7 +36,7 @@ class TestAStaffUser(WebTestCase):
         category = G(Category)
         product_class = ProductClass.objects.create(name="Book")
         page = self.get(reverse('dashboard:catalogue-product-create',
-                                args=(product_class.id,)))
+                                args=(product_class.slug,)))
         form = page.form
         form['upc'] = '123456'
         form['title'] = 'new product'
@@ -49,7 +49,7 @@ class TestAStaffUser(WebTestCase):
         category = G(Category)
         product_class = ProductClass.objects.create(name="Book")
         page = self.get(reverse('dashboard:catalogue-product-create',
-                                args=(product_class.id,)))
+                                args=(product_class.slug,)))
         form = page.form
         form['upc'] = '123456'
         form['title'] = 'new product'

--- a/tests/functional/dashboard/product_tests.py
+++ b/tests/functional/dashboard/product_tests.py
@@ -42,10 +42,10 @@ class TestGatewayPage(ProductWebTest):
     def test_redirects_to_form_page_when_valid_query_param(self):
         pclass = G(ProductClass)
         url = reverse('dashboard:catalogue-product-create')
-        response = self.get(url + '?product_class=%d' % pclass.id)
+        response = self.get(url + '?product_class=%s' % pclass.slug)
         self.assertRedirects(response,
                              reverse('dashboard:catalogue-product-create',
-                                     kwargs={'product_class_id': pclass.id}))
+                                     kwargs={'product_class_slug': pclass.slug}))
 
 
 class TestCreateGroupProduct(ProductWebTest):
@@ -57,7 +57,7 @@ class TestCreateGroupProduct(ProductWebTest):
 
     def submit(self, title=None, category=None, upc=None):
         url = reverse('dashboard:catalogue-product-create',
-                      kwargs={'product_class_id': self.pclass.id})
+                      kwargs={'product_class_slug': self.pclass.slug})
 
         product_form = self.get(url).form
 
@@ -113,7 +113,7 @@ class TestCreateChildProduct(ProductWebTest):
 
     def test_categories_are_not_required(self):
         url = reverse('dashboard:catalogue-product-create',
-                      kwargs={'product_class_id': self.pclass.id})
+                      kwargs={'product_class_slug': self.pclass.slug})
         page = self.get(url)
 
         product_form = page.form


### PR DESCRIPTION
This gives more readable URLs and it makes tests (for code that uses oscar with specific product classes that need testing) more maintainable by referring to product classes by the slug that usually doesn't change as opposed to the volatile id.
