### PR TITLE
Fix product select2 dropdown in dashboard promotions

### DIFF
--- a/oscar/static/oscar/js/oscar/dashboard.js
+++ b/oscar/static/oscar/js/oscar/dashboard.js
@@ -77,7 +77,7 @@ var oscar = (function(o, $) {
             $('.form-stacked select:visible').css('width', '95%');
             $('.form-inline select:visible').css('width', '300px');
             $(el).find('select:visible').select2({width: 'resolve'});
-            $(el).find('input.select2:visible').each(function(i, e) {
+            $(el).find('input.select2').each(function(i, e) {
                 var opts = {};
                 if($(e).data('ajax-url')) {
                     opts = {


### PR DESCRIPTION
The dashboard promotion product widget is hidden and select2
still needs to be initialized.
