### PR TITLE
Support arbitrary number of permission lists

### DIFF
--- a/oscar/views/decorators.py
+++ b/oscar/views/decorators.py
@@ -52,8 +52,9 @@ def staff_member_required(view_func, login_url=None):
 
 def check_permissions(user, permissions):
     """
-    Permissions can be a list or a two-tuple of lists. If it is a two-tuple,
-    both permission lists will be evaluated and the outcome will be or'ed.
+    Permissions can be a list or a tuple of lists. If it is a tuple,
+    every permission list will be evaluated and the outcome will be checked
+    for truthiness.
     Each item of the list(s) must be either a valid Django permission name
     (model.codename) or an attribute on the User model
     (e.g. 'is_active', 'is_superuser').
@@ -80,14 +81,13 @@ def check_permissions(user, permissions):
     elif isinstance(permissions, list):
         return _check_one_permission_list(permissions)
     else:
-        return (_check_one_permission_list(permissions[0]) or
-                _check_one_permission_list(permissions[1]))
+        return any(_check_one_permission_list(perm) for perm in permissions)
 
 
 def permissions_required(permissions, login_url=None):
     """
     Decorator that checks if a user has the given permissions.
-    Accepts a list or two-tuple of lists of permissions (see check_permissions
+    Accepts a list or tuple of lists of permissions (see check_permissions
     documentation).
     If the user is not logged in and the test fails, she is redirected to a
     login page. If the user is logged in, she gets a HTTP 403 Permission Denied


### PR DESCRIPTION
I'd like to propose small enhancement to Oscar's permission system.

Currently it's only possible to define permissions as a list or a tuple of two lists, it's not always sufficient.

Simple use case - you need to support several types of non-staff accounts which can access dashboard's specific pages. You extend user model with two boolean fields, for example, `is_manager` and `is_content_manager`. Now you need to re-define application specific `default_permissions` or `permissions_map`, but it's not possible to add more that two distinct roles and you already have `is_staff` and `partner.dashboard_access`.

The proposed implementation may help in such scenarios and should be backwards compatible.
