### PR TITLE
Don't overwrite bootstrap error, success and information alert colors

### DIFF
--- a/oscar/static/oscar/css/dashboard.css
+++ b/oscar/static/oscar/css/dashboard.css
@@ -3325,11 +3325,6 @@ caption > i,
 .promotions .well-info {
   background-color: #ffffff;
 }
-.alert {
-  background-color: #fff49f;
-  border-color: #ede181;
-  color: #333;
-}
 #order-graph {
   position: relative;
   margin-bottom: 5em;

--- a/oscar/static/oscar/less/dashboard.less
+++ b/oscar/static/oscar/less/dashboard.less
@@ -509,13 +509,6 @@ caption,
 .promotions .well-info {
     background-color: @white;
 }
-// ALERTS
-// -----
-.alert {
-  background-color: #fff49f;
-  border-color: #ede181;
-  color: #333;
-}
 // DASHBOARD GRAPH
 // ----------------
 #order-graph {


### PR DESCRIPTION
http://getbootstrap.com/2.3.2/components.html#alerts

git blame doesn't reveal any useful information as to why this was added in
the first place.

(Edit: added screenshots)

Before:
![before](https://f.cloud.github.com/assets/133575/2399029/3c827500-a9fb-11e3-9029-0665d16f9249.png)
After:
![after](https://f.cloud.github.com/assets/133575/2399031/40fd885e-a9fb-11e3-828d-b5001dc5bd7e.png)
