### PR TITLE
Added `group_pricing_policy` to `FixedRateTax`

### DIFF
--- a/oscar/apps/partner/strategy.py
+++ b/oscar/apps/partner/strategy.py
@@ -258,6 +258,18 @@ class FixedRateTax(object):
             excl_tax=stockrecord.price_excl_tax,
             tax=tax)
 
+    def group_pricing_policy(self, product, variant_stock):
+        stockrecords = [x[1] for x in variant_stock if x[1] is not None]
+        if not stockrecords:
+            return prices.Unavailable()
+        # We take price from first record
+        stockrecord = stockrecords[0]
+        tax = (stockrecord.price_excl_tax * self.rate).quantize(self.exponent)
+        return prices.FixedPrice(
+            currency=stockrecord.price_currency,
+            excl_tax=stockrecord.price_excl_tax,
+            tax=tax)
+
 
 class DeferredTax(object):
     """


### PR DESCRIPTION
Using a strategy derived from the `FixedRateTax` mixin breaks the default templates (which require a `group_pricing_policy` attribute).  I basically copied the one from `NoTax` and added the tax calculation from `FixedRateTax.pricing_policy`.
