### PR TITLE
Preserve sort order in search form

### DIFF
--- a/oscar/templates/oscar/dashboard/catalogue/product_list.html
+++ b/oscar/templates/oscar/dashboard/catalogue/product_list.html
@@ -33,6 +33,11 @@
         </div>
         <div class="well">
             <form action="." method="get" class="form-inline">
+                {% for name, value in request.GET.items %}
+                    {% if name not in form.fields %}
+                        <input type="hidden" name="{{ name }}" value="{{ value }}"/>
+                    {% endif %}
+                {% endfor %}
                 {% include "partials/form_fields_inline.html" with form=form %}
                 <button type="submit" class="btn btn-primary">{% trans "Search" %}</button>
             </form>


### PR DESCRIPTION
When you do a search in the product list, sort ordering is lost.

Sort order in the product list is kept in the query string – GET variables. Add the current query string to the search form so that the sort order is not reset when searching.
