### PR TITLE
Fix internal server error in with flash_messages.error(request, msg) call

### DIFF
--- a/oscar/apps/basket/views.py
+++ b/oscar/apps/basket/views.py
@@ -205,7 +205,7 @@ class BasketView(ModelFormSetView):
                 else:
                     msg = _("You can't save an item for later if you're "
                             "not logged in!")
-                    flash_messages.error(self.request, msg)
+                    flash_messages.error(msg)
                     return HttpResponseRedirect(self.get_success_url())
 
         if save_for_later:


### PR DESCRIPTION
Also occurs in 0.7.1

The method signature is `FlashMessages.error(messages)`, no request should be passed.
