### PR TITLE
Remove useless entropy-increasing calls of django.conf.urls.patterns

### DIFF
--- a/docs/source/howto/how_to_change_a_url.rst
+++ b/docs/source/howto/how_to_change_a_url.rst
@@ -30,11 +30,11 @@ application, so we need to replace that. Hence, to use
 
         # Override get_urls method
         def get_urls(self):
-            urlpatterns = patterns('',
-                (r'^catalog/', include(self.catalogue_app.urls)),
+            urlpatterns = [
+                url(r'^catalog/', include(self.catalogue_app.urls)),
 
                 ... # all the remaining URLs, removed for simplicity
-            )
+            ]
             return urlpatterns
 
     application = MyShop()
@@ -44,10 +44,10 @@ Now modify your root ``urls.py`` to use your new application instance::
     # urls.py
     from myproject.app import application
 
-    urlpatterns = patterns('',
+    urlpatterns = [
        ... # Your other URLs
-       (r'', include(application.urls)),
-    )
+       url(r'', include(application.urls)),
+    ]
 
 All URLs containing ``catalogue`` previously are now displayed as ``catalog``.
 

--- a/docs/source/howto/how_to_disable_an_app.rst
+++ b/docs/source/howto/how_to_disable_an_app.rst
@@ -11,10 +11,10 @@ over the URLs structure.  So your root ``urls.py`` should have::
     # urls.py
     from myproject.app import application
 
-    urlpatterns = patterns('',
+    urlpatterns = [
         ...
-        (r'', include(application.urls)),
-    )
+        url(r'', include(application.urls)),
+    ]
 
 where ``application`` is a subclass of ``oscar.app.Shop`` which overrides the 
 link to the dashboard app::

--- a/docs/source/internals/getting_started.rst
+++ b/docs/source/internals/getting_started.rst
@@ -175,13 +175,13 @@ include Django's i18n URLs:
 
 .. code-block:: django
 
-    from django.conf.urls import patterns, include, url
+    from django.conf.urls import include, url
     from oscar.app import application
 
-    urlpatterns = patterns('',
-        (r'^i18n/', include('django.conf.urls.i18n')),
+    urlpatterns = [
+        url(r'^i18n/', include('django.conf.urls.i18n')),
         url(r'', include(application.urls))
-    )
+    ]
 
 Search backend
 ==============

--- a/docs/source/topics/customisation.rst
+++ b/docs/source/topics/customisation.rst
@@ -57,10 +57,10 @@ wired up in your ``urls.py``::
     # urls.py
     from oscar.app import application
 
-    urlpatterns = patterns('',
-       ... # Your other URLs
-       (r'', include(application.urls)),
-    )
+    urlpatterns = [
+        ... # Your other URLs
+        url(r'', include(application.urls)),
+    ]
 
 Modifying root app
 ------------------
@@ -83,10 +83,10 @@ Now hook this up in your ``urls.py`` instead::
     # urls.py
     from yourproject.app import application
 
-    urlpatterns = patterns('',
+    urlpatterns = [
         ...
-        (r'', include(application.urls)),
-    )
+        url(r'', include(application.urls)),
+    ]
 
 Modifying sub-apps
 ------------------

--- a/oscar/app.py
+++ b/oscar/app.py
@@ -1,7 +1,7 @@
 # flake8: noqa, because URL syntax is more readable with long lines
 
 import django
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
 from django.contrib.auth import views as auth_views
 from django.core.urlresolvers import reverse_lazy
 
@@ -25,13 +25,13 @@ class Shop(Application):
 
     def get_urls(self):
         urls = [
-            (r'^catalogue/', include(self.catalogue_app.urls)),
-            (r'^basket/', include(self.basket_app.urls)),
-            (r'^checkout/', include(self.checkout_app.urls)),
-            (r'^accounts/', include(self.customer_app.urls)),
-            (r'^search/', include(self.search_app.urls)),
-            (r'^dashboard/', include(self.dashboard_app.urls)),
-            (r'^offers/', include(self.offer_app.urls)),
+            url(r'^catalogue/', include(self.catalogue_app.urls)),
+            url(r'^basket/', include(self.basket_app.urls)),
+            url(r'^checkout/', include(self.checkout_app.urls)),
+            url(r'^accounts/', include(self.customer_app.urls)),
+            url(r'^search/', include(self.search_app.urls)),
+            url(r'^dashboard/', include(self.dashboard_app.urls)),
+            url(r'^offers/', include(self.offer_app.urls)),
 
             # Password reset - as we're using Django's default view functions,
             # we can't namespace these urls as that prevents
@@ -72,9 +72,9 @@ class Shop(Application):
             url(r'^password-reset/complete/$',
                 login_forbidden(auth_views.password_reset_complete),
                 name='password-reset-complete'),
-            (r'', include(self.promotions_app.urls)),
+            url(r'', include(self.promotions_app.urls)),
         ]
-        return patterns('', *urls)
+        return urls
 
 
 # 'shop' kept for legacy projects - 'application' is a better name

--- a/oscar/apps/basket/app.py
+++ b/oscar/apps/basket/app.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.contrib.auth.decorators import login_required
 
 from oscar.apps.basket import views
@@ -24,7 +24,7 @@ class BasketApplication(Application):
             url(r'^saved/$', login_required(self.saved_view.as_view()),
                 name='saved'),
         ]
-        return self.post_process_urls(patterns('', *urls))
+        return self.post_process_urls(urls)
 
 
 application = BasketApplication()

--- a/oscar/apps/catalogue/app.py
+++ b/oscar/apps/catalogue/app.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
 
 from oscar.core.application import Application
 from oscar.apps.catalogue import views
@@ -14,7 +14,7 @@ class BaseCatalogueApplication(Application):
 
     def get_urls(self):
         urlpatterns = super(BaseCatalogueApplication, self).get_urls()
-        urls = [
+        urlpatterns += [
             # has different urlname for legacy reasons
             url(r'^$', self.category_view.as_view(), name='index'),
             url(r'^(?P<product_slug>[\w-]*)_(?P<pk>\d+)/$',
@@ -26,7 +26,6 @@ class BaseCatalogueApplication(Application):
                 self.category_view.as_view()),
             url(r'^ranges/(?P<slug>[\w-]+)/$',
                 self.range_view.as_view(), name='range')]
-        urlpatterns += patterns('', *urls)
         return self.post_process_urls(urlpatterns)
 
 
@@ -36,11 +35,10 @@ class ReviewsApplication(Application):
 
     def get_urls(self):
         urlpatterns = super(ReviewsApplication, self).get_urls()
-        urls = [
+        urlpatterns += [
             url(r'^(?P<product_slug>[\w-]*)_(?P<product_pk>\d+)/reviews/',
                 include(self.reviews_app.urls)),
         ]
-        urlpatterns += patterns('', *urls)
         return self.post_process_urls(urlpatterns)
 
 

--- a/oscar/apps/catalogue/reviews/app.py
+++ b/oscar/apps/catalogue/reviews/app.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from oscar.core.application import Application
 from . import views
@@ -22,7 +22,7 @@ class ProductReviewsApplication(Application):
                 name='reviews-vote'),
             url(r'^$', self.list_view.as_view(), name='reviews-list'),
         ]
-        return self.post_process_urls(patterns('', *urls))
+        return self.post_process_urls(urls)
 
 
 application = ProductReviewsApplication()

--- a/oscar/apps/checkout/app.py
+++ b/oscar/apps/checkout/app.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.contrib.auth.decorators import login_required
 from django.conf import settings
 
@@ -49,7 +49,7 @@ class CheckoutApplication(Application):
             url(r'thank-you/$', self.thankyou_view.as_view(),
                 name='thank-you'),
         ]
-        return self.post_process_urls(patterns('', *urls))
+        return self.post_process_urls(urls)
 
     def get_url_decorator(self, pattern):
         if not settings.OSCAR_ALLOW_ANON_CHECKOUT:

--- a/oscar/apps/customer/app.py
+++ b/oscar/apps/customer/app.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.contrib.auth.decorators import login_required
 from django.views import generic
 
@@ -185,7 +185,7 @@ class CustomerApplication(Application):
                                .as_view()),
                 name='wishlists-move-product-to-another')]
 
-        return self.post_process_urls(patterns('', *urls))
+        return self.post_process_urls(urls)
 
 
 application = CustomerApplication()

--- a/oscar/apps/dashboard/app.py
+++ b/oscar/apps/dashboard/app.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
 
 from oscar.apps.dashboard import views
 from oscar.core.application import Application
@@ -41,7 +41,7 @@ class DashboardApplication(Application):
             url(r'^vouchers/', include(self.vouchers_app.urls)),
             url(r'^comms/', include(self.comms_app.urls)),
         ]
-        return self.post_process_urls(patterns('', *urls))
+        return self.post_process_urls(urls)
 
 
 application = DashboardApplication()

--- a/oscar/apps/dashboard/catalogue/app.py
+++ b/oscar/apps/dashboard/catalogue/app.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from oscar.core.application import Application
 from oscar.apps.dashboard.catalogue import views
@@ -88,7 +88,7 @@ class CatalogueApplication(Application):
                 name='catalogue-class-delete'),
 
         ]
-        return self.post_process_urls(patterns('', *urls))
+        return self.post_process_urls(urls)
 
 
 application = CatalogueApplication()

--- a/oscar/apps/dashboard/communications/app.py
+++ b/oscar/apps/dashboard/communications/app.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from oscar.core.application import Application
 from oscar.apps.dashboard.communications import views
@@ -17,7 +17,7 @@ class CommsDashboardApplication(Application):
             url(r'^(?P<slug>\w+)/$', self.update_view.as_view(),
                 name='comms-update'),
         ]
-        return self.post_process_urls(patterns('', *urls))
+        return self.post_process_urls(urls)
 
 
 application = CommsDashboardApplication()

--- a/oscar/apps/dashboard/offers/app.py
+++ b/oscar/apps/dashboard/offers/app.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from oscar.core.application import Application
 from oscar.apps.dashboard.offers import views
@@ -49,7 +49,7 @@ class OffersDashboardApplication(Application):
             url(r'^(?P<pk>\d+)/$', self.detail_view.as_view(),
                 name='offer-detail'),
         ]
-        return self.post_process_urls(patterns('', *urls))
+        return self.post_process_urls(urls)
 
 
 application = OffersDashboardApplication()

--- a/oscar/apps/dashboard/orders/app.py
+++ b/oscar/apps/dashboard/orders/app.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from oscar.core.application import Application
 from oscar.apps.dashboard.orders import views
@@ -37,7 +37,7 @@ class OrdersDashboardApplication(Application):
                 self.shipping_address_view.as_view(),
                 name='order-shipping-address'),
         ]
-        return self.post_process_urls(patterns('', *urls))
+        return self.post_process_urls(urls)
 
 
 application = OrdersDashboardApplication()

--- a/oscar/apps/dashboard/pages/app.py
+++ b/oscar/apps/dashboard/pages/app.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from oscar.core.application import Application
 from oscar.apps.dashboard.pages import views
@@ -25,7 +25,7 @@ class FlatPageManagementApplication(Application):
             url(r'^delete/(?P<pk>\d+)/$',
                 self.delete_view.as_view(), name='page-delete')
         ]
-        return self.post_process_urls(patterns('', *urls))
+        return self.post_process_urls(urls)
 
 
 application = FlatPageManagementApplication()

--- a/oscar/apps/dashboard/partners/app.py
+++ b/oscar/apps/dashboard/partners/app.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from oscar.core.application import Application
 from oscar.apps.dashboard.partners import views
@@ -43,7 +43,7 @@ class PartnersDashboardApplication(Application):
                 self.user_update_view.as_view(),
                 name='partner-user-update'),
         ]
-        return self.post_process_urls(patterns('', *urls))
+        return self.post_process_urls(urls)
 
 
 application = PartnersDashboardApplication()

--- a/oscar/apps/dashboard/promotions/app.py
+++ b/oscar/apps/dashboard/promotions/app.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from oscar.core.application import Application
 from oscar.apps.dashboard.promotions import views
@@ -50,7 +50,7 @@ class PromotionsDashboardApplication(Application):
                     getattr(self, 'delete_%s_view' % code).as_view(),
                     name='promotion-delete')]
 
-        return self.post_process_urls(patterns('', *urls))
+        return self.post_process_urls(urls)
 
 
 application = PromotionsDashboardApplication()

--- a/oscar/apps/dashboard/ranges/app.py
+++ b/oscar/apps/dashboard/ranges/app.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from oscar.core.application import Application
 from oscar.apps.dashboard.ranges import views
@@ -16,8 +16,7 @@ class RangeDashboardApplication(Application):
     reorder_view = views.RangeReorderView
 
     def get_urls(self):
-        urlpatterns = patterns(
-            '',
+        urlpatterns = [
             url(r'^$', self.list_view.as_view(), name='range-list'),
             url(r'^create/$', self.create_view.as_view(), name='range-create'),
             url(r'^(?P<pk>\d+)/$', self.update_view.as_view(),
@@ -28,7 +27,7 @@ class RangeDashboardApplication(Application):
                 name='range-products'),
             url(r'^(?P<pk>\d+)/reorder/$', self.reorder_view.as_view(),
                 name='range-reorder'),
-        )
+        ]
         return self.post_process_urls(urlpatterns)
 
 

--- a/oscar/apps/dashboard/reports/app.py
+++ b/oscar/apps/dashboard/reports/app.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from oscar.core.application import Application
 from oscar.apps.dashboard.reports import views
@@ -14,7 +14,7 @@ class ReportsApplication(Application):
         urls = [
             url(r'^$', self.index_view.as_view(), name='reports-index'),
         ]
-        return self.post_process_urls(patterns('', *urls))
+        return self.post_process_urls(urls)
 
 
 application = ReportsApplication()

--- a/oscar/apps/dashboard/reviews/app.py
+++ b/oscar/apps/dashboard/reviews/app.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from oscar.core.application import Application
 from oscar.apps.dashboard.reviews import views
@@ -20,7 +20,7 @@ class ReviewsApplication(Application):
             url(r'^(?P<pk>\d+)/delete/$', self.delete_view.as_view(),
                 name='reviews-delete'),
         ]
-        return self.post_process_urls(patterns('', *urls))
+        return self.post_process_urls(urls)
 
 
 application = ReviewsApplication()

--- a/oscar/apps/dashboard/users/app.py
+++ b/oscar/apps/dashboard/users/app.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from oscar.core.application import Application
 from oscar.apps.dashboard.users import views
@@ -35,7 +35,7 @@ class UserManagementApplication(Application):
                 self.alert_update_view.as_view(),
                 name='user-alert-update'),
         ]
-        return self.post_process_urls(patterns('', *urls))
+        return self.post_process_urls(urls)
 
 
 application = UserManagementApplication()

--- a/oscar/apps/dashboard/vouchers/app.py
+++ b/oscar/apps/dashboard/vouchers/app.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from oscar.core.application import Application
 from oscar.apps.dashboard.vouchers import views
@@ -26,7 +26,7 @@ class VoucherDashboardApplication(Application):
             url(r'^stats/(?P<pk>\d+)/$', self.stats_view.as_view(),
                 name='voucher-stats'),
         ]
-        return self.post_process_urls(patterns('', *urls))
+        return self.post_process_urls(urls)
 
 
 application = VoucherDashboardApplication()

--- a/oscar/apps/offer/app.py
+++ b/oscar/apps/offer/app.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from oscar.apps.offer import views
 from oscar.core.application import Application
@@ -15,7 +15,7 @@ class OfferApplication(Application):
             url(r'^(?P<slug>[\w-]+)/$', self.detail_view.as_view(),
                 name='detail'),
         ]
-        return self.post_process_urls(patterns('', *urls))
+        return self.post_process_urls(urls)
 
 
 application = OfferApplication()

--- a/oscar/apps/promotions/app.py
+++ b/oscar/apps/promotions/app.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from oscar.core.application import Application
 from oscar.apps.promotions.views import HomeView, RecordClickView
@@ -21,7 +21,7 @@ class PromotionsApplication(Application):
                 name='keyword-click'),
             url(r'^$', self.home_view.as_view(), name='home'),
         ]
-        return self.post_process_urls(patterns('', *urls))
+        return self.post_process_urls(urls)
 
 
 application = PromotionsApplication()

--- a/oscar/apps/search/app.py
+++ b/oscar/apps/search/app.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.conf import settings
 
 from haystack.query import SearchQuerySet
@@ -17,14 +17,13 @@ class SearchApplication(Application):
 
         # The form class has to be passed to the __init__ method as that is how
         # Haystack works.  It's slightly different to normal CBVs.
-        urlpatterns = patterns(
-            '',
+        urlpatterns = [
             url(r'^$', search_view_factory(
                 view_class=self.search_view,
                 form_class=self.search_form,
                 searchqueryset=self.get_sqs()),
                 name='search'),
-        )
+        ]
         return self.post_process_urls(urlpatterns)
 
     def get_sqs(self):

--- a/oscar/core/application.py
+++ b/oscar/core/application.py
@@ -1,7 +1,5 @@
 import six
 
-from django.conf.urls import patterns
-
 from oscar.core.loading import feature_hidden
 from oscar.views.decorators import permissions_required
 
@@ -35,7 +33,7 @@ class Application(object):
         """
         Return the url patterns for this app.
         """
-        return patterns('')
+        return []
 
     def post_process_urls(self, urlpatterns):
         """
@@ -54,7 +52,7 @@ class Application(object):
         # Test if this the URLs in the Application instance should be
         # available.  If the feature is hidden then we don't include the URLs.
         if feature_hidden(self.hidable_feature_name):
-            return patterns('')
+            return []
 
         for pattern in urlpatterns:
             if hasattr(pattern, 'url_patterns'):

--- a/sites/demo/urls.py
+++ b/sites/demo/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.conf import settings
 from django.contrib import admin
 from django.conf.urls.static import static
@@ -17,28 +17,28 @@ js_info_dict = {
 
 admin.autodiscover()
 
-urlpatterns = patterns('',
-    (r'^admin/', include(admin.site.urls)),
-    (r'^i18n/', include('django.conf.urls.i18n')),
+urlpatterns = [
+    url(r'^admin/', include(admin.site.urls)),
+    url(r'^i18n/', include('django.conf.urls.i18n')),
     url(r'^jsi18n/$', 'django.views.i18n.javascript_catalog', js_info_dict),
 
     # Stores extension
-    (r'^stores/', include(stores_app.urls)),
-    (r'^dashboard/stores/', include(dashboard_app.urls)),
+    url(r'^stores/', include(stores_app.urls)),
+    url(r'^dashboard/stores/', include(dashboard_app.urls)),
 
     # PayPal extension
-    (r'^checkout/paypal/', include('paypal.express.urls')),
+    url(r'^checkout/paypal/', include('paypal.express.urls')),
 
     # Datacash extension
-    (r'^dashboard/datacash/', include(datacash_app.urls)),
+    url(r'^dashboard/datacash/', include(datacash_app.urls)),
 
-    (r'', include(application.urls)),
-)
+    url(r'', include(application.urls)),
+]
 
 if settings.DEBUG:
     import debug_toolbar
     urlpatterns += static(settings.MEDIA_URL,
                           document_root=settings.MEDIA_ROOT)
-    urlpatterns += patterns('',
+    urlpatterns += [
         url(r'^__debug__/', include(debug_toolbar.urls)),
-    )
+    ]

--- a/sites/sandbox/apps/gateway/urls.py
+++ b/sites/sandbox/apps/gateway/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from apps.gateway import views
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^$', views.GatewayView.as_view(), name='gateway')
-)
+]

--- a/sites/sandbox/urls.py
+++ b/sites/sandbox/urls.py
@@ -14,29 +14,29 @@ from apps.sitemaps import base_sitemaps
 
 admin.autodiscover()
 
-urlpatterns = patterns('',
+urlpatterns = [
     # Include admin as convenience. It's unsupported and you should
     # use the dashboard
-    (r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', include(admin.site.urls)),
     # Custom functionality to allow dashboard users to be created
-    (r'^gateway/', include('apps.gateway.urls')),
+    url(r'^gateway/', include('apps.gateway.urls')),
     # i18n URLS need to live outside of i18n_patterns scope of the shop
-    (r'^i18n/', include('django.conf.urls.i18n')),
+    url(r'^i18n/', include('django.conf.urls.i18n')),
     # include a basic sitemap
-    (r'^sitemap\.xml$', 'django.contrib.sitemaps.views.index', {'sitemaps': base_sitemaps}),
-    (r'^sitemap-(?P<section>.+)\.xml$', 'django.contrib.sitemaps.views.sitemap', {'sitemaps': base_sitemaps}),
-)
+    url(r'^sitemap\.xml$', 'django.contrib.sitemaps.views.index', {'sitemaps': base_sitemaps}),
+    url(r'^sitemap-(?P<section>.+)\.xml$', 'django.contrib.sitemaps.views.sitemap', {'sitemaps': base_sitemaps}),
+]
 
 # Prefix Oscar URLs with language codes
 urlpatterns += i18n_patterns('',
-    (r'', include(shop.urls)),
+    url(r'', include(shop.urls)),
 )
 
 # Allow rosetta to be used to add translations
 if 'rosetta' in settings.INSTALLED_APPS:
-    urlpatterns += patterns('',
-        (r'^rosetta/', include('rosetta.urls')),
-    )
+    urlpatterns += [
+        url(r'^rosetta/', include('rosetta.urls')),
+    ]
 
 if settings.DEBUG:
     import debug_toolbar
@@ -45,11 +45,9 @@ if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL,
                           document_root=settings.MEDIA_ROOT)
     # Allow error pages to be tested
-    urlpatterns += patterns('',
+    urlpatterns += [
         url(r'^403$', handler403),
         url(r'^404$', handler404),
-        url(r'^500$', handler500)
-    )
-    urlpatterns += patterns('',
+        url(r'^500$', handler500),
         url(r'^__debug__/', include(debug_toolbar.urls)),
-    )
+    ]

--- a/tests/_site/urls.py
+++ b/tests/_site/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, include
+from django.conf.urls import url, include
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
@@ -6,9 +6,9 @@ from oscar.app import shop
 
 admin.autodiscover()
 
-urlpatterns = patterns('',
-    (r'^admin/', include(admin.site.urls)),
-    (r'', include(shop.urls)),
-    (r'^i18n/', include('django.conf.urls.i18n')),
-)
+urlpatterns = [
+    url(r'^admin/', include(admin.site.urls)),
+    url(r'', include(shop.urls)),
+    url(r'^i18n/', include('django.conf.urls.i18n')),
+]
 urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
The function `patterns()` essentially does two things:
1. it applies a prefix - the first argument - to the given urls. In no
   instance a prefix was given
2. it calls url() for simple tuple or list elements in the given iterable.
   Cases where such a tuple or list was passed to patterns have been
   replaced by direct calls to url()

2 allowed for both calls to url() and simple tuples to be listed in
get_urls() and similar places. This allowed for unnecessary variation.
Always calling url() makes the url lists look less noisy and more uniform,
allowing the reader to focus on the actual differences of the urls instead
of superfluities.

django.conf.urls.patterns will also undergo deprecation starting from
Django 1.8. This commit anticipates that change.

https://docs.djangoproject.com/en/dev/releases/1.8/#django-conf-urls-patterns
