### PR TITLE
Clarifyng labels in the proper way.

### DIFF
--- a/oscar/apps/address/abstract_models.py
+++ b/oscar/apps/address/abstract_models.py
@@ -210,7 +210,7 @@ class AbstractAddress(models.Model):
     }
 
     title = models.CharField(
-        pgettext_lazy(u"Treatment Pronouns for the customer", u"Person's Title"),
+        pgettext_lazy(u"Treatment Pronouns for the customer", u"Title"),
         max_length=64, choices=TITLE_CHOICES, blank=True)
     first_name = models.CharField(_("First name"), max_length=255, blank=True)
     last_name = models.CharField(_("Last name"), max_length=255, blank=True)

--- a/oscar/apps/catalogue/abstract_models.py
+++ b/oscar/apps/catalogue/abstract_models.py
@@ -14,7 +14,7 @@ from django.core.files.base import File
 from django.core.validators import RegexValidator
 from django.db import models
 from django.db.models import Sum, Count
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _, pgettext_lazy
 from django.utils.functional import cached_property
 
 from treebeard.mp_tree import MP_Node
@@ -400,7 +400,7 @@ class AbstractProduct(models.Model):
         if not title and self.parent_id:
             title = self.parent.title
         return title
-    get_title.short_description = _("Product title")
+    get_title.short_description = pgettext_lazy(u"Product title", u"Title")
 
     def get_product_class(self):
         """

--- a/oscar/apps/catalogue/reviews/abstract_models.py
+++ b/oscar/apps/catalogue/reviews/abstract_models.py
@@ -3,7 +3,7 @@ from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.db.models import Sum, Count
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _, pgettext_lazy
 
 from oscar.apps.catalogue.reviews.managers import ApprovedReviewsManager
 from oscar.core.compat import AUTH_USER_MODEL
@@ -27,7 +27,7 @@ class AbstractProductReview(models.Model):
     score = models.SmallIntegerField(_("Score"), choices=SCORE_CHOICES)
 
     title = models.CharField(
-        max_length=255, verbose_name=_("Review title"),
+        max_length=255, verbose_name=pgettext_lazy(u"Product review title", "Title"),
         validators=[validators.non_whitespace])
     body = models.TextField(_("Body"))
 
@@ -36,7 +36,7 @@ class AbstractProductReview(models.Model):
         AUTH_USER_MODEL, related_name='reviews', null=True, blank=True)
 
     # Fields to be completed if user is anonymous
-    name = models.CharField(_("Name"), max_length=255, blank=True)
+    name = models.CharField(pgettext_lazy(u"Anonymous reviewer name", u"Name"), max_length=255, blank=True)
     email = models.EmailField(_("Email"), blank=True)
     homepage = models.URLField(_("URL"), blank=True)
 

--- a/oscar/apps/dashboard/pages/forms.py
+++ b/oscar/apps/dashboard/pages/forms.py
@@ -1,7 +1,6 @@
 from django import forms
 from oscar.core.loading import get_model
-from django.utils.translation import ugettext_lazy as _
-
+from django.utils.translation import ugettext_lazy as _, pgettext_lazy
 from oscar.core.validators import URLDoesNotExistValidator
 
 FlatPage = get_model('flatpages', 'FlatPage')
@@ -11,7 +10,7 @@ class PageSearchForm(forms.Form):
     """
     Search form to filter pages by *title.
     """
-    title = forms.CharField(required=False, label=_("Page title"))
+    title = forms.CharField(required=False, label=pgettext_lazy(u"Page title", u"Title"))
 
 
 class PageUpdateForm(forms.ModelForm):

--- a/oscar/apps/dashboard/partners/forms.py
+++ b/oscar/apps/dashboard/partners/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.contrib.auth.models import Permission
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _, pgettext_lazy
 
 from oscar.core.loading import get_model
 from oscar.core.compat import existing_user_fields, get_user_model
@@ -13,7 +13,7 @@ PartnerAddress = get_model('partner', 'PartnerAddress')
 
 
 class PartnerSearchForm(forms.Form):
-    name = forms.CharField(required=False, label=_("Partner name"))
+    name = forms.CharField(required=False, label=pgettext_lazy(u"Partner's name", u"Name"))
 
 
 class PartnerCreateForm(forms.ModelForm):

--- a/oscar/apps/dashboard/users/forms.py
+++ b/oscar/apps/dashboard/users/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _, pgettext_lazy
 
 from oscar.core.loading import get_model
 from oscar.core.compat import get_user_model
@@ -10,7 +10,7 @@ ProductAlert = get_model('customer', 'ProductAlert')
 
 class UserSearchForm(forms.Form):
     email = forms.CharField(required=False, label=_("Email"))
-    name = forms.CharField(required=False, label=_("User name"))
+    name = forms.CharField(required=False, label=pgettext_lazy(u"User's name", u"Name"))
 
 
 class ProductAlertUpdateForm(forms.ModelForm):

--- a/oscar/apps/order/abstract_models.py
+++ b/oscar/apps/order/abstract_models.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.db import models
 from django.db.models import Sum
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _, pgettext_lazy
 from django.utils.datastructures import SortedDict
 
 from oscar.core.compat import AUTH_USER_MODEL
@@ -412,7 +412,7 @@ class AbstractLine(models.Model):
     product = models.ForeignKey(
         'catalogue.Product', on_delete=models.SET_NULL, blank=True, null=True,
         verbose_name=_("Product"))
-    title = models.CharField(_("Product title"), max_length=255)
+    title = models.CharField(pgettext_lazy(u"Product title", u"Title"), max_length=255)
     # UPC can be null because it's usually set as the product's UPC, and that
     # can be null as well
     upc = models.CharField(_("UPC"), max_length=128, blank=True, null=True)

--- a/oscar/apps/partner/abstract_models.py
+++ b/oscar/apps/partner/abstract_models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _, pgettext_lazy
 
 from oscar.core.compat import AUTH_USER_MODEL
 from oscar.models.fields import AutoSlugField
@@ -18,7 +18,7 @@ class AbstractPartner(models.Model):
     """
     code = AutoSlugField(_("Code"), max_length=128, unique=True,
                          populate_from='name')
-    name = models.CharField(_("Partner name"), max_length=128, blank=True)
+    name = models.CharField(pgettext_lazy(u"Partner's name", u"Name"), max_length=128, blank=True)
 
     #: A partner can have users assigned to it. This is used
     #: for access modelling in the permission-based dashboard

--- a/oscar/apps/promotions/models.py
+++ b/oscar/apps/promotions/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _, pgettext_lazy
 from django.core.urlresolvers import reverse
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes import generic
@@ -228,7 +228,7 @@ class AbstractProductList(AbstractPromotion):
     Abstract superclass for promotions which are essentially a list
     of products.
     """
-    name = models.CharField(_("List title"), max_length=255)
+    name = models.CharField(pgettext_lazy(u"Promotion product list title", "Title"), max_length=255)
     description = models.TextField(_("Description"), blank=True)
     link_url = ExtendedURLField(_('Link URL'), blank=True)
     link_text = models.CharField(_("Link text"), max_length=255, blank=True)
@@ -325,7 +325,7 @@ class OrderedProductList(HandPickedProductList):
 class TabbedBlock(AbstractPromotion):
 
     _type = 'Tabbed block'
-    name = models.CharField(_("Block title"), max_length=255)
+    name = models.CharField(pgettext_lazy(u"Tabbed block title", u"Title"), max_length=255)
     date_created = models.DateTimeField(_("Date Created"), auto_now_add=True)
 
     class Meta:

--- a/oscar/apps/wishlists/abstract_models.py
+++ b/oscar/apps/wishlists/abstract_models.py
@@ -3,7 +3,7 @@ import random
 import six
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _, pgettext_lazy
 from django.core.urlresolvers import reverse
 
 from oscar.core.compat import AUTH_USER_MODEL
@@ -112,7 +112,7 @@ class AbstractLine(models.Model):
         blank=True, null=True)
     quantity = models.PositiveIntegerField(_('Quantity'), default=1)
     #: Store the title in case product gets deleted
-    title = models.CharField(_("Product title"), max_length=255)
+    title = models.CharField(pgettext_lazy(u"Product title", u"Title"), max_length=255)
 
     def __unicode__(self):
         return u'%sx %s on %s' % (self.quantity, self.title,

--- a/oscar/templates/oscar/dashboard/catalogue/product_list.html
+++ b/oscar/templates/oscar/dashboard/catalogue/product_list.html
@@ -77,8 +77,8 @@
                 <table class="table table-striped table-bordered">
                     {% block product_list_header %}
                         <tr>
-                            <th>{% if 'recently_edited' in request.GET %}{% trans "Product title" %}
-                                {% else %}{% anchor 'title' _("Product title") %}{% endif %}</th>
+                            <th>{% if 'recently_edited' in request.GET %}{% trans "Title" context "Product title" %}
+                                {% else %}{% anchor 'title' _("Title") %}{% endif %}</th>
                             <th>{% trans "UPC" %}</th>
                             <th>{% trans "Image" %}</th>
                             <th>{% trans "Product Type" %}</th>

--- a/oscar/templates/oscar/dashboard/orders/line_detail.html
+++ b/oscar/templates/oscar/dashboard/orders/line_detail.html
@@ -37,7 +37,7 @@
             </div>
             <table class="table table-striped table-bordered">
                 <tr>
-                    <th>{% trans "Product title" %}</th>
+                    <th>{% trans "Title" context "Product title" %}</th>
                     <td>
                         {% if line.product %}
                             <a href="{{ line.product.get_absolute_url }}">{{ line.title }}</a>

--- a/oscar/templates/oscar/dashboard/pages/index.html
+++ b/oscar/templates/oscar/dashboard/pages/index.html
@@ -48,7 +48,7 @@
             <table class="table table-striped table-bordered table-hover">
                 <thead>
                     <tr>
-                        <th>{% trans "Page title" %}</th>
+                        <th>{% trans "Title" context "Page title" %}</th>
                         <th>{% trans "URL" %}</th>
                         <th></th>
                     </tr>

--- a/oscar/templates/oscar/dashboard/partners/partner_list.html
+++ b/oscar/templates/oscar/dashboard/partners/partner_list.html
@@ -42,7 +42,7 @@
             </caption>
             {% if partners %}
                 <tr>
-                    <th>{% anchor 'name' _('Partner name') %}</th>
+                    <th>{% anchor 'name' _('Name') %}</th>
                     <th>{% trans 'Users' %}</th>
                     <th>{% trans 'Addresses' %}</th>
                     <th>&nbsp;</th>

--- a/oscar/templates/oscar/dashboard/ranges/range_product_list.html
+++ b/oscar/templates/oscar/dashboard/ranges/range_product_list.html
@@ -95,7 +95,7 @@
                             <tr>
                                 <th></th>
                                 <th>{% trans "UPC" %}</th>
-                                <th>{% trans "Product title" %}</th>
+                                <th>{% trans "Title" context "Product title" %}</th>
                                 <th>{% trans "Is product discountable?" %}</th>
                                 <th></th>
                             </tr>

--- a/oscar/templates/oscar/dashboard/reviews/review_delete.html
+++ b/oscar/templates/oscar/dashboard/reviews/review_delete.html
@@ -35,7 +35,7 @@
 
         <table class="table table-striped table-bordered table-hover">
             <tbody> 
-                <tr><th>{% trans "Review Title" %}</th><td>{{ review.title }}</td></tr>
+                <tr><th>{% trans "Title" context "Product review title" %}</th><td>{{ review.title }}</td></tr>
                 <tr><th>{% trans "Product" %}</th><td>{{ review.product.title }}</td></tr>
                 <tr><th>{% trans "User" %}</th><td>{{ review.user.reviewer_name|default:"-" }}</td></tr>
                 <tr><th>{% trans "Score" %}</th><td>{{ review.score|floatformat:1 }}</td></tr>

--- a/oscar/templates/oscar/dashboard/reviews/review_list.html
+++ b/oscar/templates/oscar/dashboard/reviews/review_list.html
@@ -54,7 +54,7 @@
                 </caption>
                 <tr>
                     <th></th>
-                    <th>{% trans "Review title" %}</th>
+                    <th>{% trans "Title" context "Review title" %}</th>
                     <th>{% trans "Product" %}</th>
                     <th>{% trans "User" %}</th>
                     <th>{% anchor 'score' _("Score") %}</th>

--- a/oscar/templates/oscar/dashboard/users/detail.html
+++ b/oscar/templates/oscar/dashboard/users/detail.html
@@ -176,7 +176,7 @@
                                     <tr>
                                         <th>{% trans "Product ID" %}</th>
                                         <th>{% trans "Score" %}</th>
-                                        <th>{% trans "Review title" %}</th>
+                                        <th>{% trans "Title" context "Product review title" %}</th>
                                         <th>{% trans "Body" %}</th>
                                         <th>{% trans "Date created" %}</th>
                                     </tr>


### PR DESCRIPTION
Added contextual markers as @mbertheau suggested here: https://github.com/tangentlabs/django-oscar/pull/1353
I found the line that seems a bit strange for me: https://github.com/tangentlabs/django-oscar/blob/master/oscar/templates/oscar/dashboard/catalogue/product_list.html#L81
Originally, it was

```
{% anchor 'title' _("Title") %}
```

that looks some mmm... hackish, didnt it?
