### PR TITLE
avoid custom model methods in data migration

### DIFF
--- a/oscar/apps/catalogue/migrations/0010_call_update_product_ratings.py
+++ b/oscar/apps/catalogue/migrations/0010_call_update_product_ratings.py
@@ -4,17 +4,60 @@ from south.db import db
 from south.v2 import DataMigration
 from django.db import models
 
+from oscar.core.compat import AUTH_USER_MODEL, AUTH_USER_MODEL_NAME
+
+
 class Migration(DataMigration):
 
     def forwards(self, orm):
-        for product in orm['catalogue.Product'].objects.all():
-            product.update_rating()
+        for product in orm.Product.objects.all():
+            # adapted from Product.calculate_rating
+            result = orm['reviews.ProductReview'].objects.filter(
+                product_id=product.id,
+                status=1
+            ).aggregate(
+                sum=models.Sum('score'), count=models.Count('id'))
+            reviews_sum = result['sum'] or 0
+            reviews_count = result['count'] or 0
+            rating = None
+            if reviews_count > 0:
+                rating = float(reviews_sum) / reviews_count
+            orm.Product.objects.filter(id=product.id).update(rating=rating)
 
     def backwards(self, orm):
         # rating field will be deleted anyway if migrating backwards
         pass
 
     models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        AUTH_USER_MODEL: {
+            'Meta': {'object_name': AUTH_USER_MODEL_NAME},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
         'catalogue.attributeentity': {
             'Meta': {'object_name': 'AttributeEntity'},
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
@@ -155,8 +198,39 @@ class Migration(DataMigration):
             'primary': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'primary_recommendations'", 'to': "orm['catalogue.Product']"}),
             'ranking': ('django.db.models.fields.PositiveSmallIntegerField', [], {'default': '0'}),
             'recommendation': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['catalogue.Product']"})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'reviews.productreview': {
+            'Meta': {'ordering': "['-delta_votes', 'id']", 'unique_together': "(('product', 'user'),)", 'object_name': 'ProductReview'},
+            'body': ('django.db.models.fields.TextField', [], {}),
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'delta_votes': ('django.db.models.fields.IntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'homepage': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'reviews'", 'null': 'True', 'on_delete': 'models.SET_NULL', 'to': u"orm['catalogue.Product']"}),
+            'score': ('django.db.models.fields.SmallIntegerField', [], {}),
+            'status': ('django.db.models.fields.SmallIntegerField', [], {'default': '1'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'total_votes': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'reviews'", 'null': 'True', 'to': u"orm['{0}']".format(AUTH_USER_MODEL)})
+        },
+        'reviews.vote': {
+            'Meta': {'ordering': "['-date_created']", 'unique_together': "(('user', 'review'),)", 'object_name': 'Vote'},
+            'date_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'delta': ('django.db.models.fields.SmallIntegerField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'review': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'votes'", 'to': u"orm['reviews.ProductReview']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'review_votes'", 'to': u"orm['{0}']".format(AUTH_USER_MODEL)})
         }
     }
 
-    complete_apps = ['catalogue']
+    complete_apps = ['catalogue', 'reviews']
     symmetrical = True


### PR DESCRIPTION
The data migration for product ratings does not work correctly
with South 8 (and earlier) due to reliance on methods that are
not included in the frozen model. This behavior was introduced
in #773, which was a step in the right direction, but which fails
when run against a non-empty product catalogue.

This migration mimics the logic of Product.calculate_rating, adding
the frozen models from the reviews app and friends, and avoiding
any custom methods or joins. It also uses a hard-coded value in
place of ProductReview.APPROVED, for better or worse.

The final difference is the use of QuerySet.update() rather than
Product.save(), which may or may not be desirable in this case.
