### PR TITLE
Can't extend AbstractUser within customised customer app

### DIFF
--- a/oscar/apps/customer/abstract_models.py
+++ b/oscar/apps/customer/abstract_models.py
@@ -13,7 +13,10 @@ from django.utils.translation import ugettext_lazy as _
 from oscar.apps.customer.managers import CommunicationTypeManager
 from oscar.core.compat import AUTH_USER_MODEL
 
+
 if hasattr(auth_models, 'BaseUserManager'):
+    ProductAlert = models.get_model('customer', 'ProductAlert')
+
     # Only define custom UserModel when Django >= 1.5
     class UserManager(auth_models.BaseUserManager):
 
@@ -82,6 +85,23 @@ if hasattr(auth_models, 'BaseUserManager'):
 
         def get_short_name(self):
             return self.first_name
+
+        def _migrate_alerts_to_user(self):
+            """
+            Transfer any active alerts linked to a user's email address to the newly
+            registered user.
+            """
+            alerts = ProductAlert.objects.filter(
+                email=self.email, status=ProductAlert.ACTIVE)
+            alerts.update(user=self, key=None, email=None)
+
+        def save(self, *args, **kwargs):
+            super(AbstractUser, self).save(*args, **kwargs)
+            # Migrate any "anonymous" product alerts to the registered user
+            # Ideally, this would be done via a post-save signal. But we can't
+            # use get_user_model to wire up signals to custom user models
+            # see Oscar ticket #1127, Django ticket #19218
+            self._migrate_alerts_to_user()
 
 
 class AbstractEmail(models.Model):

--- a/oscar/apps/customer/alerts/receivers.py
+++ b/oscar/apps/customer/alerts/receivers.py
@@ -1,12 +1,6 @@
 from django.conf import settings
 from django.db.models import get_model
 from django.db.models.signals import post_save
-from django.db import connection
-
-from oscar.core.compat import get_user_model
-
-
-User = get_user_model()
 
 
 def send_product_alerts(sender, instance, created, **kwargs):
@@ -14,28 +8,6 @@ def send_product_alerts(sender, instance, created, **kwargs):
         return
     from oscar.apps.customer.alerts import utils
     utils.send_product_alerts(instance.product)
-
-
-def migrate_alerts_to_user(sender, instance, created, **kwargs):
-    """
-    Transfer any active alerts linked to a user's email address to the newly
-    registered user.
-    """
-    if not created:
-        return
-    ProductAlert = get_model('customer', 'ProductAlert')
-
-    # This signal will be raised when creating a superuser as part of syncdb,
-    # at which point only a subset of tables will be created.  Thus, we test if
-    # the alert table exists before trying to exercise the ORM.
-    table = ProductAlert._meta.db_table
-    if table in connection.introspection.table_names():
-        alerts = ProductAlert.objects.filter(
-            email=instance.email, status=ProductAlert.ACTIVE)
-        alerts.update(user=instance, key=None, email=None)
-
-
-post_save.connect(migrate_alerts_to_user, sender=User)
 
 
 if settings.OSCAR_EAGER_ALERTS:

--- a/oscar/defaults.py
+++ b/oscar/defaults.py
@@ -61,15 +61,12 @@ OSCAR_MODERATE_REVIEWS = False
 # Accounts
 OSCAR_ACCOUNTS_REDIRECT_URL = 'customer:profile-view'
 
-# This enables sending alert notifications/emails
-# instantly when products get back in stock
-# by listening to stock record update signals
-# this might impact performace for large numbers
-# stock record updates.
-# Alternatively, the management command
-# ``oscar_send_alerts`` can be used to
-# run periodically, e.g. as a cronjob. In this case
-# instant alerts should be disabled.
+# This enables sending alert notifications/emails instantly when products get
+# back in stock by listening to stock record update signals.
+# This might impact performance for large numbers of stock record updates.
+# Alternatively, the management command ``oscar_send_alerts`` can be used to
+# run periodically, e.g. as a cron job. In this case eager alerts should be
+# disabled.
 OSCAR_EAGER_ALERTS = True
 
 # Registration


### PR DESCRIPTION
According to Django [documentation](https://docs.djangoproject.com/en/1.6/topics/auth/customizing/#custom-users-and-signals) we cant' use `get_user_model` in [this](https://github.com/tangentlabs/django-oscar/blob/master/oscar/apps/customer/alerts/receivers.py#L9) context.

Related Django bug - https://code.djangoproject.com/ticket/19218.

I'm still thinking it's a bug in Django, but it's always easier to document the limitations. :)
