### PR TITLE
Contextual markers required for proper translation to Dutch

### DIFF
--- a/oscar/apps/customer/forms.py
+++ b/oscar/apps/customer/forms.py
@@ -11,6 +11,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import ValidationError
 from oscar.core.loading import get_model
 from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import pgettext_lazy
 
 from oscar.core.loading import get_profile_class, get_class
 from oscar.core.compat import get_user_model
@@ -226,8 +227,10 @@ class EmailUserCreationForm(forms.ModelForm):
 
 
 class OrderSearchForm(forms.Form):
-    date_from = forms.DateField(required=False, label=_("From"))
-    date_to = forms.DateField(required=False, label=_("To"))
+    date_from = forms.DateField(
+        required=False, label=pgettext_lazy("start date", "From"))
+    date_to = forms.DateField(
+        required=False, label=pgettext_lazy("end date", "To"))
     order_number = forms.CharField(required=False, label=_("Order number"))
 
     def clean(self):

--- a/oscar/apps/dashboard/orders/forms.py
+++ b/oscar/apps/dashboard/orders/forms.py
@@ -4,6 +4,7 @@ from django import forms
 from oscar.core.loading import get_model
 from django.http import QueryDict
 from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import pgettext_lazy
 from oscar.apps.address.forms import AbstractAddressForm
 
 from oscar.views.generic import PhoneNumberMixin
@@ -15,8 +16,10 @@ SourceType = get_model('payment', 'SourceType')
 
 
 class OrderStatsForm(forms.Form):
-    date_from = forms.DateField(required=False, label=_("From"))
-    date_to = forms.DateField(required=False, label=_("To"))
+    date_from = forms.DateField(
+        required=False, label=pgettext_lazy("start date", "From"))
+    date_to = forms.DateField(
+        required=False, label=pgettext_lazy("end date", "To"))
 
     _filters = _description = None
 

--- a/oscar/templates/oscar/customer/notifications/list.html
+++ b/oscar/templates/oscar/customer/notifications/list.html
@@ -5,7 +5,7 @@
 
     <ul class="nav nav-tabs">
         <li class="{% if list_type == 'inbox' %}active{% endif %}"><a href="{% url 'customer:notifications-inbox' %}">{% trans 'Inbox' %}</a></li>
-        <li class="{% if list_type == 'archive' %}active{% endif %}"><a href="{% url 'customer:notifications-archive' %}">{% trans 'Archive' %}</a></li>
+        <li class="{% if list_type == 'archive' %}active{% endif %}"><a href="{% url 'customer:notifications-archive' %}">{% trans 'Archive' context 'noun' %}</a></li>
     </ul>
 
     {% if notifications %}
@@ -35,7 +35,7 @@
                             <td>
                                 <a href="{% url 'customer:notifications-detail' pk=notification.pk %}" class="btn btn-info btn-small">{% trans 'View' %}</a>
                                 {% if list_type == 'inbox' %}
-                                    <a class="btn btn-success btn-small" href="#" data-behaviours="archive">{% trans 'Archive' %}</a>
+                                    <a class="btn btn-success btn-small" href="#" data-behaviours="archive">{% trans 'Archive' context 'verb' %}</a>
                                 {% endif %}
                                 <a class="btn btn-danger btn-small "href="#" data-behaviours="delete">{% trans 'Delete' %}</a>
                             </td>
@@ -45,7 +45,7 @@
             </table>
             {% trans "With selected items:" %} 
             {% if list_type == 'inbox' %}
-                <button type="submit" class="btn btn-success" name="action" value="archive">{% trans "Archive" %}</button>
+                <button type="submit" class="btn btn-success" name="action" value="archive">{% trans "Archive" context 'verb' %}</button>
             {% endif %}
             <button type="submit" class="btn btn-danger" name="action" value="delete">{% trans "Delete" %}</button>
         </form>
@@ -62,4 +62,3 @@
     {{ block.super }}
     oscar.notifications.init();
 {% endblock %}
-


### PR DESCRIPTION
I am currently working on the Dutch [nl] translation for Django Oscar and am running into a couple of strings that would benefit from having a contextual marker to distinguish  between one use of the word and another:

'To' - As found in oscar/apps/customer/forms.py:230 and oscar/apps/dashboard/orders/forms.py. Because 'to' can mean 'up to' as in '1 to 60' but it can also refer to a person you are writing 'to'. In Dutch we have two different words for that "tot" and "aan".

'Archive' - As found in templates/oscar/customer/notifications/list.html.
Archive can refer to the noun but also to the verb ('to archive'). In Dutch we again have two different words for that: "Archief" and "Archiveer/Archiveren". People should know the difference between the button that takes them to the Archive and the button that will move a notification to the Archive.
