### PR TITLE
Fix missing link to offers list in offer details view.

### DIFF
--- a/oscar/templates/oscar/offer/detail.html
+++ b/oscar/templates/oscar/offer/detail.html
@@ -15,7 +15,7 @@
         <span class="divider">/</span>
     </li>
     <li>
-        <a href="#">{% trans "Offers" %}</a>
+        <a href="{% url 'offer:list' %}">{% trans "Offers" %}</a>
         <span class="divider">/</span>
     </li>
     <li class="active">{{ offer.name }}</li>


### PR DESCRIPTION
Breadcrumbs link to offers list on the page with offer details is missing.
