### PR TITLE
Make it easy to not use promotions app

### DIFF
--- a/docs/source/ref/apps/promotions.rst
+++ b/docs/source/ref/apps/promotions.rst
@@ -2,7 +2,7 @@
 Promotions
 ==========
 
-Promotions are small blocks of content that can link through to other parts of this site.  
+Promotions are small blocks of content that can link through to other parts of this site.
 Examples include:
 
 * A banner image shown on at the top of the homepage that links through to a new offer page

--- a/docs/source/ref/settings.rst
+++ b/docs/source/ref/settings.rst
@@ -23,6 +23,15 @@ Default: ``''``
 
 The tagline that is displayed next to the shop name and in the browser title.
 
+``OSCAR_HOMEPAGE``
+----------------------
+
+Default: ``reverse_lazy('promotions:home')``
+
+URL of home page of your site. This value is used for `Home` link in
+navigation and redirection page after logout. Useful if you use a different app
+to serve your homepage.
+
 ``OSCAR_PARTNER_WRAPPERS``
 --------------------------
 

--- a/oscar/apps/customer/views.py
+++ b/oscar/apps/customer/views.py
@@ -181,7 +181,7 @@ class AccountAuthView(RegisterUserMixin, TemplateView):
 
 
 class LogoutView(RedirectView):
-    url = reverse_lazy('promotions:home')
+    url = settings.OSCAR_HOMEPAGE
     permanent = False
 
     def get(self, request, *args, **kwargs):
@@ -300,6 +300,7 @@ class ProfileDeleteView(PageTitleMixin, FormView):
     template_name = 'customer/profile/profile_delete.html'
     page_title = _('Delete profile')
     active_tab = 'profile'
+    success_url = settings.OSCAR_HOMEPAGE
 
     def get_form_kwargs(self):
         kwargs = super(ProfileDeleteView, self).get_form_kwargs()
@@ -312,9 +313,6 @@ class ProfileDeleteView(PageTitleMixin, FormView):
             self.request,
             _("Your profile has now been deleted. Thanks for using the site."))
         return HttpResponseRedirect(self.get_success_url())
-
-    def get_success_url(self):
-        return reverse('promotions:home')
 
 
 class ChangePasswordView(PageTitleMixin, FormView):

--- a/oscar/core/context_processors.py
+++ b/oscar/core/context_processors.py
@@ -9,6 +9,7 @@ def metadata(request):
             'version': getattr(settings, 'VERSION', 'N/A'),
             'shop_name': settings.OSCAR_SHOP_NAME,
             'shop_tagline': settings.OSCAR_SHOP_TAGLINE,
+            'homepage_url': settings.OSCAR_HOMEPAGE,
             'use_less': getattr(settings, 'USE_LESS', False),
             # Whether to use a tracker gif in the dashboard to call back to one
             # of Tangent's servers.

--- a/oscar/defaults.py
+++ b/oscar/defaults.py
@@ -1,7 +1,9 @@
 from django.utils.translation import ugettext_lazy as _
+from django.core.urlresolvers import reverse_lazy
 
 OSCAR_SHOP_NAME = 'Oscar'
 OSCAR_SHOP_TAGLINE = ''
+OSCAR_HOMEPAGE = reverse_lazy('promotions:home')
 
 # Basket settings
 OSCAR_BASKET_COOKIE_LIFETIME = 7 * 24 * 60 * 60

--- a/oscar/templates/oscar/basket/basket.html
+++ b/oscar/templates/oscar/basket/basket.html
@@ -9,7 +9,7 @@
 {% block breadcrumbs %}
     <ul class="breadcrumb">
         <li>
-            <a href="{% url 'promotions:home' %}">{% trans "Home" %}</a>
+            <a href="{{ homepage_url }}">{% trans "Home" %}</a>
             <span class="divider">/</span>
         </li>
         <li class="active">{% trans "Basket" %}</li>

--- a/oscar/templates/oscar/basket/partials/basket_content.html
+++ b/oscar/templates/oscar/basket/partials/basket_content.html
@@ -149,7 +149,7 @@
     {% block emptybasket %}
         <p>
             {% trans "Your basket is empty." %}
-            <a href="{% url 'promotions:home' %}">{% trans "Continue shopping" %}</a>
+            <a href="{{ homepage_url }}">{% trans "Continue shopping" %}</a>
         </p>
     {% endblock %}
 {% endif %}

--- a/oscar/templates/oscar/catalogue/browse.html
+++ b/oscar/templates/oscar/catalogue/browse.html
@@ -18,7 +18,7 @@
 {% block breadcrumbs %}
     <ul class="breadcrumb">
         <li>
-            <a href="{% url "promotions:home" %}">{% trans "Home" %}</a>
+            <a href="{{ homepage_url }}">{% trans "Home" %}</a>
             <span class="divider">/</span>
         </li>
         {% if not category %}

--- a/oscar/templates/oscar/catalogue/detail.html
+++ b/oscar/templates/oscar/catalogue/detail.html
@@ -20,7 +20,7 @@
 {% block breadcrumbs %}
 <ul class="breadcrumb">
 	<li>
-		<a href="{% url 'promotions:home' %}">{% trans "Home" %}</a>
+		<a href="{{ homepage_url }}">{% trans "Home" %}</a>
         <span class="divider">/</span>
     </li>
     {% with category=product.categories.all.0 %}

--- a/oscar/templates/oscar/catalogue/reviews/review_detail.html
+++ b/oscar/templates/oscar/catalogue/reviews/review_detail.html
@@ -8,7 +8,7 @@
 {% block breadcrumbs %}
     <ul class="breadcrumb">
         <li>
-            <a href="{% url 'promotions:home' %}">{% trans "Home" %}</a>
+            <a href="{{ homepage_url }}">{% trans "Home" %}</a>
             <span class="divider">/</span>
         </li>
         {% with category=product.categories.all.0 %}

--- a/oscar/templates/oscar/catalogue/reviews/review_list.html
+++ b/oscar/templates/oscar/catalogue/reviews/review_list.html
@@ -10,7 +10,7 @@
 {% block breadcrumbs %}
     <ul class="breadcrumb">
         <li>
-            <a href="{% url 'promotions:home' %}">{% trans "Home" %}</a>
+            <a href="{{ homepage_url }}">{% trans "Home" %}</a>
             <span class="divider">/</span>
         </li>
         {% with category=product.categories.all.0 %}

--- a/oscar/templates/oscar/checkout/thank_you.html
+++ b/oscar/templates/oscar/checkout/thank_you.html
@@ -282,7 +282,7 @@
                     <p><a onclick="window.print()" href="#" class="btn btn-primary btn-block btn-large">{% trans "Print this page" %}</a></p>
                 </div>
                 <div class="span3 offset6">
-                    <p><a href="{% url 'promotions:home' %}" class="btn btn-primary btn-block btn-large">{% trans "Continue shopping" %}</a></p>
+                    <p><a href="{{ homepage_url }}" class="btn btn-primary btn-block btn-large">{% trans "Continue shopping" %}</a></p>
                 </div>
             </div>
         </div>

--- a/oscar/templates/oscar/customer/baseaccountpage.html
+++ b/oscar/templates/oscar/customer/baseaccountpage.html
@@ -11,7 +11,7 @@
 {% block breadcrumbs %}
     <ul class="breadcrumb">
         <li>
-            <a href="{% url 'promotions:home' %}">{% trans 'Home' %}</a>
+            <a href="{{ homepage_url }}">{% trans 'Home' %}</a>
             <span class="divider">/</span>
         </li>
         <li>

--- a/oscar/templates/oscar/customer/login_registration.html
+++ b/oscar/templates/oscar/customer/login_registration.html
@@ -8,7 +8,7 @@
 {% block breadcrumbs %}
     <ul class="breadcrumb">
         <li>
-            <a href="{% url 'promotions:home' %}">{% trans 'Home' %}</a>
+            <a href="{{ homepage_url }}">{% trans 'Home' %}</a>
             <span class="divider">/</span>
         </li>
         <li class="active">{% trans 'Login or register' %}</li>

--- a/oscar/templates/oscar/customer/order/order_list.html
+++ b/oscar/templates/oscar/customer/order/order_list.html
@@ -6,7 +6,7 @@
 {% block breadcrumbs %}
     <ul class="breadcrumb">
         <li>
-            <a href="{% url 'promotions:home' %}">{% trans 'Home' %}</a>
+            <a href="{{ homepage_url }}">{% trans 'Home' %}</a>
             <span class="divider">/</span>
         </li>
         <li>

--- a/oscar/templates/oscar/customer/registration.html
+++ b/oscar/templates/oscar/customer/registration.html
@@ -9,7 +9,7 @@
 {% block breadcrumbs %}
     <ul class="breadcrumb">
         <li>
-            <a href="{% url 'promotions:home' %}">{% trans 'Home' %}</a>
+            <a href="{{ homepage_url }}">{% trans 'Home' %}</a>
             <span class="divider">/</span>
         </li>
         <li class="active">{% trans 'Register' %}</li>

--- a/oscar/templates/oscar/customer/wishlists/wishlists_delete.html
+++ b/oscar/templates/oscar/customer/wishlists/wishlists_delete.html
@@ -4,7 +4,7 @@
 {% block breadcrumbs %}
     <ul class="breadcrumb">
         <li>
-            <a href="{% url 'promotions:home' %}">{% trans 'Home' %}</a>
+            <a href="{{ homepage_url }}">{% trans 'Home' %}</a>
             <span class="divider">/</span>
         </li>
         <li>

--- a/oscar/templates/oscar/customer/wishlists/wishlists_delete_product.html
+++ b/oscar/templates/oscar/customer/wishlists/wishlists_delete_product.html
@@ -4,7 +4,7 @@
 {% block breadcrumbs %}
     <ul class="breadcrumb">
         <li>
-            <a href="{% url 'promotions:home' %}">{% trans 'Home' %}</a>
+            <a href="{{ homepage_url }}">{% trans 'Home' %}</a>
             <span class="divider">/</span>
         </li>
         <li>

--- a/oscar/templates/oscar/customer/wishlists/wishlists_detail.html
+++ b/oscar/templates/oscar/customer/wishlists/wishlists_detail.html
@@ -5,7 +5,7 @@
 {% block breadcrumbs %}
     <ul class="breadcrumb">
         <li>
-            <a href="{% url 'promotions:home' %}">{% trans 'Home' %}</a>
+            <a href="{{ homepage_url }}">{% trans 'Home' %}</a>
             <span class="divider">/</span>
         </li>
         <li>

--- a/oscar/templates/oscar/customer/wishlists/wishlists_form.html
+++ b/oscar/templates/oscar/customer/wishlists/wishlists_form.html
@@ -4,7 +4,7 @@
 {% block breadcrumbs %}
     <ul class="breadcrumb">
         <li>
-            <a href="{% url 'promotions:home' %}">{% trans 'Home' %}</a>
+            <a href="{{ homepage_url }}">{% trans 'Home' %}</a>
             <span class="divider">/</span>
         </li>
         <li>

--- a/oscar/templates/oscar/dashboard/layout.html
+++ b/oscar/templates/oscar/dashboard/layout.html
@@ -44,7 +44,7 @@
                 <div class="nav-collapse nav-accounts collapse">
                     <ul class="nav pull-right">
                         <li><span>{% trans "Welcome" %} <em>{{ request.user.get_full_name|default:request.user.email }}</em></span></li>
-                        <li><a href="{% url 'promotions:home' %}"><i class="icon-home"></i> {% trans "Return to site" %}</a></li>
+                        <li><a href="{{ homepage_url }}"><i class="icon-home"></i> {% trans "Return to site" %}</a></li>
                         <li><a href="{% url 'customer:summary' %}"><i class="icon-user"></i> {% trans "Account" %}</a></li>
                         <li><a href="{% url 'customer:logout' %}"><i class="icon-signout"></i> {% trans "Log out" %}</a></li>
                     </ul>

--- a/oscar/templates/oscar/dashboard/offers/offer_list.html
+++ b/oscar/templates/oscar/dashboard/offers/offer_list.html
@@ -11,7 +11,7 @@
 {% block breadcrumbs %}
     <ul class="breadcrumb">
         <li>
-            <a href="{% url 'promotions:home' %}">{% trans "Dashboard" %}</a>
+            <a href="{{ homepage_url }}">{% trans "Dashboard" %}</a>
             <span class="divider">/</span>
         </li>
         <li class="active">{% trans "Offer management" %}</li>

--- a/oscar/templates/oscar/error.html
+++ b/oscar/templates/oscar/error.html
@@ -10,7 +10,7 @@
         {% block error_message %}{% endblock %}
         <p>
             <a class="btn btn-primary btn-large" onclick="javascript:history.go(-1);">{% trans 'Return to previous page' %}</a>
-            <a class="btn btn-primary btn-large" href="{% url 'promotions:home' %}">{% trans "Go to homepage" %}</a>
+            <a class="btn btn-primary btn-large" href="{{ homepage_url }}">{% trans "Go to homepage" %}</a>
         </p>
     </div>
 </div>

--- a/oscar/templates/oscar/flatpages/default.html
+++ b/oscar/templates/oscar/flatpages/default.html
@@ -12,7 +12,7 @@
 {% block breadcrumbs %}
     <ul class="breadcrumb">
         <li>
-            <a href="{% url 'promotions:home' %}">{% trans "Home" %}</a>
+            <a href="{{ homepage_url }}">{% trans "Home" %}</a>
             <span class="divider">/</span>
         </li>
         <li class="active">{{ flatpage.title }}</li>

--- a/oscar/templates/oscar/offer/detail.html
+++ b/oscar/templates/oscar/offer/detail.html
@@ -11,7 +11,7 @@
 {% block breadcrumbs %}
 <ul class="breadcrumb">
     <li>
-	<a href="{% url 'promotions:home' %}">{% trans "Home" %}</a>
+	<a href="{{ homepage_url }}">{% trans "Home" %}</a>
         <span class="divider">/</span>
     </li>
     <li>

--- a/oscar/templates/oscar/offer/list.html
+++ b/oscar/templates/oscar/offer/list.html
@@ -11,7 +11,7 @@
 {% block breadcrumbs %}
 <ul class="breadcrumb">
     <li>
-	<a href="{% url 'promotions:home' %}">{% trans "Home" %}</a>
+	<a href="{{ homepage_url }}">{% trans "Home" %}</a>
         <span class="divider">/</span>
     </li>
     <li class="active">{% trans "Offers" %}</li>

--- a/oscar/templates/oscar/offer/range.html
+++ b/oscar/templates/oscar/offer/range.html
@@ -13,7 +13,7 @@
 {% block breadcrumbs %}
     <ul class="breadcrumb">
         <li>
-            <a href="{% url "promotions:home" %}">{% trans "Home" %}</a>
+            <a href="{{ homepage_url }}">{% trans "Home" %}</a>
             <span class="divider">/</span>
         </li>
         <li class="active">{{ range.name }}</li>

--- a/oscar/templates/oscar/partials/brand.html
+++ b/oscar/templates/oscar/partials/brand.html
@@ -1,1 +1,1 @@
-<h1 class="span7"><a href="{% url 'promotions:home' %}">{% block brand_title %}{{ shop_name }}</a><small> {{ shop_tagline }}</small>{% endblock %}</h1>
+<h1 class="span7"><a href="{{ homepage_url }}">{% block brand_title %}{{ shop_name }}</a><small> {{ shop_tagline }}</small>{% endblock %}</h1>

--- a/oscar/templates/oscar/partials/nav_checkout.html
+++ b/oscar/templates/oscar/partials/nav_checkout.html
@@ -10,7 +10,7 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </a>
-                <a class="brand hidden" href="{% url 'promotions:home' %}">{{ shop_name }}</a>
+                <a class="brand hidden" href="{{ homepage_url }}">{{ shop_name }}</a>
                 <div class="nav-collapse">
 
                     <ul class="nav">
@@ -21,7 +21,7 @@
                             </li>
                         {% endfor %}
                         <!-- Delete this if other links present -->
-                        <li><a href="{% url 'promotions:home' %}">&larr;</a></li>
+                        <li><a href="{{ homepage_url }}">&larr;</a></li>
                     </ul>
                 </div><!-- /.nav-collapse -->
             </div>

--- a/oscar/templates/oscar/registration/password_reset_complete.html
+++ b/oscar/templates/oscar/registration/password_reset_complete.html
@@ -8,7 +8,7 @@
 {% block breadcrumbs %}
 <ul class="breadcrumb">
     <li>
-        <a href="{% url 'promotions:home' %}">{% trans 'Home' %}</a>
+        <a href="{{ homepage_url }}">{% trans 'Home' %}</a>
         <span class="divider">/</span>
     </li>
     <li class="active">{% trans 'Password reset complete' %}</li>

--- a/oscar/templates/oscar/registration/password_reset_confirm.html
+++ b/oscar/templates/oscar/registration/password_reset_confirm.html
@@ -8,7 +8,7 @@
 {% block breadcrumbs %}
 <ul class="breadcrumb">
     <li>
-        <a href="{% url 'promotions:home' %}">{% trans 'Home' %}</a>
+        <a href="{{ homepage_url }}">{% trans 'Home' %}</a>
         <span class="divider">/</span>
     </li>
     <li class="active">{% trans 'Enter new password' %}</li>

--- a/oscar/templates/oscar/registration/password_reset_done.html
+++ b/oscar/templates/oscar/registration/password_reset_done.html
@@ -8,7 +8,7 @@
 {% block breadcrumbs %}
 <ul class="breadcrumb">
     <li>
-        <a href="{% url 'promotions:home' %}">{% trans 'Home' %}</a>
+        <a href="{{ homepage_url }}">{% trans 'Home' %}</a>
         <span class="divider">/</span>
     </li>
     <li class="active">{% trans 'Password reset sent' %}</li>

--- a/oscar/templates/oscar/registration/password_reset_form.html
+++ b/oscar/templates/oscar/registration/password_reset_form.html
@@ -8,7 +8,7 @@
 {% block breadcrumbs %}
 <ul class="breadcrumb">
     <li>
-        <a href="{% url 'promotions:home' %}">{% trans 'Home' %}</a>
+        <a href="{{ homepage_url }}">{% trans 'Home' %}</a>
         <span class="divider">/</span>
     </li>
     <li class="active">{% trans 'Password reset' %}</li>

--- a/oscar/templates/oscar/search/results.html
+++ b/oscar/templates/oscar/search/results.html
@@ -12,7 +12,7 @@
 {% block breadcrumbs %}
     <ul class="breadcrumb">
         <li>
-            <a href="{% url 'promotions:home' %}">{% trans "Home" %}</a>
+            <a href="{{ homepage_url }}">{% trans "Home" %}</a>
             <span class="divider">/</span>
         </li>
         <li>

--- a/sites/demo/templates/partials/brand.html
+++ b/sites/demo/templates/partials/brand.html
@@ -1,4 +1,4 @@
 {% load staticfiles %}
-<a href="{% url 'promotions:home' %}">
+<a href="{{ homepage_url }}">
 	<img src="{% static "demo/img/svg/logo.svg" %}" class="logo" alt="{{ shop_name }} - {{ shop_tagline }}" width="140" height="108" />
 </a>

--- a/sites/demo/templates/promotions/singleproduct.html
+++ b/sites/demo/templates/promotions/singleproduct.html
@@ -4,6 +4,6 @@
 <section class="promotion_single">
     <h3>{{ promotion.name }}</h3>
     <div class="well">
-        {% include "promotions/partials/productsingle.html" %}  
+        {% include "promotions/partials/productsingle.html" %}
     </div>
 </section>

--- a/sites/sandbox/update_latest.sh
+++ b/sites/sandbox/update_latest.sh
@@ -19,7 +19,7 @@ cd sites/sandbox
 ./manage.py collectstatic --noinput
 ./manage.py thumbnail clear
 
-# Load standard fixtures
+# Load standard fixtures
 ./manage.py loaddata ../_fixtures/promotions.json
 
 # Restart Tomcat (to pick up any solr schema changes)

--- a/tests/_site/templates/layout.html
+++ b/tests/_site/templates/layout.html
@@ -7,7 +7,7 @@
 {% block layout %}
     <div id="container">
         <div id="header">
-            <p><a href="{% url 'promotions:home' %}">{% trans "Oscar // Flexible e-commerce for Django" %}</a></p>
+            <p><a href="{{ homepage_url }}">{% trans "Oscar // Flexible e-commerce for Django" %}</a></p>
 
             <form method="get" action="{% url 'search:search' %}">
                 {{ search_form.as_p }}


### PR DESCRIPTION
When Oscar integrated into an existing project, there might not be need to use promotions app. By default, the app handles home page and is used for reversing link to home page.

Tangent project use their own app for handling home page and I ended up changing templates. Oscar should be usable with promotions app.
