### PR TITLE
Added block super into dahsboard body class blocks

### DIFF
--- a/oscar/templates/oscar/dashboard/catalogue/category_delete.html
+++ b/oscar/templates/oscar/dashboard/catalogue/category_delete.html
@@ -2,9 +2,7 @@
 {% load url from future %}
 {% load i18n %}
 
-{% block body_class %}
-    create-page
-{% endblock %}
+{% block body_class %}{{ block.super }} create-page{% endblock %}
 
 {% block breadcrumbs %}
     <ul class="breadcrumb">

--- a/oscar/templates/oscar/dashboard/catalogue/category_form.html
+++ b/oscar/templates/oscar/dashboard/catalogue/category_form.html
@@ -3,7 +3,7 @@
 {% load category_tags %}
 {% load i18n %}
 
-{% block body_class %}create-page catalogue{% endblock %}
+{% block body_class %}{{ block.super }} create-page catalogue{% endblock %}
 
 {% block title %}
     {{ title }} | {% trans "Category management" %} | {{ block.super }}

--- a/oscar/templates/oscar/dashboard/catalogue/category_list.html
+++ b/oscar/templates/oscar/dashboard/catalogue/category_list.html
@@ -3,7 +3,7 @@
 {% load category_tags %}
 {% load i18n %}
 
-{% block body_class %}catalogue{% endblock %}
+{% block body_class %}{{ block.super }} catalogue{% endblock %}
 
 {% block title %}
     {% trans "Category management" %} | {{ block.super }}

--- a/oscar/templates/oscar/dashboard/catalogue/product_delete.html
+++ b/oscar/templates/oscar/dashboard/catalogue/product_delete.html
@@ -10,9 +10,7 @@
     {{ block.super }}
 {% endblock %}
 
-{% block body_class %}
-    create-page
-{% endblock %}
+{% block body_class %}{{ block.super }} create-page{% endblock %}
 
 {% block breadcrumbs %}
     <ul class="breadcrumb">

--- a/oscar/templates/oscar/dashboard/catalogue/product_list.html
+++ b/oscar/templates/oscar/dashboard/catalogue/product_list.html
@@ -5,7 +5,7 @@
 {% load staticfiles %}
 {% load sorting_tags %}
 
-{% block body_class %}catalogue{% endblock %}
+{% block body_class %}{{ block.super }} catalogue{% endblock %}
 
 {% block title %}
     {% trans "Product management" %} | {{ block.super }}

--- a/oscar/templates/oscar/dashboard/catalogue/product_update.html
+++ b/oscar/templates/oscar/dashboard/catalogue/product_update.html
@@ -5,7 +5,7 @@
 {% load staticfiles %}
 
 
-{% block body_class %}create-page catalogue{% endblock %}
+{% block body_class %}{{ block.super }} create-page catalogue{% endblock %}
 
 {% block title %}
     {{ title }} | {% trans "Product management" %} | {{ block.super }}

--- a/oscar/templates/oscar/dashboard/catalogue/stockalert_list.html
+++ b/oscar/templates/oscar/dashboard/catalogue/stockalert_list.html
@@ -3,7 +3,7 @@
 {% load url from future %}
 {% load i18n %}
 
-{% block body_class %}catalogue{% endblock %}
+{% block body_class %}{{ block.super }} catalogue{% endblock %}
 
 {% block title %}
 {% trans "Stock alerts" %} | {{ block.super }}

--- a/oscar/templates/oscar/dashboard/comms/detail.html
+++ b/oscar/templates/oscar/dashboard/comms/detail.html
@@ -3,9 +3,7 @@
 {% load url from future %}
 
 {% load i18n %}
-{% block body_class %}
-    create-page default
-{% endblock %}
+{% block body_class %}{{ block.super }} create-page{% endblock %}
 
 {% block title %}
     {{ commtype.name }} | {{ block.super }}

--- a/oscar/templates/oscar/dashboard/index.html
+++ b/oscar/templates/oscar/dashboard/index.html
@@ -3,7 +3,7 @@
 {% load currency_filters %}
 {% load i18n %}
 
-{% block body_class %}orders home{% endblock %}
+{% block body_class %}{{ block.super }} orders home{% endblock %}
 
 {% block extrahead %}
     {{ block.super }}

--- a/oscar/templates/oscar/dashboard/offers/offer_delete.html
+++ b/oscar/templates/oscar/dashboard/offers/offer_delete.html
@@ -2,9 +2,7 @@
 {% load url from future %}
 {% load i18n %}
 
-{% block body_class %}
-    create-page
-{% endblock %}
+{% block body_class %}{{ block.super }} create-page{% endblock %}
 
 {% block title %}
     {% trans "Delete offer" %} | {% trans "Offer management" %} | {{ block.super }}

--- a/oscar/templates/oscar/dashboard/offers/step_form.html
+++ b/oscar/templates/oscar/dashboard/offers/step_form.html
@@ -5,7 +5,7 @@
 
 {% load i18n %}
 
-{% block body_class %}create-page{% endblock %}
+{% block body_class %}{{ block.super }} create-page{% endblock %}
 
 {% block title %}
     {% if offer.pk %}

--- a/oscar/templates/oscar/dashboard/orders/order_detail.html
+++ b/oscar/templates/oscar/dashboard/orders/order_detail.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 {% load currency_filters %}
 
-{% block body_class %}orders{% endblock %}
+{% block body_class %}{{ block.super }} orders{% endblock %}
 
 {% block title %}
     {% blocktrans with number=order.number %}Order {{ number }}{% endblocktrans %} | {{ block.super }}

--- a/oscar/templates/oscar/dashboard/orders/order_list.html
+++ b/oscar/templates/oscar/dashboard/orders/order_list.html
@@ -4,7 +4,7 @@
 {% load sorting_tags %}
 {% load i18n %}
 
-{% block body_class %}orders{% endblock %}
+{% block body_class %}{{ block.super }} orders{% endblock %}
 
 {% block title %}
     {% trans "Order management" %} | {{ block.super }}

--- a/oscar/templates/oscar/dashboard/orders/statistics.html
+++ b/oscar/templates/oscar/dashboard/orders/statistics.html
@@ -3,7 +3,7 @@
 {% load currency_filters %}
 {% load i18n %}
 
-{% block body_class %}orders{% endblock %}
+{% block body_class %}{{ block.super }} orders{% endblock %}
 
 {% block title %}
     {% trans "Order statistics" %} | {{ block.super }}

--- a/oscar/templates/oscar/dashboard/pages/delete.html
+++ b/oscar/templates/oscar/dashboard/pages/delete.html
@@ -2,9 +2,7 @@
 {% load url from future %}
 {% load i18n %}
 
-{% block body_class %}
-    create-page
-{% endblock %}
+{% block body_class %}{{ block.super }} create-page{% endblock %}
 
 {% block title %}
     {% blocktrans with title=object.title %}Delete page '{{ title }}'?{% endblocktrans %}

--- a/oscar/templates/oscar/dashboard/pages/index.html
+++ b/oscar/templates/oscar/dashboard/pages/index.html
@@ -3,7 +3,7 @@
 {% load dashboard_tags %}
 {% load i18n %}
 
-{% block body_class %}pages{% endblock %}
+{% block body_class %}{{ block.super }} pages{% endblock %}
 
 {% block title %}
     {% trans "Pages" %} | {{ block.super }}

--- a/oscar/templates/oscar/dashboard/pages/update.html
+++ b/oscar/templates/oscar/dashboard/pages/update.html
@@ -3,7 +3,7 @@
 {% load url from future %}
 {% load i18n %}
 
-{% block body_class %}create-page pages{% endblock %}
+{% block body_class %}{{ block.super }} create-page pages{% endblock %}
 {% block title %}
 {{ title }} | {{ block.super }}
 {% endblock %}

--- a/oscar/templates/oscar/dashboard/partners/partner_delete.html
+++ b/oscar/templates/oscar/dashboard/partners/partner_delete.html
@@ -2,9 +2,7 @@
 {% load i18n %}
 {% load url from future %}
 
-{% block body_class %}
-    create-page
-{% endblock %}
+{% block body_class %}{{ block.super }} create-page{% endblock %}
 
 {% block title %}
     {% trans "Delete partner" %} | {% trans "Partner management" %} | {{ block.super }}

--- a/oscar/templates/oscar/dashboard/partners/partner_form.html
+++ b/oscar/templates/oscar/dashboard/partners/partner_form.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 {% load url from future %}
 
-{% block body_class %}create-page partner{% endblock %}
+{% block body_class %}{{ block.super }} create-page partner{% endblock %}
 
 {% block title %}
     {{ title }} | {% trans "Partner management" %} | {{ block.super }}

--- a/oscar/templates/oscar/dashboard/partners/partner_user_form.html
+++ b/oscar/templates/oscar/dashboard/partners/partner_user_form.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 {% load url from future %}
 
-{% block body_class %}create-page partner{% endblock %}
+{% block body_class %}{{ block.super }} create-page partner{% endblock %}
 
 {% block title %}
     {{ title }} | {{ partner.name }} | {% trans "Partner management" %} | {{ block.super }}

--- a/oscar/templates/oscar/dashboard/promotions/delete.html
+++ b/oscar/templates/oscar/dashboard/promotions/delete.html
@@ -2,9 +2,7 @@
 {% load url from future %}
 {% load i18n %}
 
-{% block body_class %}
-    create-page
-{% endblock %}
+{% block body_class %}{{ block.super }} create-page{% endblock %}
 
 {% block title %}
     {% blocktrans with name=object.name %}Delete content block '{{ name }}'?"{% endblocktrans %}

--- a/oscar/templates/oscar/dashboard/promotions/delete_pagepromotion.html
+++ b/oscar/templates/oscar/dashboard/promotions/delete_pagepromotion.html
@@ -2,9 +2,7 @@
 {% load url from future %}
 {% load i18n %}
 
-{% block body_class %}
-    create-page
-{% endblock %}
+{% block body_class %}{{ block.super }} create-page{% endblock %}
 
 {% block breadcrumbs %}
     <ul class="breadcrumb">

--- a/oscar/templates/oscar/dashboard/promotions/form.html
+++ b/oscar/templates/oscar/dashboard/promotions/form.html
@@ -2,7 +2,7 @@
 {% load url from future %}
 {% load i18n %}
 
-{% block body_class %}create-page promotions{% endblock %}
+{% block body_class %}{{ block.super }} create-page promotions{% endblock %}
 
 {% block breadcrumbs %}
     <ul class="breadcrumb">

--- a/oscar/templates/oscar/dashboard/promotions/page_detail.html
+++ b/oscar/templates/oscar/dashboard/promotions/page_detail.html
@@ -4,7 +4,7 @@
 
 {% load i18n %}
 
-{% block body_class %}promotions{% endblock %}
+{% block body_class %}{{ block.super }} promotions{% endblock %}
 
 {% block title %}
     {% blocktrans %}Content blocks for page {{ page_url }}{% endblocktrans %} | {{ block.super }}

--- a/oscar/templates/oscar/dashboard/promotions/pagepromotion_list.html
+++ b/oscar/templates/oscar/dashboard/promotions/pagepromotion_list.html
@@ -2,7 +2,7 @@
 {% load url from future %}
 {% load i18n %}
 
-{% block body_class %}content-blocks{% endblock %}
+{% block body_class %}{{ block.super }} content-blocks{% endblock %}
 
 {% block headertext %}
     {% trans "Content block management" %}

--- a/oscar/templates/oscar/dashboard/promotions/promotion_list.html
+++ b/oscar/templates/oscar/dashboard/promotions/promotion_list.html
@@ -2,7 +2,7 @@
 {% load url from future %}
 {% load i18n %}
 
-{% block body_class %}content-blocks{% endblock %}
+{% block body_class %}{{ block.super }} content-blocks{% endblock %}
 
 {% block title %}
     {% trans "Content blocks" %} | {{ block.super }}

--- a/oscar/templates/oscar/dashboard/ranges/range_delete.html
+++ b/oscar/templates/oscar/dashboard/ranges/range_delete.html
@@ -2,9 +2,7 @@
 {% load url from future %}
 {% load i18n %}
 
-{% block body_class %}
-    create-page
-{% endblock %}
+{% block body_class %}{{ block.super }} create-page{% endblock %}
 
 {% block title %}
     {% blocktrans with name=range.name %}Delete range '{{ name }}'?{% endblocktrans %} | {% trans "Range management" %} | {{ block.super }}

--- a/oscar/templates/oscar/dashboard/ranges/range_form.html
+++ b/oscar/templates/oscar/dashboard/ranges/range_form.html
@@ -2,7 +2,7 @@
 {% load url from future %}
 {% load i18n %}
 
-{% block body_class %}create-page{% endblock %}
+{% block body_class %}{{ block.super }} create-page{% endblock %}
 
 {% block title %}
     {{ title }} | {% trans "Range management" %} | {{ block.super }}

--- a/oscar/templates/oscar/dashboard/ranges/range_product_list.html
+++ b/oscar/templates/oscar/dashboard/ranges/range_product_list.html
@@ -2,7 +2,7 @@
 {% load url from future %}
 {% load i18n %}
 
-{% block body_class %}create-page{% endblock %}
+{% block body_class %}{{ block.super }} create-page{% endblock %}
 
 {% block title %}
     {% blocktrans with name=range.name %}Products in range '{{ name }}'{% endblocktrans %} | {{ block.super }}

--- a/oscar/templates/oscar/dashboard/reports/index.html
+++ b/oscar/templates/oscar/dashboard/reports/index.html
@@ -2,7 +2,7 @@
 {% load url from future %}
 {% load i18n %}
 
-{% block body_class %}reports{% endblock %}
+{% block body_class %}{{ block.super }} reports{% endblock %}
 {% block title %}
     {% trans "Reports" %} | {{ block.super }}
 {% endblock %}

--- a/oscar/templates/oscar/dashboard/reviews/review_delete.html
+++ b/oscar/templates/oscar/dashboard/reviews/review_delete.html
@@ -3,9 +3,7 @@
 {% load currency_filters %}
 {% load i18n %}
 
-{% block body_class %}
-    create-page
-{% endblock %}
+{% block body_class %}{{ block.super }} create-page{% endblock %}
 
 {% block title %}
     {% blocktrans with title=review.title|truncatechars:30 %}Delete review '{{ title }}'?{% endblocktrans %} | {% trans "Review management" %} | {{ block.super }}

--- a/oscar/templates/oscar/dashboard/reviews/review_list.html
+++ b/oscar/templates/oscar/dashboard/reviews/review_list.html
@@ -4,7 +4,7 @@
 {% load sorting_tags %}
 {% load i18n %}
 
-{% block body_class %}reviews{% endblock %}
+{% block body_class %}{{ block.super }} reviews{% endblock %}
 {% block title %}
     {% trans "Reviews" %} | {{ block.super }}
 {% endblock %}

--- a/oscar/templates/oscar/dashboard/reviews/review_update.html
+++ b/oscar/templates/oscar/dashboard/reviews/review_update.html
@@ -3,7 +3,7 @@
 {% load currency_filters %}
 {% load i18n %}
 
-{% block body_class %}create-page{% endblock %}
+{% block body_class %}{{ block.super }} create-page{% endblock %}
 
 {% block title %}
     {% trans "Update review" %} | {{ block.super }}

--- a/oscar/templates/oscar/dashboard/users/alerts/delete.html
+++ b/oscar/templates/oscar/dashboard/users/alerts/delete.html
@@ -3,7 +3,7 @@
 {% load url from future %}
 {% load i18n %}
 
-{% block body_class %}create-page users{% endblock %}
+{% block body_class %}{{ block.super }} create-page users{% endblock %}
 
 {% block title %}
     {% blocktrans with id=alert.id %}Alert #{{ id }}{% endblocktrans %} | {{ block.super }}

--- a/oscar/templates/oscar/dashboard/users/alerts/list.html
+++ b/oscar/templates/oscar/dashboard/users/alerts/list.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 {% load currency_filters %}
 
-{% block body_class %}users{% endblock %}
+{% block body_class %}{{ block.super }} users{% endblock %}
 
 {% block title %}
     {% trans "Product alerts" %} | {{ block.super }}

--- a/oscar/templates/oscar/dashboard/users/alerts/update.html
+++ b/oscar/templates/oscar/dashboard/users/alerts/update.html
@@ -2,7 +2,7 @@
 {% load url from future %}
 {% load i18n %}
 
-{% block body_class %}users{% endblock %}
+{% block body_class %}{{ block.super }} users{% endblock %}
 
 {% block title %}
     {% blocktrans with id=alert.id %}Update alert #{{ id }}{% endblocktrans %} | {{ block.super }}

--- a/oscar/templates/oscar/dashboard/users/detail.html
+++ b/oscar/templates/oscar/dashboard/users/detail.html
@@ -3,7 +3,7 @@
 {% load currency_filters %}
 {% load i18n %}
 
-{% block body_class %}users{% endblock %}
+{% block body_class %}{{ block.super }} users{% endblock %}
 
 {% block title %}
     {% blocktrans with email=customer.email %}{{ email }}{% endblocktrans %} | {{ block.super }}

--- a/oscar/templates/oscar/dashboard/users/index.html
+++ b/oscar/templates/oscar/dashboard/users/index.html
@@ -3,7 +3,7 @@
 {% load dashboard_tags %}
 {% load i18n %}
 
-{% block body_class %}users{% endblock %}
+{% block body_class %}{{ block.super }} users{% endblock %}
 
 {% block title %}
     {% trans "Customers" %} | {{ block.super }}

--- a/oscar/templates/oscar/dashboard/vouchers/voucher_delete.html
+++ b/oscar/templates/oscar/dashboard/vouchers/voucher_delete.html
@@ -3,9 +3,7 @@
 {% load currency_filters %}
 {% load i18n %}
 
-{% block body_class %}
-    create-page
-{% endblock %}
+{% block body_class %}{{ block.super }} create-page{% endblock %}
 
 {% block title %}
     {% blocktrans with name=voucher.name %}Delete voucher '{{ name }}'?{% endblocktrans %} | {% trans "Vouchers" %} | {{ block.super }}

--- a/oscar/templates/oscar/dashboard/vouchers/voucher_form.html
+++ b/oscar/templates/oscar/dashboard/vouchers/voucher_form.html
@@ -3,9 +3,7 @@
 {% load currency_filters %}
 {% load i18n %}
 
-{% block body_class %}
-    create-page default
-{% endblock %}
+{% block body_class %}{{ block.super }} create-page{% endblock %}
 
 {% block title %}
     {{ title }} | {% trans "Vouchers" %} | {{ block.super }}


### PR DESCRIPTION
## Added block super into dashboard body class blocks

I was modifying the dashboard for another project that uses arabic language and rtl direction and I was looking to add a body class in the dashboard layout, something like bidi-ltr and bidi-rtl so I could use this make any dashboard style changes for languages right to left. But there are other classes added to different dashboard templates. So I have added {{ block.super }} into dashboard templates that contain {% block body_class %}

**Related pull request for direction RTL**
https://github.com/tangentlabs/magrudys-matjaro/pull/88

**Notes**
On a related note with these dashboard body classes -- at one point some of these classes help distinguish where the current section of the dashboard you were in. Am not sure this is working -- so maybe these excess ones should be removed?
