### PR TITLE
Handle removed search fields in customized ProductSearchForms

### DIFF
--- a/oscar/apps/dashboard/catalogue/views.py
+++ b/oscar/apps/dashboard/catalogue/views.py
@@ -124,12 +124,12 @@ class ProductListView(generic.ListView):
 
         data = self.form.cleaned_data
 
-        if data['upc']:
+        if data.get('upc', None):
             queryset = queryset.filter(upc=data['upc'])
             description_ctx['upc_filter'] = _(
                 " including an item with UPC '%s'") % data['upc']
 
-        if data['title']:
+        if data.get('title', None):
             queryset = queryset.filter(
                 title__icontains=data['title']).distinct()
             description_ctx['title_filter'] = _(


### PR DESCRIPTION
This change allows implementors to remove the upc or title field from the search form without having to duplicate code in `apply_search`.
