### PR TITLE
Allow non-linear prices

### DIFF
--- a/oscar/apps/analytics/receivers.py
+++ b/oscar/apps/analytics/receivers.py
@@ -51,26 +51,28 @@ def _record_products_in_order(order):
 
 
 def _record_user_order(user, order):
-    try:
-        record = UserRecord.objects.filter(user=user)
-        affected = record.update(
-            num_orders=F('num_orders') + 1,
-            num_order_lines=F('num_order_lines') + order.num_lines,
-            num_order_items=F('num_order_items') + order.num_items,
-            total_spent=F('total_spent') + order.total_incl_tax,
-            date_last_order=order.date_placed)
-        if not affected:
-            UserRecord.objects.create(
-                user=user, num_orders=1, num_order_lines=order.num_lines,
-                num_order_items=order.num_items,
-                total_spent=order.total_incl_tax,
-                date_last_order=order.date_placed)
-    except IntegrityError:
-        logger.error(
-            "IntegrityError in analytics when recording a user order.")
+    """
+    Records a user's order
 
+    Note: Unfortunately, Django's F() expressions aren't working with decimals.
+          So we have to go down the costly route of fetching the record and
+          updating it.
+    """
+    if user.is_authenticated():
+        try:
+            record, __ = UserRecord.objects.get_or_create(user=user)
+            record.num_orders += 1
+            record.num_order_lines += order.num_lines
+            record.num_order_items += order.num_items
+            record.total_spent += order.total_incl_tax
+            record.date_last_order = order.date_placed
+            record.save()
+        except IntegrityError:
+            logger.error(
+                "IntegrityError in analytics when recording a user order.")
 
 # Receivers
+
 
 @receiver(product_viewed)
 def receive_product_view(sender, product, user, **kwargs):

--- a/oscar/apps/basket/abstract_models.py
+++ b/oscar/apps/basket/abstract_models.py
@@ -171,7 +171,8 @@ class AbstractBasket(models.Model):
         # Ensure that all lines are the same currency
         price_currency = self.currency
         stock_info = self.strategy.fetch_for_product(product)
-        if price_currency and stock_info.price.currency != price_currency:
+        price = stock_info.price.get_unit_price()
+        if price_currency and price.currency != price_currency:
             raise ValueError((
                 "Basket lines must all have the same currency. Proposed "
                 "line has currency %s, while basket has currency %s")
@@ -191,11 +192,11 @@ class AbstractBasket(models.Model):
         # audit and sometimes caching.
         defaults = {
             'quantity': quantity,
-            'price_excl_tax': stock_info.price.excl_tax,
-            'price_currency': stock_info.price.currency,
+            'price_excl_tax': price.excl_tax,
+            'price_currency': price.currency,
         }
-        if stock_info.price.is_tax_known:
-            defaults['price_incl_tax'] = stock_info.price.incl_tax
+        if price.is_tax_known:
+            defaults['price_incl_tax'] = price.incl_tax
 
         line, created = self.lines.get_or_create(
             line_reference=line_ref,
@@ -723,8 +724,18 @@ class AbstractLine(models.Model):
         return self._info
 
     @property
+    def unit_price(self):
+        return self.purchase_info.price.get_unit_price()
+
+    @property
+    def line_price(self):
+        return self.purchase_info.price.get_price(self.quantity)
+
+    # Most of the properties below should be deprecated at some point
+
+    @property
     def is_tax_known(self):
-        return self.purchase_info.price.is_tax_known
+        return self.unit_price.is_tax_known
 
     @property
     def unit_effective_price(self):
@@ -735,19 +746,19 @@ class AbstractLine(models.Model):
 
     @property
     def unit_price_excl_tax(self):
-        return self.purchase_info.price.excl_tax
+        return self.unit_price.excl_tax
 
     @property
     def unit_price_incl_tax(self):
-        return self.purchase_info.price.incl_tax
+        return self.unit_price.incl_tax
 
     @property
     def unit_tax(self):
-        return self.purchase_info.price.tax
+        return self.unit_price.tax
 
     @property
     def line_price_excl_tax(self):
-        return self.quantity * self.unit_price_excl_tax
+        return self.line_price.excl_tax
 
     @property
     def line_price_excl_tax_incl_discounts(self):
@@ -771,11 +782,11 @@ class AbstractLine(models.Model):
 
     @property
     def line_tax(self):
-        return self.quantity * self.unit_tax
+        return self.line_price.tax
 
     @property
     def line_price_incl_tax(self):
-        return self.quantity * self.unit_price_incl_tax
+        return self.line_price.incl_tax
 
     @property
     def description(self):
@@ -797,20 +808,19 @@ class AbstractLine(models.Model):
             msg = u"'%(product)s' is no longer available"
             return _(msg) % {'product': self.product.get_title()}
 
-        if not self.price_incl_tax:
-            return
-        if not self.purchase_info.price.is_tax_known:
+        if not self.is_tax_known:
             return
 
         # Compare current price to price when added to basket
-        current_price_incl_tax = self.purchase_info.price.incl_tax
-        if current_price_incl_tax != self.price_incl_tax:
+        new_price_incl_tax = self.unit_price.incl_tax
+        old_price_incl_tax = self.price_incl_tax
+        if new_price_incl_tax != old_price_incl_tax:
             product_prices = {
                 'product': self.product.get_title(),
-                'old_price': currency(self.price_incl_tax),
-                'new_price': currency(current_price_incl_tax)
+                'old_price': currency(old_price_incl_tax),
+                'new_price': currency(new_price_incl_tax)
             }
-            if current_price_incl_tax > self.price_incl_tax:
+            if new_price_incl_tax > old_price_incl_tax:
                 warning = _("The price of '%(product)s' has increased from"
                             " %(old_price)s to %(new_price)s since you added"
                             " it to your basket")

--- a/oscar/apps/partner/abstract_models.py
+++ b/oscar/apps/partner/abstract_models.py
@@ -107,9 +107,11 @@ class AbstractStockRecord(models.Model):
         _("Price (excl. tax)"), decimal_places=2, max_digits=12,
         blank=True, null=True)
 
-    #: Retail price for this item.  This is simply the recommended price from
-    #: the manufacturer.  If this is used, it is for display purposes only.
-    #: This prices is the NOT the price charged to the customer.
+    #: Retail price for this item. Not used by Oscar, included for convenience.
+    #: This can be used for the recommended price from the manufacturer, for
+    #: displayed purposes; e.g. "Save $x over the recommended retail price!")
+    #: How and where you use this, and whether tax is included is entirely up
+    #: to you.
     price_retail = models.DecimalField(
         _("Price (retail)"), decimal_places=2, max_digits=12,
         blank=True, null=True)

--- a/oscar/apps/partner/prices.py
+++ b/oscar/apps/partner/prices.py
@@ -12,26 +12,42 @@ class Base(object):
     #: Whether tax is known
     is_tax_known = False
 
-    #: Price excluding tax
-    excl_tax = None
-
-    #: Price including tax
-    incl_tax = None
-
-    #: Price to use for offer calculations
-    @property
-    def effective_price(self):
-        # Default to using the price excluding tax for calculations
-        return self.excl_tax
-
-    #: Price tax
-    tax = None
-
     #: Price currency (3 char code)
     currency = None
 
+    #: Price for single unit to use for offer calculations
+    #: Note that offers app currently won't work with non-linear prices!
+    @property
+    def effective_price(self):
+        # Default to using the price excluding tax for calculations
+        return self.get_price().excl_tax
+
+    def get_price(self, quantity=1):
+        """
+        Returns a oscar.core.prices.Price instance for a given quantity.
+        """
+        return prices.Price(currency=None, excl_tax=None)
+
     def __repr__(self):
         return "%s(%r)" % (self.__class__.__name__, self.__dict__)
+
+    ## Deprecated attributes ##
+    # TODO Raise DeprecationWarning
+
+    #: Price for single unit excluding tax
+    @property
+    def excl_tax(self):
+        return self.get_price().excl_tax
+
+    #: Price for single unit including tax
+    @property
+    def incl_tax(self):
+        return self.get_price().incl_tax
+
+    #: Price tax for single unit
+    @property
+    def tax(self):
+        return self.get_price().tax
 
 
 class Unavailable(Base):

--- a/oscar/apps/partner/prices.py
+++ b/oscar/apps/partner/prices.py
@@ -22,13 +22,16 @@ class Base(object):
     @property
     def effective_price(self):
         # Default to using the price excluding tax for calculations
-        return self.get_price().excl_tax
+        return self.get_unit_price().excl_tax
 
-    def get_price(self, quantity=1):
+    def get_price(self, quantity):
         """
         Returns a oscar.core.prices.Price instance for a given quantity.
         """
         return prices.Price(currency=None, excl_tax=None)
+
+    def get_unit_price(self):
+        return self.get_price(1)
 
     def __repr__(self):
         return "%s(%r)" % (self.__class__.__name__, self.__dict__)
@@ -41,7 +44,7 @@ class Base(object):
         warnings.warn(
             "The excl_tax property is deprecated. "
             "Use get_price(qty).excl_tax instead.", DeprecationWarning)
-        return self.get_price().excl_tax
+        return self.get_unit_price().excl_tax
 
     #: Price for single unit including tax
     @property
@@ -49,7 +52,7 @@ class Base(object):
         warnings.warn(
             "The incl_tax property is deprecated. "
             "Use get_price(qty).incl_tax instead.", DeprecationWarning)
-        return self.get_price().incl_tax
+        return self.get_unit_price().incl_tax
 
     #: Price tax for single unit
     @property
@@ -57,7 +60,7 @@ class Base(object):
         warnings.warn(
             "The tax property is deprecated. "
             "Use get_price(qty).tax instead.", DeprecationWarning)
-        return self.get_price().tax
+        return self.get_unit_price().tax
 
 
 class Unavailable(Base):
@@ -103,7 +106,7 @@ class FixedPrice(Base):
             return None
         return total_excl_tax * self.tax_rate
 
-    def get_price(self, quantity=1):
+    def get_price(self, quantity):
         total_excl_tax = self.calculate_total(quantity)
         tax = self.calculate_tax(total_excl_tax)
         return prices.Price(self.currency, total_excl_tax, tax=tax)
@@ -130,4 +133,4 @@ class TaxInclusiveFixedPrice(FixedPrice):
 
     @property
     def effective_price(self):
-        return self.get_price().incl_tax
+        return self.get_unit_price().incl_tax

--- a/oscar/apps/partner/prices.py
+++ b/oscar/apps/partner/prices.py
@@ -92,15 +92,12 @@ class FixedPrice(Base):
         """
         Implements a naive linear pricing. Override this function to implement
         e.g. bulk pricing.
-        Defaults to quantizing with the same precision as the unit price.
         """
         return self._excl_tax * quantity
 
     def calculate_tax(self, total_excl_tax):
         """
         Calculates tax, given a non-tax total.
-        Defaults to quantizing with the same precision as the given total,
-        which should be the precision of the prices.
         """
         if self.tax_rate is None:
             return None

--- a/oscar/apps/partner/prices.py
+++ b/oscar/apps/partner/prices.py
@@ -1,3 +1,5 @@
+import warnings
+
 from oscar.core import prices
 
 
@@ -37,6 +39,7 @@ class Base(object):
     #: Price for single unit excluding tax
     @property
     def excl_tax(self):
+        warnings.warn("The excl_tax property is ")
         return self.get_price().excl_tax
 
     #: Price for single unit including tax

--- a/oscar/apps/partner/prices.py
+++ b/oscar/apps/partner/prices.py
@@ -33,23 +33,30 @@ class Base(object):
     def __repr__(self):
         return "%s(%r)" % (self.__class__.__name__, self.__dict__)
 
-    ## Deprecated attributes ##
-    # TODO Raise DeprecationWarning
+    # -- Deprecated attributes -- #
 
     #: Price for single unit excluding tax
     @property
     def excl_tax(self):
-        warnings.warn("The excl_tax property is ")
+        warnings.warn(
+            "The excl_tax property is deprecated. "
+            "Use get_price(qty).excl_tax instead.", DeprecationWarning)
         return self.get_price().excl_tax
 
     #: Price for single unit including tax
     @property
     def incl_tax(self):
+        warnings.warn(
+            "The incl_tax property is deprecated. "
+            "Use get_price(qty).incl_tax instead.", DeprecationWarning)
         return self.get_price().incl_tax
 
     #: Price tax for single unit
     @property
     def tax(self):
+        warnings.warn(
+            "The tax property is deprecated. "
+            "Use get_price(qty).tax instead.", DeprecationWarning)
         return self.get_price().tax
 
 

--- a/oscar/apps/partner/prices.py
+++ b/oscar/apps/partner/prices.py
@@ -81,7 +81,7 @@ class FixedPrice(Base):
         e.g. bulk pricing.
         Defaults to quantizing with the same precision as the unit price.
         """
-        return (self._excl_tax * quantity).quantize(self._excl_tax)
+        return self._excl_tax * quantity
 
     def calculate_tax(self, total_excl_tax):
         """
@@ -91,7 +91,7 @@ class FixedPrice(Base):
         """
         if self.tax_rate is None:
             return None
-        return (total_excl_tax * self.tax_rate).quantize(total_excl_tax)
+        return total_excl_tax * self.tax_rate
 
     def get_price(self, quantity=1):
         total_excl_tax = self.calculate_total(quantity)

--- a/oscar/apps/partner/prices.py
+++ b/oscar/apps/partner/prices.py
@@ -27,9 +27,6 @@ class Base(object):
     #: Price tax
     tax = None
 
-    #: Retail price
-    retail = None
-
     #: Price currency (3 char code)
     currency = None
 

--- a/oscar/apps/partner/strategy.py
+++ b/oscar/apps/partner/strategy.py
@@ -220,6 +220,10 @@ class NoTax(object):
     Pricing policy mixin for use with the ``Structured`` base strategy.
     This mixin specifies zero tax and uses the ``price_excl_tax`` from the
     stockrecord.
+
+    Note that if you use this mixin, access to the Price.incl_tax and Price.tax
+    attributes will throw a TaxNotKnown exception. If you want a tax of 0%,
+    use the FixedRateTax mixin below.
     """
     price_class = prices.FixedPrice
     rate = None
@@ -288,7 +292,7 @@ class DeferredTax(object):
 # charge tax!
 
 
-class Default(UseFirstStockRecord, StockRequired, NoTax, Structured):
+class Default(UseFirstStockRecord, StockRequired, FixedRateTax, Structured):
     """
     Default stock/price strategy that uses the first found stockrecord for a
     product, ensures that stock is available (unless the product class

--- a/oscar/core/prices.py
+++ b/oscar/core/prices.py
@@ -10,34 +10,39 @@ class Price(object):
     Simple price class that encapsulates a price and its tax information
 
     Attributes:
-        incl_tax (Decimal): Price including taxes
+        incl_tax (Decimal): Price including taxes. None if tax is not known.
         excl_tax (Decimal): Price excluding taxes
-        tax (Decimal): Tax amount
+        tax (Decimal): Tax amount, or None if tax is not known.
         is_tax_known (bool): Whether tax is known
         currency (str): 3 character currency code
+
+    Price instances should be treated as read-only instances, as pricing
+    policies are responsible for calculating tax and quantity pricing.
     """
 
     def __init__(self, currency, excl_tax, incl_tax=None, tax=None):
         self.currency = currency
         self.excl_tax = excl_tax
         if incl_tax is not None:
-            self.incl_tax = incl_tax
+            self._incl_tax = incl_tax
             self.is_tax_known = True
         elif tax is not None:
-            self.incl_tax = excl_tax + tax
+            self._incl_tax = excl_tax + tax
             self.is_tax_known = True
         else:
-            self.incl_tax = None
             self.is_tax_known = False
 
-    def _get_tax(self):
-        return self.incl_tax - self.excl_tax
+    @property
+    def tax(self):
+        if self.is_tax_known:
+            return self.incl_tax - self.excl_tax
+        raise TaxNotKnown
 
-    def _set_tax(self, value):
-        self.incl_tax = self.excl_tax + value
-        self.is_tax_known = True
-
-    tax = property(_get_tax, _set_tax)
+    @property
+    def incl_tax(self):
+        if self.is_tax_known:
+            return self._incl_tax
+        raise TaxNotKnown
 
     def __repr__(self):
         if self.is_tax_known:

--- a/oscar/core/prices.py
+++ b/oscar/core/prices.py
@@ -1,3 +1,6 @@
+from decimal import Decimal as D
+
+
 class TaxNotKnown(Exception):
     """
     Exception for when a tax-inclusive price is requested but we don't know
@@ -7,12 +10,16 @@ class TaxNotKnown(Exception):
 
 class Price(object):
     """
-    Simple price class that encapsulates a price and its tax information
+    This class encapsulates a price and its tax information.
+
+    Amounts are returned as decimals internally and are quantized
+    to the given exponent. If no exponent is given, it defaults to two digits
+    after the comma.
 
     Attributes:
-        incl_tax (Decimal): Price including taxes. None if tax is not known.
         excl_tax (Decimal): Price excluding taxes
         tax (Decimal): Tax amount, or None if tax is not known.
+        incl_tax (Decimal): Price including taxes. None if tax is not known.
         is_tax_known (bool): Whether tax is known
         currency (str): 3 character currency code
 
@@ -20,9 +27,11 @@ class Price(object):
     policies are responsible for calculating tax and quantity pricing.
     """
 
-    def __init__(self, currency, excl_tax, incl_tax=None, tax=None):
+    def __init__(self, currency, excl_tax, incl_tax=None, tax=None,
+                 exponent=None):
         self.currency = currency
-        self.excl_tax = excl_tax
+        self.exponent = exponent or D('0.01')
+        self._excl_tax = excl_tax
         if incl_tax is not None:
             self._incl_tax = incl_tax
             self.is_tax_known = True
@@ -33,15 +42,20 @@ class Price(object):
             self.is_tax_known = False
 
     @property
+    def excl_tax(self):
+        if self._excl_tax is not None:
+            return D(self._excl_tax).quantize(self.exponent)
+
+    @property
     def tax(self):
         if self.is_tax_known:
-            return self.incl_tax - self.excl_tax
+            return (self.incl_tax - self._excl_tax).quantize(self.exponent)
         raise TaxNotKnown
 
     @property
     def incl_tax(self):
         if self.is_tax_known:
-            return self._incl_tax
+            return D(self._incl_tax).quantize(self.exponent)
         raise TaxNotKnown
 
     def __repr__(self):

--- a/oscar/templates/oscar/basket/partials/basket_content.html
+++ b/oscar/templates/oscar/basket/partials/basket_content.html
@@ -195,9 +195,9 @@
                             <div class="span2 align-center">
                                 <p class="price_color">
                                     {% if saved.price.is_tax_known %}
-                                        {{ saved.price.incl_tax|currency:saved.price.currency }}
+                                        {{ saved.price.get_unit_price.incl_tax|currency:saved.price.currency }}
                                     {% else %}
-                                        {{ saved.price.excl_tax|currency:saved.price.currency }}
+                                        {{ saved.price.get_unit_price.excl_tax|currency:saved.price.currency }}
                                     {% endif %}
                                 </p>
                             </div>

--- a/oscar/templates/oscar/catalogue/detail.html
+++ b/oscar/templates/oscar/catalogue/detail.html
@@ -137,17 +137,19 @@
 
         {% purchase_info_for_product request product as session %}
         {% if session.price.exists %}
-            <tr>
-                <th>{% trans "Price (excl. tax)" %}</th><td>{{ session.price.excl_tax|currency:session.price.currency }}</td>
-            </tr>
-            {% if session.price.is_tax_known %}
+            {% with price=session.price.get_unit_price %}
                 <tr>
-                    <th>{% trans "Price (incl. tax)" %}</th><td>{{ session.price.incl_tax|currency:session.price.currency }}</td>
+                    <th>{% trans "Price (excl. tax)" %}</th><td>{{ price.excl_tax|currency:price.currency }}</td>
                 </tr>
-                <tr>
-                    <th>{% trans "Tax" %}</th><td>{{ session.price.tax|currency:session.price.currency }}</td>
-                </tr>
-            {% endif %}
+                {% if price.is_tax_known %}
+                    <tr>
+                        <th>{% trans "Price (incl. tax)" %}</th><td>{{ price.incl_tax|currency:price.currency }}</td>
+                    </tr>
+                    <tr>
+                        <th>{% trans "Tax" %}</th><td>{{ price.tax|currency:price.currency }}</td>
+                    </tr>
+                {% endif %}
+            {% endwith %}
             <tr>
                 <th>{% trans "Availability" %}</th>
                 <td>{{ session.availability.message }}</td>

--- a/oscar/templates/oscar/catalogue/partials/stock_record.html
+++ b/oscar/templates/oscar/catalogue/partials/stock_record.html
@@ -6,12 +6,12 @@
 {% purchase_info_for_product request product as session %}
 
 {% if session.price.exists %}
-    {% if session.price.excl_tax == 0 %}
+    {% if session.price.get_unit_price.excl_tax == 0 %}
         <h2 class="price_color">{% trans "Free" %}</h2>
     {% elif session.price.is_tax_known %}
-        <h2 class="price_color">{{ session.price.incl_tax|currency:session.price.currency }}</h2>
+        <h2 class="price_color">{{ session.price.get_unit_price.incl_tax|currency:session.price.currency }}</h2>
     {% else %}
-        <h2 class="price_color">{{ session.price.excl_tax|currency:session.price.currency }}</h2>
+        <h2 class="price_color">{{ session.price.get_unit_price.excl_tax|currency:session.price.currency }}</h2>
     {% endif %}
 {% else %}
     <h2 class="price_color">&nbsp;</h2>

--- a/runtests.py
+++ b/runtests.py
@@ -84,12 +84,14 @@ if __name__ == '__main__':
     with warnings.catch_warnings():
         # The warnings module in default configuration will never cause tests
         # to fail, as it never raises an exception.  We alter that behaviour by
-        # turning DeprecationWarnings into exceptions, but exclude warnings
-        # triggered by third-party libs. Note: The context manager is not thread
-        # safe. Behaviour with multiple threads is undefined.
+        # turning DeprecationWarnings and RuntimeWarnings into exceptions,
+        # but exclude warnings triggered by third-party libs.
+        # Note: The context manager is not thread safe. Behaviour with
+        # multiple threads is undefined.
         warnings.filterwarnings('error', category=DeprecationWarning)
         warnings.filterwarnings('error', category=RuntimeWarning)
         libs = r'(sorl\.thumbnail.*|bs4.*|webtest.*)'
         warnings.filterwarnings(
             'ignore', r'.*', DeprecationWarning, libs)
+
         run_tests(verbosity, *args)

--- a/sites/demo/templates/catalogue/detail.html
+++ b/sites/demo/templates/catalogue/detail.html
@@ -123,10 +123,10 @@
                 </tr>
                 {% if session.availability.is_available_to_buy %}
                 <tr>
-                    <th>{% trans "Price (excl. tax)" %}</th><td>{{ session.price.excl_tax|currency }}</td>
+                    <th>{% trans "Price (excl. tax)" %}</th><td>{{ session.price.get_unit_price.excl_tax|currency }}</td>
                 </tr>
                 <tr>
-                    <th>{% trans "Price (incl. tax)" %}</th><td>{{ session.price.incl_tax|currency }}</td>
+                    <th>{% trans "Price (incl. tax)" %}</th><td>{{ session.price.get_unit_price.incl_tax|currency }}</td>
                 </tr>
                 <tr>
                     <th>{% trans "Availability" %}</th>

--- a/sites/demo/templates/catalogue/partials/stock_record.html
+++ b/sites/demo/templates/catalogue/partials/stock_record.html
@@ -5,7 +5,16 @@
 {% purchase_info_for_product request product as session %}
 
 {% if product.is_group %}
-    <span>{% blocktrans with product.min_variant_price_incl_tax|currency as price %} <i>From</i> {{ price }}{% endblocktrans %}</span>
+    <span>
+        {% blocktrans with product.min_variant_price_incl_tax|currency as price %} <i>From</i> {{ price }}{% endblocktrans %}
+    </span>
 {% else %}
-    <span>{% if session.price.retail > session.price.incl_tax %}<del>{{ session.price.retail|currency }}</del>{% endif %} {{ session.price.incl_tax|currency }}</span>
+    <span>
+        {% with price=session.price.get_unit_price %}
+            {% if session.stockrecord.price_retail > price.incl_tax %}
+                <del>{{ session.stockrecord.retail_price|currency }}</del>
+            {% endif %}
+            {{ price.incl_tax|currency }}
+        {% endwith %}
+    </span>
 {% endif %}

--- a/sites/us/apps/tax.py
+++ b/sites/us/apps/tax.py
@@ -16,8 +16,7 @@ def apply_to(submission):
     # New Jersey and New York. In reality, you'll probably want to use a tax
     # service like Avalara to look up the taxes for a given submission.
     shipping_address = submission['shipping_address']
-    rate = STATE_TAX_RATES.get(
-        shipping_address.state, ZERO)
+    rate = STATE_TAX_RATES.get(shipping_address.state, ZERO)
     for line in submission['basket'].all_lines():
         line_tax = calculate_tax(
             line.line_price_excl_tax_incl_discounts, rate)

--- a/tests/integration/basket/model_tests.py
+++ b/tests/integration/basket/model_tests.py
@@ -18,6 +18,7 @@ class TestAddingAProductToABasket(TestCase):
             currency='GBP',
             product=self.product, price_excl_tax=D('10.00'))
         self.purchase_info = factories.create_purchase_info(self.record)
+        self.unit_price = self.purchase_info.price.get_unit_price()
         self.basket.add(self.product)
 
     def test_creates_a_line(self):
@@ -25,8 +26,8 @@ class TestAddingAProductToABasket(TestCase):
 
     def test_sets_line_prices(self):
         line = self.basket.lines.all()[0]
-        self.assertEqual(line.price_incl_tax, self.purchase_info.price.incl_tax)
-        self.assertEqual(line.price_excl_tax, self.purchase_info.price.excl_tax)
+        self.assertEqual(line.price_incl_tax, self.unit_price.incl_tax)
+        self.assertEqual(line.price_excl_tax, self.unit_price.excl_tax)
 
     def test_means_another_currency_product_cannot_be_added(self):
         product = factories.create_product()

--- a/tests/integration/offer/tax_tests.py
+++ b/tests/integration/offer/tax_tests.py
@@ -11,7 +11,7 @@ from oscar.test.basket import add_product
 class TestAValueBasedOffer(TestCase):
 
     def setUp(self):
-        # Get 20% if spending more than 20.00
+        # Get 20% if spending more than 10.00
         range = models.Range.objects.create(
             name="All products", includes_all_products=True)
         condition = models.Condition.objects.create(

--- a/tests/integration/partner/strategy_tests.py
+++ b/tests/integration/partner/strategy_tests.py
@@ -16,14 +16,15 @@ class TestDefaultStrategy(TestCase):
         product = factories.create_product()
         info = self.strategy.fetch_for_product(product)
         self.assertFalse(info.availability.is_available_to_buy)
-        self.assertIsNone(info.price.incl_tax)
+        self.assertIsNone(info.price.excl_tax)
 
     def test_one_stockrecord(self):
-        product = factories.create_product(price=D('1.99'), num_in_stock=4)
+        price = D('1.99')
+        product = factories.create_product(price=price, num_in_stock=4)
         info = self.strategy.fetch_for_product(product)
         self.assertTrue(info.availability.is_available_to_buy)
-        self.assertEqual(D('1.99'), info.price.excl_tax)
-        self.assertEqual(D('1.99'), info.price.incl_tax)
+        self.assertEqual(price, info.price.excl_tax)
+        self.assertEqual(price, info.price.incl_tax)
 
     def test_product_which_doesnt_track_stock(self):
         product_class = models.ProductClass.objects.create(
@@ -39,7 +40,7 @@ class TestDefaultStrategy(TestCase):
         line = Line(product=product)
         info = self.strategy.fetch_for_line(line)
         self.assertFalse(info.availability.is_available_to_buy)
-        self.assertIsNone(info.price.incl_tax)
+        self.assertIsNone(info.price.excl_tax)
 
     def test_free_product_is_available_to_buy(self):
         product = factories.create_product(price=D('0'), num_in_stock=1)

--- a/tests/integration/partner/strategy_tests.py
+++ b/tests/integration/partner/strategy_tests.py
@@ -3,6 +3,7 @@ from decimal import Decimal as D
 
 from oscar.apps.partner import strategy
 from oscar.apps.catalogue import models
+from oscar.apps.partner import prices
 from oscar.test import factories
 from oscar.apps.basket.models import Line
 
@@ -108,3 +109,42 @@ class TestDefaultStrategyForParentProductWithOutOfStockVariant(TestCase):
 
     def test_specifies_product_has_correct_price(self):
         self.assertEqual(D('10.00'), self.info.price.get_unit_price().excl_tax)
+
+
+# Setup for non-linear pricing tests
+
+
+class DiscountingPricingPolicy(prices.FixedPrice):
+
+    def calculate_total(self, quantity):
+        """
+        Gives 10% discount on orders over 10 units
+        """
+        if quantity <= 10:
+            discount = D('0')
+        else:
+            discount = D('0.1')
+        return self._excl_tax * quantity * (D(1) - discount)
+
+
+class DiscountingNoTax(strategy.NoTax):
+
+    price_class = DiscountingPricingPolicy
+
+
+class NonLinearStrategy(
+    strategy.UseFirstStockRecord, strategy.StockRequired,
+    DiscountingNoTax, strategy.Structured):
+    pass
+
+
+class TestNonLinearPricingStrategy(TestCase):
+
+    def test_higher_quantities_are_discounted(self):
+        self.strategy = NonLinearStrategy()
+        price = D('1.99')
+        product = factories.create_product(price=price, num_in_stock=1)
+        info = self.strategy.fetch_for_product(product)
+
+        self.assertEqual(price, info.price.get_unit_price().excl_tax)
+        self.assertNotEqual(price*11, info.price.get_price(11).excl_tax)

--- a/tests/integration/partner/strategy_tests.py
+++ b/tests/integration/partner/strategy_tests.py
@@ -16,15 +16,15 @@ class TestDefaultStrategy(TestCase):
         product = factories.create_product()
         info = self.strategy.fetch_for_product(product)
         self.assertFalse(info.availability.is_available_to_buy)
-        self.assertIsNone(info.price.excl_tax)
+        self.assertIsNone(info.price.get_unit_price().excl_tax)
 
     def test_one_stockrecord(self):
         price = D('1.99')
         product = factories.create_product(price=price, num_in_stock=4)
         info = self.strategy.fetch_for_product(product)
         self.assertTrue(info.availability.is_available_to_buy)
-        self.assertEqual(price, info.price.excl_tax)
-        self.assertEqual(price, info.price.incl_tax)
+        self.assertEqual(price, info.price.get_unit_price().excl_tax)
+        self.assertEqual(price, info.price.get_unit_price().incl_tax)
 
     def test_product_which_doesnt_track_stock(self):
         product_class = models.ProductClass.objects.create(
@@ -40,7 +40,7 @@ class TestDefaultStrategy(TestCase):
         line = Line(product=product)
         info = self.strategy.fetch_for_line(line)
         self.assertFalse(info.availability.is_available_to_buy)
-        self.assertIsNone(info.price.excl_tax)
+        self.assertIsNone(info.price.get_unit_price().excl_tax)
 
     def test_free_product_is_available_to_buy(self):
         product = factories.create_product(price=D('0'), num_in_stock=1)
@@ -86,7 +86,7 @@ class TestDefaultStrategyForParentProductWithInStockVariant(TestCase):
         self.assertEqual('available', self.info.availability.code)
 
     def test_specifies_product_has_correct_price(self):
-        self.assertEqual(D('10.00'), self.info.price.incl_tax)
+        self.assertEqual(D('10.00'), self.info.price.get_unit_price().excl_tax)
 
 
 class TestDefaultStrategyForParentProductWithOutOfStockVariant(TestCase):
@@ -107,4 +107,4 @@ class TestDefaultStrategyForParentProductWithOutOfStockVariant(TestCase):
         self.assertEqual('unavailable', self.info.availability.code)
 
     def test_specifies_product_has_correct_price(self):
-        self.assertEqual(D('10.00'), self.info.price.incl_tax)
+        self.assertEqual(D('10.00'), self.info.price.get_unit_price().excl_tax)

--- a/tests/unit/core/prices_tests.py
+++ b/tests/unit/core/prices_tests.py
@@ -16,3 +16,11 @@ class TestPriceObject(TestCase):
         price = Price('USD', D('10.00'))
         price.tax = D('2.00')
         self.assertEqual(D('12.00'), price.incl_tax)
+
+    def test_quantizes_amounts(self):
+        price = Price('USD', D('6.004'))
+        self.assertEqual(D('6.00'), price.excl_tax)
+
+    def test_quantizes_as_late_as_possible(self):
+        price = Price('USD', D('6.004'), tax=D('0.004'))
+        self.assertEqual(D('6.01'), price.incl_tax)

--- a/tests/unit/partner/price_tests.py
+++ b/tests/unit/partner/price_tests.py
@@ -8,16 +8,17 @@ from oscar.apps.partner import prices
 class TestUnavailable(TestCase):
 
     def setUp(self):
-        self.price = prices.Unavailable()
+        self.pricing_policy = prices.Unavailable()
+        self.price = self.pricing_policy.get_unit_price()
 
     def test_means_unknown_tax(self):
         self.assertFalse(self.price.is_tax_known)
 
     def test_means_prices_dont_exist(self):
-        self.assertFalse(self.price.exists)
+        self.assertFalse(self.pricing_policy.exists)
         self.assertIsNone(self.price.excl_tax)
 
-    def test_means_tax_cant_be_acccessed(self):
+    def test_means_tax_cant_be_accessed(self):
         self.assertRaises(TaxNotKnown, getattr, self.price, 'incl_tax')
         self.assertRaises(TaxNotKnown, getattr, self.price, 'tax')
 
@@ -25,7 +26,8 @@ class TestUnavailable(TestCase):
 class TestFixedPriceWithoutTax(TestCase):
 
     def setUp(self):
-        self.price = prices.FixedPrice('GBP', D('9.15'))
+        self.pricing_policy = prices.FixedPrice('GBP', D('9.15'))
+        self.price = self.pricing_policy.get_unit_price()
 
     def test_means_unknown_tax(self):
         self.assertFalse(self.price.is_tax_known)

--- a/tests/unit/partner/price_tests.py
+++ b/tests/unit/partner/price_tests.py
@@ -15,11 +15,11 @@ class TestUnavailable(TestCase):
 
     def test_means_prices_dont_exist(self):
         self.assertFalse(self.price.exists)
-
-    def test_means_price_attributes_are_none(self):
-        self.assertIsNone(self.price.incl_tax)
         self.assertIsNone(self.price.excl_tax)
-        self.assertIsNone(self.price.tax)
+
+    def test_means_tax_cant_be_acccessed(self):
+        self.assertRaises(TaxNotKnown, getattr, self.price, 'incl_tax')
+        self.assertRaises(TaxNotKnown, getattr, self.price, 'tax')
 
 
 class TestFixedPriceWithoutTax(TestCase):

--- a/tests/unit/partner/tax_mixin_tests.py
+++ b/tests/unit/partner/tax_mixin_tests.py
@@ -4,6 +4,7 @@ from django.test import TestCase
 import mock
 
 from oscar.apps.partner import strategy
+from oscar.core import prices
 
 
 class TestNoTaxMixin(TestCase):
@@ -19,15 +20,17 @@ class TestNoTaxMixin(TestCase):
             self.product, None)
         self.assertFalse(policy.exists)
 
-    def test_returns_zero_tax(self):
+    def test_doesnt_return_tax(self):
         policy = self.mixin.pricing_policy(
             self.product, self.stockrecord)
-        self.assertEqual(D('0.00'), policy.tax)
+        with self.assertRaises(prices.TaxNotKnown):
+            policy.tax
 
-    def test_doesnt_add_tax_to_net_price(self):
+    def test_doesnt_have_tax_inclusive_price(self):
         policy = self.mixin.pricing_policy(
             self.product, self.stockrecord)
-        self.assertEqual(D('12.00'), policy.incl_tax)
+        with self.assertRaises(prices.TaxNotKnown):
+            policy.incl_tax
 
 
 class TestFixedRateTaxMixin(TestCase):
@@ -48,7 +51,7 @@ class TestFixedRateTaxMixin(TestCase):
         policy = self.mixin.pricing_policy(
             self.product, self.stockrecord)
         self.assertEqual(self.mixin.rate * self.stockrecord.price_excl_tax,
-                          policy.tax)
+                         policy.tax)
 
     def test_adds_tax_to_net_price(self):
         policy = self.mixin.pricing_policy(

--- a/tests/unit/partner/tax_mixin_tests.py
+++ b/tests/unit/partner/tax_mixin_tests.py
@@ -24,13 +24,13 @@ class TestNoTaxMixin(TestCase):
         policy = self.mixin.pricing_policy(
             self.product, self.stockrecord)
         with self.assertRaises(prices.TaxNotKnown):
-            policy.tax
+            policy.get_unit_price().tax
 
     def test_doesnt_have_tax_inclusive_price(self):
         policy = self.mixin.pricing_policy(
             self.product, self.stockrecord)
         with self.assertRaises(prices.TaxNotKnown):
-            policy.incl_tax
+            policy.get_unit_price().incl_tax
 
 
 class TestFixedRateTaxMixin(TestCase):
@@ -51,9 +51,9 @@ class TestFixedRateTaxMixin(TestCase):
         policy = self.mixin.pricing_policy(
             self.product, self.stockrecord)
         self.assertEqual(self.mixin.rate * self.stockrecord.price_excl_tax,
-                         policy.tax)
+                         policy.get_unit_price().tax)
 
     def test_adds_tax_to_net_price(self):
         policy = self.mixin.pricing_policy(
             self.product, self.stockrecord)
-        self.assertEqual(D('13.20'), policy.incl_tax)
+        self.assertEqual(D('13.20'), policy.get_unit_price().incl_tax)


### PR DESCRIPTION
Oscar defaults implementation makes assumption that the price is computed as:

```
line_price = quantity * unit price
```

That is not always a case. For example, you might want to implement bulk prices:
- 1-99 items... unit price of X
- 100-999 items... unit price of Y

This could be easily implemented by adding additional methods to Price object:
- `price_for_quantity(quantity)` (effective one)
- `price_excl_tax_for_quantity(quantity)`
- `price_incl_tax_for_quantity(quantity)`

Default implementation could reflect the current one, so it is backwards compatible.
