### PR TITLE
Support dynamic formsets

### DIFF
--- a/oscar/static/oscar/js/oscar/dashboard.js
+++ b/oscar/static/oscar/js/oscar/dashboard.js
@@ -33,7 +33,7 @@ var oscar = (function(o, $) {
             };
             o.dashboard.options = $.extend(defaults, options);
 
-            o.dashboard.initWidgets();
+            o.dashboard.initWidgets(window.document);
 
             $('.scroll-pane').jScrollPane();
 
@@ -56,17 +56,28 @@ var oscar = (function(o, $) {
 
             o.dashboard.filereader.init();
         },
-        initWidgets: function() {
-            o.dashboard.initDatePickers();
-            o.dashboard.initWYSIWYG();
-            o.dashboard.initSelects();
+        initWidgets: function(el) {
+            /** Attach widgets to form input.
+             *
+             * This function is called once for the whole page. In that case el is window.document.
+             *
+             * It is also called when input elements have been dynamically added. In that case el
+             * contains the newly added elements.
+             *
+             * If the element selector refers to elements that may be outside of newly added
+             * elements, don't limit to elements within el. Then the operation will be performed
+             * twice for these elements. Make sure that that is harmless.
+             */
+            o.dashboard.initDatePickers(el);
+            o.dashboard.initWYSIWYG(el);
+            o.dashboard.initSelects(el);
         },
-        initSelects: function() {
+        initSelects: function(el) {
             // Adds type/search for select fields
             $('.form-stacked select:visible').css('width', '95%');
             $('.form-inline select:visible').css('width', '300px');
-            $('select:visible').select2({width: 'resolve'});
-            $('input.select2:visible').each(function(i, e) {
+            $(el).find('select:visible').select2({width: 'resolve'});
+            $(el).find('input.select2:visible').each(function(i, e) {
                 var opts = {};
                 if($(e).data('ajax-url')) {
                     opts = {
@@ -111,11 +122,11 @@ var oscar = (function(o, $) {
                 $(e).select2(opts);
             });
         },
-        initDatePickers: function() {
+        initDatePickers: function(el) {
             // Use datepicker for all inputs that have 'date' or 'datetime' in the name
             if ($.datepicker) {
                 var defaultDatepickerConfig = {'dateFormat': o.dashboard.options.dateFormat};
-                $('input[name^="date"]:visible, input[name$="date"]:visible').each(function(ind, ele) {
+                $(el).find('input[name^="date"]:visible, input[name$="date"]:visible').each(function(ind, ele) {
                     var $ele = $(ele),
                         config = $.extend({}, defaultDatepickerConfig, {
                             'dateFormat': $ele.data('dateformat')
@@ -129,7 +140,7 @@ var oscar = (function(o, $) {
                     'timeFormat': o.dashboard.options.timeFormat,
                     'stepMinute': o.dashboard.options.stepMinute
                 };
-                $('input[name$="datetime"]:visible').each(function(ind, ele) {
+                $(el).find('input[name$="datetime"]:visible').each(function(ind, ele) {
                     var $ele = $(ele),
                         config = $.extend({}, defaultDatetimepickerConfig, {
                         'dateFormat': $ele.data('dateformat'),
@@ -142,7 +153,7 @@ var oscar = (function(o, $) {
                     'timeFormat': o.dashboard.options.timeFormat,
                     'stepMinute': o.dashboard.options.stepMinute
                 };
-                $('input[name$="time"]:visible').not('input[name$="datetime"]').each(function(ind, ele) {
+                $(el).find('input[name$="time"]:visible').not('input[name$="datetime"]').each(function(ind, ele) {
                     var $ele = $(ele),
                         config = $.extend({}, defaultTimepickerConfig, {
                         'timeFormat': $ele.data('timeformat'),
@@ -151,9 +162,10 @@ var oscar = (function(o, $) {
                 });
             }
         },
-        initWYSIWYG: function() {
+        initWYSIWYG: function(el) {
             // Use TinyMCE by default
-            $('form.wysiwyg textarea:visible, textarea.wysiwyg:visible').tinymce(o.dashboard.options.tinyConfig);
+            $('form.wysiwyg textarea:visible').tinymce(o.dashboard.options.tinyConfig);
+            $(el).find('textarea.wysiwyg:visible').tinymce(o.dashboard.options.tinyConfig);
         },
         offers: {
             init: function() {


### PR DESCRIPTION
These changes make it easier to implement dynamic formsets in implementations of oscar in two ways:
1. Initialize widgets like select2 and the wysiwyg editor only on visible elements. That way a hidden empty form template is left alone. The form template is usually cloned to add a new form to a formset. Cloning a select2 widget got select2 mighty confused (it didn't know the correct position of the `<input>` and all cloned inputs were controlled by the same select widget).
2. Provide a function to initialize these widgets on a new form has been added dynamically.
