### PR TITLE
Fix of absent discount attribute in shipping models

### DIFF
--- a/oscar/apps/shipping/models.py
+++ b/oscar/apps/shipping/models.py
@@ -96,6 +96,10 @@ class OrderAndItemCharges(ShippingMethod):
         # We assume tax is known
         return True
 
+    @property
+    def discount(self):
+        return D('0.00')
+
 
 class WeightBased(ShippingMethod):
     upper_charge = models.DecimalField(
@@ -138,6 +142,10 @@ class WeightBased(ShippingMethod):
     def is_tax_known(self):
         # We assume tax is known
         return True
+
+    @property
+    def discount(self):
+        return D('0.00')
 
     def get_band_for_weight(self, weight):
         """


### PR DESCRIPTION
It's necessary for place_order in oscar.apps.order.utils [here](https://github.com/tangentlabs/django-oscar/blob/master/oscar/apps/order/utils.py#L82):

``` python
…
            if application['result'].affects_shipping:
                # Skip zero shipping discounts
                if shipping_method.discount <= D('0.00'):
                    continue
                # If a shipping offer, we need to grab the actual discount off
                # the shipping method instance, which should be wrapped in an
                # OfferDiscount instance.
                application['discount'] = shipping_method.discount
…
```

Purposes of existence of this attribute (or property) is not clear for me. Where it must be used considering that this property is not model field? I saw source code logic depends on it, and found almost nothing. It's always zero, except use case in OfferDiscount model (and inherited TaxExclusiveOfferDiscount, TaxInclusiveOfferDiscount).
