### PR TITLE
Remove alert that is irrelevant to the user

### DIFF
--- a/oscar/apps/checkout/session.py
+++ b/oscar/apps/checkout/session.py
@@ -112,10 +112,7 @@ class CheckoutSessionMixin(object):
         # not be if the basket is purely downloads
         if not request.basket.is_shipping_required():
             raise exceptions.FailedPreCondition(
-                url=reverse('checkout:shipping-method'),
-                message=_(
-                    "Your basket does not require a shipping"
-                    "address to be submitted")
+                url=reverse('checkout:shipping-method')
             )
 
     def check_shipping_data_is_captured(self, request):


### PR DESCRIPTION
This alert is potentially confusing noise for sites that sell only downloadable
products. I couldn't think of a case where this alert is necessary for sites
that sometimes require a shipping address and sometimes don't.
