### PR TITLE
Abstract base classes for shipping models

### DIFF
--- a/docs/source/howto/how_to_configure_shipping.rst
+++ b/docs/source/howto/how_to_configure_shipping.rst
@@ -109,10 +109,10 @@ The repository class is responsible for return shipping method instances.  Oscar
 defines several of these but it is easy to write your own, their interface is
 simple.
 
-The base shipping method class ``oscar.apps.shipping.base.ShippingMethod`` (that
+The base shipping method class ``oscar.apps.shipping.base.Base`` (that
 all shipping methods should subclass has API:
 
-.. autoclass:: oscar.apps.shipping.base.ShippingMethod
+.. autoclass:: oscar.apps.shipping.base.Base
     :members:
     :noindex:
 

--- a/oscar/apps/shipping/abstract_models.py
+++ b/oscar/apps/shipping/abstract_models.py
@@ -8,8 +8,10 @@ from oscar.apps.shipping import Scales
 from oscar.models.fields import AutoSlugField
 
 
-class ShippingMethod(models.Model):
-    # Fields from shipping.base.ShippingMethod must be added here manually.
+class AbstractBase(models.Model):
+    """
+    Implements the interface declared by shipping.base.Base
+    """
     code = AutoSlugField(_("Slug"), max_length=128, unique=True,
                          populate_from='name')
     name = models.CharField(_("Name"), max_length=128, unique=True)
@@ -35,7 +37,7 @@ class ShippingMethod(models.Model):
         self._basket = basket
 
 
-class AbstractOrderAndItemCharges(ShippingMethod):
+class AbstractOrderAndItemCharges(AbstractBase):
     """
     Standard shipping method
 
@@ -96,7 +98,7 @@ class AbstractOrderAndItemCharges(ShippingMethod):
         return True
 
 
-class AbstractWeightBased(ShippingMethod):
+class AbstractWeightBased(AbstractBase):
     upper_charge = models.DecimalField(
         _("Upper Charge"), decimal_places=2, max_digits=12, null=True,
         help_text=_("This is the charge when the weight of the basket "

--- a/oscar/apps/shipping/base.py
+++ b/oscar/apps/shipping/base.py
@@ -74,7 +74,3 @@ class Base(object):
             "in v0.7"),
             DeprecationWarning)
         return self.charge_incl_tax
-
-
-# For backwards compatibility, keep an alias called "ShippingMethod"
-ShippingMethod = Base

--- a/oscar/apps/shipping/models.py
+++ b/oscar/apps/shipping/models.py
@@ -1,10 +1,6 @@
 from oscar.apps.shipping import abstract_models
 
 
-# backwards-compatible import
-ShippingMethod = abstract_models.ShippingMethod
-
-
 class OrderAndItemCharges(abstract_models.AbstractOrderAndItemCharges):
     pass
 


### PR DESCRIPTION
This is a common and useful Oscar pattern, and I can't see a reason to not use it for the shipping app. I wanted to configure the WeightBased class to add a field pointing to a partner, so that I can have different weight bands per partner.

They are not imported anywhere in Oscar and just provided for convenience, so no imports had to be altered.

Made a PR because I feel like I've missed something obvious and want a second set of eyeballs.
