### PR TITLE
Extract the password reset url into a method

### DIFF
--- a/oscar/apps/customer/forms.py
+++ b/oscar/apps/customer/forms.py
@@ -55,11 +55,7 @@ class PasswordResetForm(auth_forms.PasswordResetForm):
         email = self.cleaned_data['email']
         users = User._default_manager.filter(email__iexact=email)
         for user in users:
-            # Build reset url
-            reset_url = "%s://%s%s" % (
-                'https' if use_https else 'http',
-                site.domain,
-                get_password_reset_url(user))
+            reset_url = self.get_reset_url(site, request, user, use_https)
             ctx = {
                 'user': user,
                 'site': site,
@@ -67,6 +63,16 @@ class PasswordResetForm(auth_forms.PasswordResetForm):
             messages = CommunicationEventType.objects.get_and_render(
                 code=self.communication_type_code, context=ctx)
             Dispatcher().dispatch_user_messages(user, messages)
+
+    def get_reset_url(self, site, request, user, use_https):
+        # the request argument isn't used currently, but implementors might
+        # need it to determine the correct subdomain
+        reset_url = "%s://%s%s" % (
+            'https' if use_https else 'http',
+            site.domain,
+            get_password_reset_url(user))
+
+        return reset_url
 
 
 class SetPasswordForm(auth_forms.SetPasswordForm):


### PR DESCRIPTION
(There will be conflicts when merging this PR with the current master. I will submit a PR that is automatically mergeable later unless there are objections to this change.)

This makes it easier for sites with dynamic subdomains to submit the
correct url in the password reset email without copying any code from
oscar.
