### PR TITLE
Added a Warning about installing Oscar on Windows

### DIFF
--- a/docs/source/internals/sandbox.rst
+++ b/docs/source/internals/sandbox.rst
@@ -81,6 +81,12 @@ Running the sandbox locally
 It's pretty straightforward to get the sandbox site running locally so you can
 play around with Oscar.
 
+.. warning::
+    
+    While installing Oscar is straightforward, some of Oscar's dependencies
+    don't support Windows and are tricky to be properly installed, and therefore
+    you might encounter some errors that prevent a successful installation.
+    
 Install Oscar and its dependencies within a virtualenv:
 
 .. code-block:: bash


### PR DESCRIPTION
Several of Oscar dependencies don't support Windows, some of them don't
work at all. Added a warning that indicates installing Oscar on Windows
is a tricky process.
