### PR TITLE
Correct max_length for UserAndProfileForm

### DIFF
--- a/oscar/apps/customer/forms.py
+++ b/oscar/apps/customer/forms.py
@@ -234,9 +234,9 @@ if hasattr(settings, 'AUTH_PROFILE_MODULE'):
 
     class UserAndProfileForm(forms.ModelForm):
         first_name = forms.CharField(
-            label=_('First name'), max_length=128, required=False)
+            label=_('First name'), max_length=30, required=False)
         last_name = forms.CharField(
-            label=_('Last name'), max_length=128, required=False)
+            label=_('Last name'), max_length=30, required=False)
         email = forms.EmailField(label=_('Email address'))
 
         # Fields from user model


### PR DESCRIPTION
Django's User model specifies a max_length of 30 for first_name and last_name fields.

https://github.com/django/django/blob/stable/1.4.x/django/contrib/auth/models.py#L235
