### PR TITLE
Simplify basket_form tag implementation

### DIFF
--- a/oscar/templates/oscar/catalogue/partials/add_to_basket_form_compact.html
+++ b/oscar/templates/oscar/catalogue/partials/add_to_basket_form_compact.html
@@ -5,7 +5,7 @@
 {% purchase_info_for_product request product as session %}
 
 {% if session.availability.is_available_to_buy %}
-    {% basket_form request product as basket_form single %}
+    {% basket_form request product 'single' as basket_form %}
     <form action="{% url 'basket:add' %}" method="post">
         {% csrf_token %}
         {{ basket_form.as_p }}

--- a/oscar/templatetags/basket_tags.py
+++ b/oscar/templatetags/basket_tags.py
@@ -12,52 +12,19 @@ register = template.Library()
 QNT_SINGLE, QNT_MULTIPLE = 'single', 'multiple'
 
 
-@register.tag(name="basket_form")
-def do_basket_form(parse, token):
-    """
-    Template tag for adding the add-to-basket form to the
-    template context so it can be rendered.
-    """
-    tokens = token.split_contents()
-    if len(tokens) < 4 or tokens[3] != 'as':
-        raise template.TemplateSyntaxError(
-            "%r tag uses the following syntax: "
-            "{%% basket_form request product_var as "
-            "form_var %%}" % tokens[0])
-
-    request_var, product_var, form_var = tokens[1], tokens[2], tokens[4]
-
-    quantity_type = tokens[5] if len(tokens) == 6 else QNT_MULTIPLE
-    if quantity_type not in (QNT_SINGLE, QNT_MULTIPLE):
-        raise template.TemplateSyntaxError(
-            "%r tag only accepts the following quantity types: "
-            "'single', 'multiple'" % tokens[0])
-    return BasketFormNode(request_var, product_var, form_var, quantity_type)
-
-
-class BasketFormNode(template.Node):
-    def __init__(self, request_var, product_var, form_var, quantity_type):
-        self.request_var = template.Variable(request_var)
-        self.product_var = template.Variable(product_var)
-        self.form_var = form_var
-        self.form_class = (AddToBasketForm if quantity_type == QNT_MULTIPLE
-                           else SimpleAddToBasketForm)
-
-    def render(self, context):
-        try:
-            request = self.request_var.resolve(context)
-            product = self.product_var.resolve(context)
-        except template.VariableDoesNotExist:
-            return ''
-
-        if not isinstance(product, Product):
-            return ''
-
-        initial = {}
-        if not product.is_group:
-            initial['product_id'] = product.id
-        form = self.form_class(
-            request, instance=product, initial=initial)
-
-        context[self.form_var] = form
+@register.assignment_tag()
+def basket_form(request, product, quantity_type='single'):
+    if not isinstance(product, Product):
         return ''
+
+    initial = {}
+    if not product.is_group:
+        initial['product_id'] = product.id
+
+    form_class = AddToBasketForm
+    if quantity_type == QNT_SINGLE:
+        form_class = SimpleAddToBasketForm
+
+    form = form_class(request, instance=product, initial=initial)
+
+    return form

--- a/sites/demo/templates/promotions/partials/productsingle.html
+++ b/sites/demo/templates/promotions/partials/productsingle.html
@@ -28,7 +28,7 @@
                 <a class="btn btn-large" href="{% url 'catalogue:detail' product.slug product.id %}">{% trans "View range" %}</a>
             {% else %}
                 {% if session.availability.is_available_to_buy %}
-                    {% basket_form request product as basket_form single %}
+                    {% basket_form request product 'single' as basket_form %}
                     <form action="{% url 'basket:add' %}" method="post">
                         {% csrf_token %}
                         {{ basket_form.as_p }}


### PR DESCRIPTION
This also changes it's interface to

{% basket_form request product 'single' as basket_form %}

Before it was the weird

{% basket_form request product as basket_form single %}

However in this form the assignment_tag decorator can't be used.

(needs rebasing to current master)
