### PR TITLE
Added get_success_response to CheckoutSessionMixin

### DIFF
--- a/oscar/apps/checkout/session.py
+++ b/oscar/apps/checkout/session.py
@@ -2,6 +2,7 @@ from django.contrib import messages
 from django import http
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
+from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
 from oscar.core.loading import get_model, get_class
@@ -288,3 +289,15 @@ class CheckoutSessionMixin(object):
 
     def get_success_response(self):
         return http.HttpResponseRedirect(self.get_success_url())
+
+    def get_success_url(self):
+        """
+        Django FormMixin get_success_url copy
+        """
+        if self.success_url:
+            # Forcing possible reverse_lazy evaluation
+            url = force_text(self.success_url)
+        else:
+            raise ImproperlyConfigured(
+                "No URL to redirect to. Provide a success_url.")
+        return url


### PR DESCRIPTION
E.g. we can write just:

```
class ShippingAddressView(...):
    ...
    success_url = reverse('checkout:shipping-method')

    def post(self, request):
        if all_right:
             return self.get_success_response()
```
