### PR TITLE
Check User model actually has fields for form Meta

### DIFF
--- a/oscar/apps/dashboard/partners/forms.py
+++ b/oscar/apps/dashboard/partners/forms.py
@@ -31,7 +31,7 @@ ROLE_CHOICES = (
 # from Django 1.6 the User model can be overridden and it is no longer safe to assume the User model has certain fields
 VALID_USER_FORM_FIELD_NAMES = [field.name for field in User._meta.fields]
 def valid_user_form_fields(fields):
-    return tuple(set(fields) & set(VALID_USER_FORM_FIELD_NAMES))
+    return list(set(fields) & set(VALID_USER_FORM_FIELD_NAMES))
 
 
 class NewUserForm(EmailUserCreationForm):


### PR DESCRIPTION
This is necessary because the Meta def itself is sufficient to crash the app for a different User model - the form doesn't even need to be instantiated. There is still plenty more code that makes explicit reference to first_name and last_name however.
