### PR TITLE
Add management command for forking an app

### DIFF
--- a/oscar/core/customisation.py
+++ b/oscar/core/customisation.py
@@ -1,0 +1,76 @@
+from __future__ import absolute_import
+import os
+import shutil
+import logging
+import textwrap
+
+import oscar
+
+
+def fork_app(app_label, folder_path, logger=None):
+    """
+    Create a custom version of one of Oscar's apps
+    """
+    if logger is None:
+        logger = logging.getLogger(__name__)
+
+    # Check app_label is valid
+    app_labels = [x.split('.').pop() for x in oscar.OSCAR_CORE_APPS if
+                  x.startswith('oscar')]
+    if app_label not in app_labels:
+        raise ValueError("There is no Oscar app with label '%s'" % app_label)
+
+    # Check folder exists
+    if not os.path.exists(folder_path):
+        raise ValueError(
+            "The folder '%s' does not exist. Please create it then run this "
+            "command again")
+
+    # Create folder
+    app_folder_path = os.path.join(folder_path, app_label)
+    if os.path.exists(app_folder_path):
+        raise ValueError(
+            "There is already a '%s' folder! Aborting!" % app_folder_path)
+    logger.info("Creating folder %s" % app_folder_path)
+    os.mkdir(app_folder_path)
+
+    # Create minimum app files
+    logger.info("Creating __init__.py and models.py modules")
+    create_file(os.path.join(app_folder_path, '__init__.py'))
+    create_file(
+        os.path.join(app_folder_path, 'models.py'),
+        "from oscar.apps.%s.models import *" % app_label)
+
+    # Migrations
+    source = os.path.join(
+        oscar.__path__[0], 'apps', app_label, 'migrations')
+    destination = os.path.join(app_folder_path, 'migrations')
+    logger.info("Copying migrations from %s to %s", source, destination)
+    shutil.copytree(source, destination)
+
+    # Final step needs to be done by hand
+    app_package = app_folder_path.replace('/', '.')
+    msg = (
+        "The final step is to add '%s' to INSTALLED_APPS "
+        "(replacing the equivalent Oscar app). This can be "
+        "acheived using Oscar's get_core_apps function - eg:"
+    ) % app_package
+    snippet = (
+        "  # settings.py\n"
+        "  ...\n"
+        "  INSTALLED_APPS = [\n"
+        "      'django.contrib.auth',\n"
+        "      ...\n"
+        "  ]\n"
+        "  from oscar import get_core_apps\n"
+        "  INSTALLED_APPS = INSTALLED_APPS + get_core_apps(\n"
+        "      ['%s'])"
+    ) % app_package
+    record = "\n%s\n\n%s" % (
+        "\n".join(textwrap.wrap(msg)), snippet)
+    logger.info(record)
+
+
+def create_file(filepath, content=''):
+    with open(filepath, 'w') as f:
+        f.write(content)

--- a/oscar/management/commands/oscar_fork_app.py
+++ b/oscar/management/commands/oscar_fork_app.py
@@ -1,0 +1,31 @@
+import logging
+
+from django.core.management.base import BaseCommand, CommandError
+
+from oscar.core import customisation
+
+
+class Command(BaseCommand):
+    args = '<app label> <destination folder>'
+    help = (
+        "Create a local version of one of Oscar's app so it can "
+        "be customised")
+
+    def handle(self, *args, **options):
+        # Check that the app hasn't already been forked
+        if len(args) < 2:
+            raise CommandError(
+                "You must specify an app label and a folder to create "
+                "the new app in")
+
+        # Use a stdout logger
+        logger = logging.getLogger(__name__)
+        stream = logging.StreamHandler(self.stdout)
+        logger.addHandler(stream)
+        logger.setLevel(logging.DEBUG)
+
+        app_label, folder_path = args[:2]
+        try:
+            customisation.fork_app(app_label, folder_path, logger)
+        except Exception as e:
+            raise CommandError(e.message)

--- a/tests/config.py
+++ b/tests/config.py
@@ -35,7 +35,9 @@ def configure():
                 # Use a custom partner app to test overriding models.  I can't
                 # find a way of doing this on a per-test basis, so I'm using a
                 # global change.
-            ] + oscar.get_core_apps(['tests._site.apps.partner', 'tests._site.apps.customer']),
+            ] + oscar.get_core_apps([
+                'tests._site.apps.partner',
+                'tests._site.apps.customer']),
             'TEMPLATE_CONTEXT_PROCESSORS': (
                 "django.contrib.auth.context_processors.auth",
                 "django.core.context_processors.request",

--- a/tests/unit/core/customisation_tests.py
+++ b/tests/unit/core/customisation_tests.py
@@ -1,0 +1,55 @@
+import os
+import tempfile
+
+from django.test import TestCase
+from django.conf import settings
+
+from oscar.core import customisation
+
+VALID_FOLDER_PATH = 'tests/_site/apps'
+
+
+class TestForkAppFunction(TestCase):
+
+    def setUp(self):
+        self.tmp_folder = tempfile.mkdtemp()
+
+    def test_raises_exception_for_nonexistant_app_label(self):
+        with self.assertRaises(ValueError):
+            customisation.fork_app('sillytown', 'somefolder')
+
+    def test_raises_exception_for_nonexistant_folder(self):
+        assert not os.path.exists('does_not_exist')
+        with self.assertRaises(ValueError):
+            customisation.fork_app('order', 'does_not_exist')
+
+    def test_raises_exception_if_app_has_alredy_been_forked(self):
+        # We piggyback on another test which means a custom app is already in
+        # the settings we use for the test suite. We just check that's still
+        # the case here.
+        assert 'tests._site.apps.partner' in settings.INSTALLED_APPS
+        with self.assertRaises(ValueError):
+            customisation.fork_app('partner', VALID_FOLDER_PATH)
+
+    def test_creates_new_folder(self):
+        customisation.fork_app('order', self.tmp_folder)
+        new_folder_path = os.path.join(self.tmp_folder, 'order')
+        self.assertTrue(os.path.exists(new_folder_path))
+
+    def test_creates_init_file(self):
+        customisation.fork_app('order', self.tmp_folder)
+        filepath = os.path.join(self.tmp_folder, 'order', '__init__.py')
+        self.assertTrue(os.path.exists(filepath))
+
+    def test_creates_models_file(self):
+        customisation.fork_app('order', self.tmp_folder)
+        filepath = os.path.join(self.tmp_folder, 'order', 'models.py')
+        self.assertTrue(os.path.exists(filepath))
+
+        contents = open(filepath).read()
+        self.assertTrue('from oscar.apps.order.models import *' in contents)
+
+    def test_copies_in_migrations(self):
+        customisation.fork_app('order', self.tmp_folder)
+        migration_path = os.path.join(self.tmp_folder, 'order', 'migrations')
+        self.assertTrue(os.path.exists(migration_path))


### PR DESCRIPTION
This makes it easier to customise Oscar. You can run this command to
quickly create local versions of an app that you want to customise. The
command creates the appropriate folder, **init**.py and models.py. The
only step requiring human intervention is to modify INSTALLED_APPS to
include the new app package.

Usage is:

``` bash
$ ./manage.py oscar_fork_app order apps/
```

This will then create a new `order` apps in `apps/order/` and copy the relevant files into there. The only thing to do is then use this new order app in `INSTALLED_APPS`
