### PR TITLE
Enable dashboard.js options recursively overrided

### DIFF
--- a/oscar/static/oscar/js/oscar/dashboard.js
+++ b/oscar/static/oscar/js/oscar/dashboard.js
@@ -31,7 +31,7 @@ var oscar = (function(o, $) {
                     toolbar: "styleselect | bold italic blockquote | bullist numlist | link"
                 }
             };
-            o.dashboard.options = $.extend(defaults, options);
+            o.dashboard.options = $.extend(true, defaults, options);
 
             o.dashboard.initDatePickers();
             o.dashboard.initWYSIWYG();


### PR DESCRIPTION
I'd trying to modify some TinyMCE options such as language or toolbar settings and had found that is quite difficult. If you do not want write your own whole TinyMCE config but only change some parameters, you should use 'recursive' mode for jquery.extend method. 
Issue related to all oscar.dashboard.options which contains complex objects or arrays and should be overrided partly.
