### PR TITLE
Handle cookies that contain strings

### DIFF
--- a/oscar/apps/customer/history.py
+++ b/oscar/apps/customer/history.py
@@ -35,6 +35,10 @@ def extract(request, response=None):
             # This can occur if something messes up the cookie
             if response:
                 response.delete_cookie(cookie_name)
+        else:
+            # Badly written web crawlers send garbage in double quotes
+            if not isinstance(ids, list):
+                ids = []
     return ids
 
 


### PR DESCRIPTION
We have a broken "NING/1.0" bot crawling our customer's site that sends a quoted string here that deserializes to a unicode object.
