### PR TITLE
Use SimpleLazyObject for request.basket

### DIFF
--- a/oscar/apps/basket/middleware.py
+++ b/oscar/apps/basket/middleware.py
@@ -98,8 +98,6 @@ class BasketMiddleware(object):
                 and request.basket._wrapped is empty):
             return response
 
-        basket_id = request.basket.id if hasattr(request, 'basket') else 0
-
         # Check if we need to set a cookie. If the cookies is already available
         # but is set in the cookies_to_delete list then we need to re-set it.
         has_basket_cookie = (
@@ -108,7 +106,7 @@ class BasketMiddleware(object):
 
         # If a basket has had products added to it, but the user is anonymous
         # then we need to assign it to a cookie
-        if (basket_id and not request.user.is_authenticated()
+        if (request.basket.id and not request.user.is_authenticated()
                 and not has_basket_cookie):
             cookie = self.get_basket_hash(request.basket.id)
             response.set_cookie(


### PR DESCRIPTION
Note that I've made this PR more to discuss the implemented solution. If you guys agree with it then i'll add some unittests.

This is a major performance improvement for pages where the basket is 
not used (other pages or loading basket async via javascript).

Note that request.basket is now not available when calling 
`apply_offers_to_basket`. Not sure why this is required since the 
basket is passed along.
