### PR TITLE
Correctly retrieve product class for variant products

### DIFF
--- a/oscar/apps/dashboard/catalogue/views.py
+++ b/oscar/apps/dashboard/catalogue/views.py
@@ -217,7 +217,7 @@ class ProductCreateUpdateView(generic.UpdateView):
                 return None  # success
         else:
             product = super(ProductCreateUpdateView, self).get_object(queryset)
-            self.product_class = product.product_class
+            self.product_class = product.get_product_class()
             return product
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
Variant products don't have an own product class but use that of their
parent product instead.
