### PR TITLE
Assign basket to request before check stockrecords and apply offers.

### DIFF
--- a/oscar/apps/basket/middleware.py
+++ b/oscar/apps/basket/middleware.py
@@ -21,11 +21,10 @@ class BasketMiddleware(object):
         strategy = selector.strategy(
             request=request, user=request.user)
         request.strategy = basket.strategy = strategy
+        request.basket = basket
 
         self.ensure_basket_lines_have_stockrecord(basket)
-
         self.apply_offers_to_basket(request, basket)
-        request.basket = basket
 
     def get_basket(self, request):
         """


### PR DESCRIPTION
If pricing policy in strategies have some logic depends on basket lines (or basket object itself), then `apply_offers_to_basket` in basket's middleware running before request have assigned basket object.
