### PR TITLE
Removing 'country' field in ShippingAddressForm safely

### DIFF
--- a/oscar/apps/checkout/forms.py
+++ b/oscar/apps/checkout/forms.py
@@ -25,7 +25,7 @@ class ShippingAddressForm(PhoneNumberMixin, AbstractAddressForm):
 
         # No need to show country dropdown if there is only one option
         if len(countries) == 1:
-            del self.fields['country']
+            self.fields.pop('country', None)
             self.instance.country = countries[0]
         else:
             self.fields['country'].queryset = countries


### PR DESCRIPTION
If there are only one country for shipping, we remove 'country' from form.
But user can redefine field list in form Meta class and not include 'country'.
