### PR TITLE
Clean reset password form

### DIFF
--- a/oscar/apps/customer/forms.py
+++ b/oscar/apps/customer/forms.py
@@ -40,11 +40,8 @@ class PasswordResetForm(auth_forms.PasswordResetForm):
     """
     communication_type_code = "PASSWORD_RESET"
 
-    def save(self, domain_override=None,
-             subject_template_name='registration/password_reset_subject.txt',
-             email_template_name='registration/password_reset_email.html',
-             use_https=False, token_generator=default_token_generator,
-             from_email=None, request=None, **kwargs):
+    def save(self, domain_override=None, use_https=False, request=None,
+             **kwargs):
         """
         Generates a one-use only link for resetting password and sends to the
         user.

--- a/oscar/templates/oscar/registration/password_reset_subject.txt
+++ b/oscar/templates/oscar/registration/password_reset_subject.txt
@@ -1,1 +1,0 @@
-{% load i18n %}{% autoescape off %}{% blocktrans %}Password reset on {{ site_name }}{% endblocktrans %}{% endautoescape %}


### PR DESCRIPTION
- Removed arguments for the password form that were not used
  (they are still catched by kwargs, not breaking backwards compatibility)
- Subject template is picked up from oscar/customer/emails folder.
  Removed unused template.
