### PR TITLE
Don't disable form button if HTML5 form is invalid

### DIFF
--- a/oscar/static/oscar/js/oscar/ui.js
+++ b/oscar/static/oscar/js/oscar/ui.js
@@ -61,8 +61,13 @@ var oscar = (function(o, $) {
             $('form[data-behaviours~="lock"]').submit(o.forms.submitIfNotLocked);
 
             // Disable buttons when they are clicked and show a "loading" message taken from the
-            // data-loading-text attribute (http://getbootstrap.com/2.3.2/javascript.html#buttons)
-            $('.js-disable-on-click').click(function(){$(this).button('loading');});
+            // data-loading-text attribute (http://getbootstrap.com/2.3.2/javascript.html#buttons).
+            // Do not disable if button is inside a form with invalid fields.
+            $('.js-disable-on-click').click(function(){
+                var form = $(this).parents("form");
+                if (!form || $(":invalid", form).length == 0)
+                    $(this).button('loading');
+            });
         },
         submitIfNotLocked: function(event) {
             var $form = $(this);


### PR DESCRIPTION
If HTML5 form has invalid form fields (like input type email when email is not correct) the form will not be submitted on button click. The button must not be disabled to allow form submit after the form field is updated to be valid. 

Registration form is a good example, where if email is not valid it is not possible to submit the form after correcting input as the button stays disabled.

This change will not disable button on click if it is inside a form with invalid fields.
