### PR TITLE
Used get_username() instead of referencing the username attribute

### DIFF
--- a/oscar/apps/customer/abstract_models.py
+++ b/oscar/apps/customer/abstract_models.py
@@ -123,7 +123,7 @@ class AbstractEmail(models.Model):
 
     def __unicode__(self):
         return _("Email to %(user)s with subject '%(subject)s'") % {
-            'user': self.user.username, 'subject': self.subject}
+            'user': self.user.get_username(), 'subject': self.subject}
 
 
 class AbstractCommunicationEventType(models.Model):

--- a/oscar/management/commands/oscar_find_duplicate_emails.py
+++ b/oscar/management/commands/oscar_find_duplicate_emails.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
             for email, __ in duplicates:
                 users = User.objects.filter(email__iexact=email)
                 user_strings = [
-                    "{} (#{})".format(user.username, user.pk)
+                    "{} (#{})".format(user.get_username(), user.pk)
                     for user in users]
                 print("{email} is assigned to: {pk_list}".format(
                     email=email, pk_list=u", ".join(user_strings)))


### PR DESCRIPTION
Since the User model can be swapped out, [this method](https://docs.djangoproject.com/en/1.6/ref/contrib/auth/#django.contrib.auth.models.User.get_username) should be use instead of referencing the username attribute directly.

Unfortunately I have not the time to investigate more but you probably shouldn't assume a `username` in tests e.g.:
- https://github.com/tangentlabs/django-oscar/blob/d30fc8cb0a1d81f59b97c8f4ef2d651629064f6d/oscar/test/testcases.py#L32
- https://github.com/tangentlabs/django-oscar/blob/20df512edac56a97539251c6f5ede9046273255e/tests/_site/myauth/models.py#L25
- https://github.com/tangentlabs/django-oscar/blob/d30fc8cb0a1d81f59b97c8f4ef2d651629064f6d/tests/functional/customer/history_tests.py#L53
