### PR TITLE
Fix JSON serialization in ObjectLookupView.

### DIFF
--- a/oscar/views/generic.py
+++ b/oscar/views/generic.py
@@ -141,7 +141,7 @@ class ObjectLookupView(View):
             qs, more = self.paginate(qs, page, page_limit)
 
         return HttpResponse(json.dumps({
-            'results': map(self.format_object, qs),
+            'results': list(map(self.format_object, qs)),
             'more': more,
         }), mimetype='application/json')
 


### PR DESCRIPTION
Related products search field in dashboard (create product page) failed with following error:

```
Avoid TypeError: <itertools.imap object …> is not JSON serializable
```

(used master branch of django-oscar)
