### PR TITLE
Rename arguments to match what build_submission returns

### DIFF
--- a/oscar/apps/checkout/mixins.py
+++ b/oscar/apps/checkout/mixins.py
@@ -98,7 +98,7 @@ class OrderPlacementMixin(CheckoutSessionMixin):
 
     def handle_order_placement(self, order_number, user, basket,
                                shipping_address, shipping_method,
-                               total, **kwargs):
+                               order_total, **kwargs):
         """
         Write out the order models and return the appropriate HTTP response
 
@@ -108,12 +108,13 @@ class OrderPlacementMixin(CheckoutSessionMixin):
         """
         order = self.place_order(
             order_number, user, basket, shipping_address, shipping_method,
-            total, **kwargs)
+            order_total, **kwargs)
         basket.submit()
         return self.handle_successful_order(order)
 
     def place_order(self, order_number, user, basket, shipping_address,
-                    shipping_method, total, billing_address=None, **kwargs):
+                    shipping_method, order_total, billing_address=None,
+                    **kwargs):
         """
         Writes the order out to the DB including the payment models
         """
@@ -137,7 +138,7 @@ class OrderPlacementMixin(CheckoutSessionMixin):
             basket=basket,
             shipping_address=shipping_address,
             shipping_method=shipping_method,
-            total=total,
+            total=order_total,
             billing_address=billing_address,
             status=status, **kwargs)
         self.save_payment_details(order)


### PR DESCRIPTION
This way it's easier to pass what build_submission() returns to
handle_order_placement(), compare https://github.com/machtfit/adyen/blob/ecada9ef878ebab026ca3f51d5581e8264f1e445/oscar_adyen/views.py#L104
