### PR TITLE
Move basket line removal to the managing formset

### DIFF
--- a/oscar/apps/basket/abstract_models.py
+++ b/oscar/apps/basket/abstract_models.py
@@ -591,18 +591,10 @@ class AbstractLine(models.Model):
                                  'quantity': self.quantity}
 
     def save(self, *args, **kwargs):
-        """
-        Saves a line or deletes if the quantity is 0
-        """
         if not self.basket.can_be_edited:
             raise PermissionDenied(
                 _("You cannot modify a %s basket") % (
                     self.basket.status.lower(),))
-        if self.quantity == 0:
-            # 'using' is the only kwarg that save() and delete() share
-            if 'using' in kwargs:
-                return self.delete(using=kwargs['using'])
-            return self.delete()
         return super(AbstractLine, self).save(*args, **kwargs)
 
     # =============

--- a/oscar/apps/basket/forms.py
+++ b/oscar/apps/basket/forms.py
@@ -54,6 +54,12 @@ class BaseBasketLineFormSet(BaseModelFormSet):
         return super(BaseBasketLineFormSet, self)._construct_form(
             i, strategy=self.strategy, **kwargs)
 
+    def _should_delete_form(self, form):
+        if super(BaseBasketLineFormSet, self)._should_delete_form(form):
+            return True
+        if self.can_delete and 'quantity' in form.cleaned_data:
+            return form.cleaned_data['quantity'] == 0
+
 
 BasketLineFormSet = modelformset_factory(
     Line, form=BasketLineForm, formset=BaseBasketLineFormSet, extra=0,


### PR DESCRIPTION
Old code was breaking `.save()`'s promise of setting a primary key and caused setups with M2M relations to a basket line to fail. This code causes quantity input of zero to be treated as if the user checked the DELETE checkbox.

Fixes #1267
