### PR TITLE
IOError at /dashboard/catalogue/products/create

### DIFF
--- a/oscar/apps/dashboard/catalogue/views.py
+++ b/oscar/apps/dashboard/catalogue/views.py
@@ -253,10 +253,6 @@ class ProductCreateUpdateView(generic.UpdateView):
         if is_valid and cross_form_validation_result:
             return self.forms_valid(form, formsets)
         else:
-            # delete the temporary product again
-            if self.creating and self.object and self.object.pk is not None:
-                self.object.delete()
-                self.object = None
             return self.forms_invalid(form, formsets)
 
     # form_valid and form_invalid are called depending on the validation result
@@ -291,6 +287,20 @@ class ProductCreateUpdateView(generic.UpdateView):
         return HttpResponseRedirect(self.get_success_url())
 
     def forms_invalid(self, form, formsets):
+        # delete the temporary product again
+        if self.creating and self.object and self.object.pk is not None:
+            self.object.delete()
+            self.object = None
+
+        # We currently don't hold on to images if the other formsets didn't
+        # validate. But as the browser won't re-POST any images, we can do no
+        # better than re-bind the image formset, which means the user will
+        # have to re-select the images
+        image_formset_class = self.formsets.get('image_formset')
+        if 'image_formset' in formsets and image_formset_class is not None:
+            formsets['image_formset'] = image_formset_class(
+                self.product_class, self.request.user, instance=self.object)
+
         messages.error(self.request,
                        _("Your submitted data was not valid - please "
                          "correct the below errors"))


### PR DESCRIPTION
Django oscar 0.6 installed via pip

The error indicated below occurs when a variant product is created (pointing to a parent product) with product category selected and at least one image selected.

The bug does not occur when no category is selected.  Also if no image is selected and a product category is selected,  a correct warning is given that no category should be selected for creating variant product.

IOError at /dashboard/catalogue/products/create/1/

[Errno 2] No such file or directory: u'/home/administrator/git/winkel/media/P1040923.JPG'

Request Method:     POST
Request URL:    http://local.winkel.com/dashboard/catalogue/products/create/1/
Django Version:     1.6.1
Exception Type:     IOError
Exception Value:    

[Errno 2] No such file or directory: u'/home/administrator/git/winkel/media/P1040923.JPG'
