### PR TITLE
The wysiwyg should not be initialized for the raw html body textarea.

### DIFF
--- a/oscar/apps/dashboard/promotions/forms.py
+++ b/oscar/apps/dashboard/promotions/forms.py
@@ -27,6 +27,10 @@ class RawHTMLForm(forms.ModelForm):
         model = RawHTML
         exclude = ('display_type',)
 
+    def __init__(self, *args, **kwargs):
+        super(RawHTMLForm, self).__init__(*args, **kwargs)
+        self.fields['body'].widget.attrs['class'] = "no-wysiwyg"
+
 
 class SingleProductForm(forms.ModelForm):
     class Meta:

--- a/oscar/static/oscar/js/oscar/dashboard.js
+++ b/oscar/static/oscar/js/oscar/dashboard.js
@@ -164,7 +164,7 @@ var oscar = (function(o, $) {
         },
         initWYSIWYG: function(el) {
             // Use TinyMCE by default
-            $('form.wysiwyg textarea:visible').tinymce(o.dashboard.options.tinyConfig);
+            $('form.wysiwyg textarea:visible:not(.no-wysiwyg)').tinymce(o.dashboard.options.tinyConfig);
             $(el).find('textarea.wysiwyg:visible').tinymce(o.dashboard.options.tinyConfig);
         },
         offers: {


### PR DESCRIPTION
Since the wysiwyg is set by default for all dashboard promotions
the raw html body field does not render proper HTML since it gets
processed by the wysiwyg. Need to stop it from initializing.

Added a class to the body field and testing for it in the dashboard js script.
We could also be explicit and add wysiwyg classes to each of the fields that
need to render the wysiwyg intsead of overriding the one.
Could also test for form type in the template before spitting out the 'wysiwyg' class
on the HTML form tag. Not sure how.
