### PR TITLE
add_metaclass breaks Django 1.6 compatibilty

### DIFF
--- a/oscar/models/fields.py
+++ b/oscar/models/fields.py
@@ -1,5 +1,3 @@
-from six import add_metaclass
-
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models.fields import CharField, DecimalField, Field
 from django.db.models import SubfieldBase
@@ -65,7 +63,7 @@ class PositiveDecimalField(DecimalField):
 
 
 # necessary for to_python to be called
-@add_metaclass(SubfieldBase)
+@six.add_metaclass(SubfieldBase)
 class UppercaseCharField(CharField):
     """
     A simple subclass of ``django.db.models.fields.CharField`` that


### PR DESCRIPTION
Commit 0bdf1d3105d41276cea4b2ff65a60d988a620d88 adds `add_metaclass` that is not available for Django 1.6:

```
# Create database
sites/sandbox/manage.py syncdb --noinput
Traceback (most recent call last):
  File "sites/sandbox/manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/home/imatusov/.virtualenvs/oscar/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 399, in execute_from_command_line
    utility.execute()
  File "/home/imatusov/.virtualenvs/oscar/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 392, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/imatusov/.virtualenvs/oscar/local/lib/python2.7/site-packages/django/core/management/base.py", line 242, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/home/imatusov/.virtualenvs/oscar/local/lib/python2.7/site-packages/django/core/management/base.py", line 284, in execute
    self.validate()
  File "/home/imatusov/.virtualenvs/oscar/local/lib/python2.7/site-packages/django/core/management/base.py", line 310, in validate
    num_errors = get_validation_errors(s, app)
  File "/home/imatusov/.virtualenvs/oscar/local/lib/python2.7/site-packages/django/core/management/validation.py", line 34, in get_validation_errors
    for (app_name, error) in get_app_errors().items():
  File "/home/imatusov/.virtualenvs/oscar/local/lib/python2.7/site-packages/django/db/models/loading.py", line 196, in get_app_errors
    self._populate()
  File "/home/imatusov/.virtualenvs/oscar/local/lib/python2.7/site-packages/django/db/models/loading.py", line 78, in _populate
    self.load_app(app_name)
  File "/home/imatusov/.virtualenvs/oscar/local/lib/python2.7/site-packages/django/db/models/loading.py", line 99, in load_app
    models = import_module('%s.models' % app_name)
  File "/home/imatusov/.virtualenvs/oscar/local/lib/python2.7/site-packages/django/utils/importlib.py", line 40, in import_module
    __import__(name)
  File "/home/imatusov/workspace/oscar/oscar/apps/address/models.py", line 1, in <module>
    from oscar.apps.address.abstract_models import (
  File "/home/imatusov/workspace/oscar/oscar/apps/address/abstract_models.py", line 9, in <module>
    from oscar.models.fields import UppercaseCharField, PhoneNumberField
  File "/home/imatusov/workspace/oscar/oscar/models/fields.py", line 1, in <module>
    from six import add_metaclass
ImportError: cannot import name add_metaclass
make: *** [sandbox] Error 1
(oscar)[2] 10:08 oscar > pip freeze | grep Django
Django==1.6.1
```
