### PR TITLE
Checkout flow refactor

### DIFF
--- a/TODO.branch
+++ b/TODO.branch
@@ -1,0 +1,21 @@
+Changes
+* any checkout step if requested directly will be executed; previously every
+  view checked pre_conditions and if need be redirected elsewhere
+* checkout:index is now always the right entry point to the checkout from
+  everywhere. A request to it either redirects to a checkout sub-task or
+  performs payment and creates the order.
+* checkout:identify-user now handles the task of identifying the user for
+  checkout. Previously this was handled by checkout:index.
+* The payment method view was removed. It just redirected to the next step.
+  Implementors should instead override CheckoutFlow.capture_payment_data().
+
+TODO
+* if payment details are captured, control is not returned to CheckoutFlow for
+  handling the rest of the checkout. Also, it's untested.
+* payment_kwargs are lost after a failed payment (grep TODO)
+* demo site
+* billing address extensibility
+* tests
+* Refactor CheckoutSessionData to have properties with setters instead of the
+  verbose interface using individual methods with asymmetric names for getting
+  and setting values.

--- a/src/oscar/apps/checkout/app.py
+++ b/src/oscar/apps/checkout/app.py
@@ -10,19 +10,23 @@ class CheckoutApplication(Application):
     name = 'checkout'
 
     index_view = get_class('checkout.views', 'IndexView')
+    identify_user_view = get_class('checkout.views', 'IdentifyUserView')
     shipping_address_view = get_class('checkout.views', 'ShippingAddressView')
     user_address_update_view = get_class('checkout.views',
                                          'UserAddressUpdateView')
     user_address_delete_view = get_class('checkout.views',
                                          'UserAddressDeleteView')
     shipping_method_view = get_class('checkout.views', 'ShippingMethodView')
-    payment_method_view = get_class('checkout.views', 'PaymentMethodView')
     payment_details_view = get_class('checkout.views', 'PaymentDetailsView')
     thankyou_view = get_class('checkout.views', 'ThankYouView')
 
     def get_urls(self):
         urls = [
             url(r'^$', self.index_view.as_view(), name='index'),
+
+            # Identify user view
+            url(r'identify-user/$',
+                self.identify_user_view.as_view(), name='identify-user'),
 
             # Shipping/user address views
             url(r'shipping-address/$',
@@ -39,8 +43,6 @@ class CheckoutApplication(Application):
                 self.shipping_method_view.as_view(), name='shipping-method'),
 
             # Payment views
-            url(r'payment-method/$',
-                self.payment_method_view.as_view(), name='payment-method'),
             url(r'payment-details/$',
                 self.payment_details_view.as_view(), name='payment-details'),
 

--- a/src/oscar/apps/checkout/flow.py
+++ b/src/oscar/apps/checkout/flow.py
@@ -1,0 +1,206 @@
+from django.contrib import messages
+from django.shortcuts import redirect
+from django.utils.translation import ugettext as _
+
+from oscar.apps.shipping.methods import NoShippingRequired
+from oscar.core.loading import get_class
+
+from . import signals
+
+OrderPlacementMixin = get_class('checkout.mixins', 'OrderPlacementMixin')
+RedirectRequired = get_class('checkout.mixins', 'RedirectRequired')
+CheckoutFailed = get_class('checkout.mixins', 'CheckoutFailed')
+
+
+class CheckoutFlow(OrderPlacementMixin):
+    def checkout(self):
+        """
+        Manage the checkout flow.
+
+        This mixin doesn't do any of the hard work; instead it delegates to
+        specialized views that are responsible for a certain task.
+
+        This method is the entry point for the checkout process through the
+        `IndexView`. It is also the resumption point for views that perform
+        checkout-related tasks. Such views call this method after performing
+        their work to return control here.
+
+        This method never produces an answer that is not a redirect, so it is
+        ok to call it from a POST request directly instead of redirecting do
+        checkout:index.
+        """
+        try:
+            self.do_checkout()
+        except RedirectRequired as e:
+            return redirect(e.target)
+        except CheckoutFailed as e:
+            return self.checkout_failed()
+
+        return self.checkout_successful()
+
+    def do_checkout(self, *args, **kwargs):
+        """
+        Perform the checkout steps in order. Each step is either complete, then
+        the function just returns. Or it raises RedirectRequired to redirect to
+        a view that implements the step. The steps are:
+
+            1. Identify the user (`identify_user`)
+            2. Send start_checkout signal (`send_start_checkout_signal`)
+            3. Capture shipping information (`capture_shipping_data`)
+            4. Capture payment information (`capture_payment_data`)
+            5. Get final order confirmation (`confirm_order_preview`)
+            6. Finally, conduct payment and place order (`submit_order`)
+
+        The last step can raise CheckoutFailed to initiate a retry.
+        """
+        basket = self.request.basket
+
+        self.check_basket(basket)
+        self.identify_user()
+        self.send_start_checkout_signal()
+
+        shipping_method, shipping_address = self.capture_shipping_data(basket)
+
+        shipping_charge = shipping_method.calculate(basket)
+        self.capture_payment_data(basket, shipping_charge)
+
+        self.confirm_order_preview()
+        self.submit_order()
+
+    def checkout_failed(self):
+        """
+        Also, call this from the result view after a redirect payment.
+        """
+        # try again
+        self.checkout_session.reset_preview_confirmation()
+        return self.checkout()
+
+    def checkout_successful(self):
+        """
+        Also, call this from the result view after a redirect payment.
+        """
+        self.checkout_session.flush()
+        return redirect('checkout:thank-you')
+
+    def check_basket(self, basket):
+        """
+        Check that the basket is ready for submission.
+        """
+        if basket.is_empty:
+            messages.warning(self.request, _(
+                "You need to add some items to your basket to checkout"))
+            raise RedirectRequired('basket:summary')
+
+        if not self.check_basket_available(basket):
+            raise RedirectRequired('basket:summary')
+
+    def identify_user(self):
+        # get guest checkout email or login
+        if not self.request.user.is_authenticated():
+            if not self.checkout_session.get_guest_email():
+                raise RedirectRequired('checkout:identify-user')
+
+    def send_start_checkout_signal(self):
+        if not self.checkout_session.was_start_checkout_signal_sent():
+            if self.checkout_session.get_guest_email():
+                signals.start_checkout.send_robust(
+                    sender=self, request=self.request,
+                    email=self.checkout_session.get_guest_email())
+            else:
+                signals.start_checkout.send_robust(
+                    sender=self, request=self.request)
+
+            self.checkout_session.set_sent_start_checkout_signal()
+
+    def capture_shipping_data(self, basket):
+        # capture shipping method and address
+        if not basket.is_shipping_required():
+            shipping_method = NoShippingRequired()
+            self.checkout_session.use_shipping_method(
+                shipping_method.code)
+            return shipping_method, None
+
+        if not self.checkout_session.is_shipping_address_set():
+            raise RedirectRequired('checkout:shipping-address')
+
+        # Check that the previously chosen shipping address is still valid
+        shipping_address = self.get_shipping_address(basket)
+        if not shipping_address:
+            messages.warning(self.request,
+                             _("Your previously chosen shipping address is no "
+                               "longer valid.  Please choose another one"))
+            raise RedirectRequired('checkout:shipping-address')
+
+        if not self.checkout_session.is_shipping_method_set(basket):
+            methods = self.get_available_shipping_methods(
+                basket, shipping_address)
+
+            if len(methods) == 0:
+                # No shipping methods available for given address
+                messages.warning(self.request, _(
+                    "Shipping is unavailable for your chosen address - "
+                    "please choose another"))
+                raise RedirectRequired('checkout:shipping-address')
+
+            elif len(methods) == 1:
+                # Only one shipping method - use it
+                self.checkout_session.use_shipping_method(methods[0].code)
+
+            else:
+                # Must be more than one available shipping method, we
+                # present them to the user to make a choice.
+                raise RedirectRequired('checkout:shipping-method')
+
+        shipping_method = self.get_shipping_method(basket, shipping_address)
+        if not shipping_method:
+            messages.warning(self.request,
+                             _("Your previously chosen shipping method is no "
+                               "longer valid.  Please choose another one"))
+            raise RedirectRequired('checkout:shipping-method')
+
+        return shipping_method, shipping_address
+
+    def capture_payment_data(self, basket, shipping_charge):
+        total = self.get_order_totals(basket, shipping_charge)
+
+        if total.excl_tax > 0:
+            if not self.check_payment_data_is_captured():
+                raise RedirectRequired('checkout:payment-details')
+
+    def confirm_order_preview(self):
+        if not self.checkout_session.was_preview_confirmed():
+            raise RedirectRequired('checkout:preview')
+
+    def submit_order(self):
+        return self.submit_basket(**self.build_submission())
+
+    # Helpers
+
+    def check_basket_available(self, basket):
+        """
+        Check that the basket is permitted to be submitted as an order. That
+        is, all the basket lines are available to buy - nothing has gone out of
+        stock since it was added to the basket.
+        """
+        can_submit, errors = basket.check_all_lines_available()
+        if can_submit:
+            return True
+
+        for (line, reason) in errors:
+            # Create a more meaningful message to show on the basket page
+            msg = _(
+                "'%(title)s' is no longer available to buy (%(reason)s). "
+                "Please adjust your basket to continue"
+            ) % {
+                'title': line.product.get_title(),
+                'reason': reason}
+            messages.warning(self.request, msg)
+
+        return False
+
+    def check_payment_data_is_captured(self):
+        # We don't collect payment data by default so we don't have anything to
+        # validate here. If your shop requires forms to be submitted on the
+        # payment details page, then override this method to check that the
+        # relevant data is available.
+        return True

--- a/src/oscar/apps/checkout/mixins.py
+++ b/src/oscar/apps/checkout/mixins.py
@@ -1,11 +1,15 @@
 import logging
+import six
 
-from django.http import HttpResponseRedirect
 from django.core.urlresolvers import reverse, NoReverseMatch
+from django.contrib import messages
 from django.contrib.sites.models import Site, get_current_site
 from django.core.exceptions import ObjectDoesNotExist
+from django.utils.translation import ugettext as _
 
-from oscar.core.loading import get_class, get_model
+from oscar.core.loading import get_class, get_classes, get_model
+
+from . import signals
 
 OrderCreator = get_class('order.utils', 'OrderCreator')
 Dispatcher = get_class('customer.utils', 'Dispatcher')
@@ -20,10 +24,23 @@ Basket = get_model('basket', 'Basket')
 CommunicationEventType = get_model('customer', 'CommunicationEventType')
 UnableToPlaceOrder = get_class('order.exceptions', 'UnableToPlaceOrder')
 
+PaymentRedirectRequired, UnableToTakePayment, PaymentError \
+    = get_classes('payment.exceptions', ['RedirectRequired',
+                                         'UnableToTakePayment',
+                                         'PaymentError'])
 post_checkout = get_class('checkout.signals', 'post_checkout')
 
 # Standard logger for checkout events
 logger = logging.getLogger('oscar.checkout')
+
+
+class RedirectRequired(Exception):
+    def __init__(self, target):
+        self.target = target
+
+
+class CheckoutFailed(Exception):
+    pass
 
 
 class OrderPlacementMixin(CheckoutSessionMixin):
@@ -44,8 +61,6 @@ class OrderPlacementMixin(CheckoutSessionMixin):
 
     # Default code for the email to send after successful checkout
     communication_type_code = 'ORDER_PLACED'
-
-    view_signal = post_checkout
 
     # Payment handling methods
     # ------------------------
@@ -86,6 +101,140 @@ class OrderPlacementMixin(CheckoutSessionMixin):
             reference=reference)
         self._payment_events.append(event)
 
+    # Order submission methods
+    # ------------------------
+
+    def submit_basket(self, user, basket, shipping_address, shipping_method,
+                      shipping_charge, billing_address, order_total,
+                      payment_kwargs=None, order_kwargs=None):
+        """
+        Submit a basket for order placement.
+
+        The process runs as follows:
+
+         * Generate an order number
+         * Freeze the basket so it cannot be modified any more (important when
+           redirecting the user to another site for payment as it prevents the
+           basket being manipulated during the payment process).
+         * Attempt to take payment for the order
+           - If payment is successful, place the order
+           - If a redirect is required (eg PayPal, 3DSecure), redirect
+           - If payment is unsuccessful, show an appropriate error message
+
+        :basket: The basket to submit.
+        :payment_kwargs: Additional kwargs to pass to the handle_payment
+        method. It normally makes sense to pass form instances (rather than
+        model instances) so that the forms can be re-rendered correctly if
+        payment fails.
+        :order_kwargs: Additional kwargs to pass to the place_order method
+        """
+        if payment_kwargs is None:
+            payment_kwargs = {}
+        if order_kwargs is None:
+            order_kwargs = {}
+
+        # Taxes must be known at this point
+        assert basket.is_tax_known, (
+            "Basket tax must be set before a user can place an order")
+        assert shipping_charge.is_tax_known, (
+            "Shipping charge tax must be set before a user can place an order")
+
+        # We generate the order number first as this will be used
+        # in payment requests (ie before the order model has been
+        # created).  We also save it in the session for multi-stage
+        # checkouts (eg where we redirect to a 3rd party site and place
+        # the order on a different request).
+        order_number = self.generate_order_number(basket)
+        self.checkout_session.set_order_number(order_number)
+        logger.info("Order #%s: beginning submission process for basket #%d",
+                    order_number, basket.id)
+
+        # Freeze the basket so it cannot be manipulated while the customer is
+        # completing payment on a 3rd party site.  Also, store a reference to
+        # the basket in the session so that we know which basket to thaw if we
+        # get an unsuccessful payment response when redirecting to a 3rd party
+        # site.
+        self.freeze_basket(basket)
+        self.checkout_session.set_submitted_basket(basket)
+
+        # We define a general error message for when an unanticipated payment
+        # error occurs.
+        error_msg = _("A problem occurred while processing payment for this "
+                      "order - no payment has been taken.  Please "
+                      "contact customer services if this problem persists")
+
+        signals.pre_payment.send_robust(sender=self, view=self)
+
+        try:
+            self.handle_payment(order_number, order_total, **payment_kwargs)
+        except PaymentRedirectRequired as e:
+            # Redirect required (eg PayPal, 3DS)
+            logger.info("Order #%s: redirecting to %s", order_number, e.url)
+            raise RedirectRequired(e.url)
+        except UnableToTakePayment as e:
+            # Something went wrong with payment but in an anticipated way.  Eg
+            # their bankcard has expired, wrong card number - that kind of
+            # thing. This type of exception is supposed to set a friendly error
+            # message that makes sense to the customer.
+            msg = six.text_type(e)
+            logger.warning(
+                "Order #%s: unable to take payment (%s) - restoring basket",
+                order_number, msg)
+            self.restore_frozen_basket()
+
+            # We assume that the details submitted on the payment details view
+            # were invalid (eg expired bankcard).
+            # TODO: make it so that payment details are next up
+            messages.error(self.request, msg)
+            # TODO payment_kwargs are lost now
+            raise CheckoutFailed
+        except PaymentError as e:
+            # A general payment error - Something went wrong which wasn't
+            # anticipated.  Eg, the payment gateway is down (it happens), your
+            # credentials are wrong - that king of thing.
+            # It makes sense to configure the checkout logger to
+            # mail admins on an error as this issue warrants some further
+            # investigation.
+            msg = six.text_type(e)
+            logger.error("Order #%s: payment error (%s)", order_number, msg,
+                         exc_info=True)
+            self.restore_frozen_basket()
+            messages.error(self.request, error_msg)
+            # TODO payment_kwargs are lost now
+            raise CheckoutFailed
+        except Exception as e:
+            # Unhandled exception - hopefully, you will only ever see this in
+            # development...
+            logger.error(
+                "Order #%s: unhandled exception while taking payment (%s)",
+                order_number, e, exc_info=True)
+            self.restore_frozen_basket()
+            messages.error(self.request, error_msg)
+            # TODO payment_kwargs are lost now
+            raise CheckoutFailed
+
+        signals.post_payment.send_robust(sender=self, view=self)
+
+        # If all is ok with payment, try and place order
+        logger.info("Order #%s: payment successful, placing order",
+                    order_number)
+        try:
+            self.handle_order_placement(
+                order_number, user, basket, shipping_address, shipping_method,
+                shipping_charge, billing_address, order_total, **order_kwargs)
+        except UnableToPlaceOrder as e:
+            # It's possible that something will go wrong while trying to
+            # actually place an order.  Not a good situation to be in as a
+            # payment transaction may already have taken place, but needs
+            # to be handled gracefully.
+            msg = six.text_type(e)
+            logger.error("Order #%s: unable to place order - %s",
+                         order_number, msg, exc_info=True)
+            self.restore_frozen_basket()
+            messages.error(self.request, msg)
+            # TODO payment_kwargs are lost now
+            raise CheckoutFailed
+
     # Placing order methods
     # ---------------------
 
@@ -112,7 +261,7 @@ class OrderPlacementMixin(CheckoutSessionMixin):
             shipping_charge=shipping_charge, order_total=order_total,
             billing_address=billing_address, **kwargs)
         basket.submit()
-        return self.handle_successful_order(order)
+        self.handle_successful_order(order)
 
     def place_order(self, order_number, user, basket, shipping_address,
                     shipping_method, shipping_charge, order_total,
@@ -238,23 +387,11 @@ class OrderPlacementMixin(CheckoutSessionMixin):
         # Send confirmation message (normally an email)
         self.send_confirmation_message(order, self.communication_type_code)
 
-        # Flush all session data
-        self.checkout_session.flush()
-
         # Save order id in session so thank-you page can load it
         self.request.session['checkout_order_id'] = order.id
 
-        response = HttpResponseRedirect(self.get_success_url())
-        self.send_signal(self.request, response, order)
-        return response
-
-    def send_signal(self, request, response, order):
-        self.view_signal.send(
-            sender=self, order=order, user=request.user,
-            request=request, response=response)
-
-    def get_success_url(self):
-        return reverse('checkout:thank-you')
+        post_checkout.send(sender=self, order=order, user=self.request.user,
+                           request=self.request)
 
     def send_confirmation_message(self, order, code, **kwargs):
         ctx = self.get_message_context(order)

--- a/src/oscar/apps/checkout/utils.py
+++ b/src/oscar/apps/checkout/utils.py
@@ -6,6 +6,28 @@ class CheckoutSessionData(object):
     data persisted until the final order is placed. This class helps store and
     organise checkout form data until it is required to write out the final
     order.
+
+    The data is kept in a nested dictionary as follows:
+
+        checkout:
+            signal_sent: <bool>
+        guest:
+            email: <guest email>
+        shipping:
+            user_address_id: <id of user address to ship to>
+            new_adress_fields: <dict with shipping address data>
+            method_code: <code of shipping method>
+        billing:
+            user_address_id: <id of user address to bill to>
+            new_address_fields: <dict with billing address data>
+            billing_address_same_as_shipping: <bool>
+        payment:
+            method: <payment method code>
+        submission:
+            order_number: <generated order number>
+            basket_id: <id of frozen basket>
+        preview:
+            confirmed: <bool>
     """
     SESSION_KEY = 'checkout_data'
 
@@ -68,6 +90,15 @@ class CheckoutSessionData(object):
 
     def get_guest_email(self):
         return self._get('guest', 'email')
+
+    # start_checkout signal
+    # =====================
+
+    def set_sent_start_checkout_signal(self):
+        self._set('checkout', 'signal_sent', True)
+
+    def was_start_checkout_signal_sent(self):
+        return self._get('checkout', 'signal_sent', False)
 
     # Shipping address
     # ================
@@ -225,6 +256,18 @@ class CheckoutSessionData(object):
 
     def payment_method(self):
         return self._get('payment', 'method')
+
+    # Preview methods
+    # ===============
+
+    def was_preview_confirmed(self):
+        return self._get('preview', 'confirmed', False)
+
+    def reset_preview_confirmation(self):
+        self._set('preview', 'confirmed', False)
+
+    def confirm_preview(self):
+        self._set('preview', 'confirmed', True)
 
     # Submission methods
     # ==================

--- a/src/oscar/apps/checkout/views.py
+++ b/src/oscar/apps/checkout/views.py
@@ -7,12 +7,9 @@ from django.contrib.auth import login
 from django.core.urlresolvers import reverse, reverse_lazy
 from django.utils.http import urlquote
 from django.utils.translation import ugettext as _
-from django.utils import six
 from django.views import generic
 
-from oscar.apps.shipping.methods import NoShippingRequired
 from oscar.core.loading import get_class, get_classes, get_model
-from . import signals
 
 ShippingAddressForm, GatewayForm \
     = get_classes('checkout.forms', ['ShippingAddressForm', 'GatewayForm'])
@@ -24,9 +21,8 @@ RedirectRequired, UnableToTakePayment, PaymentError \
     = get_classes('payment.exceptions', ['RedirectRequired',
                                          'UnableToTakePayment',
                                          'PaymentError'])
-UnableToPlaceOrder = get_class('order.exceptions', 'UnableToPlaceOrder')
-OrderPlacementMixin = get_class('checkout.mixins', 'OrderPlacementMixin')
-CheckoutSessionMixin = get_class('checkout.session', 'CheckoutSessionMixin')
+CheckoutFlow = get_class('checkout.flow', 'CheckoutFlow')
+
 Order = get_model('order', 'Order')
 ShippingAddress = get_model('order', 'ShippingAddress')
 CommunicationEvent = get_model('order', 'CommunicationEvent')
@@ -42,31 +38,26 @@ CommunicationEventType = get_model('customer', 'CommunicationEventType')
 logger = logging.getLogger('oscar.checkout')
 
 
-class IndexView(CheckoutSessionMixin, generic.FormView):
+class IndexView(CheckoutFlow, generic.View):
+    def get(self, request, *args, **kwargs):
+        return self.checkout()
+
+
+class IdentifyUserView(CheckoutFlow, generic.FormView):
     """
-    First page of the checkout.  We prompt user to either sign in, or
+    Identify the user for checkout.  We prompt user to either sign in, or
     to proceed as a guest (where we still collect their email address).
+
+    Checkout responsibilities:
+        * set guest email in checkout session
+        * or login user
+        * or delegate (e.g. to user registration)
     """
     template_name = 'checkout/gateway.html'
     form_class = GatewayForm
-    success_url = reverse_lazy('checkout:shipping-address')
-    pre_conditions = [
-        'check_basket_is_not_empty',
-        'check_basket_is_valid']
-
-    def get(self, request, *args, **kwargs):
-        # We redirect immediately to shipping address stage if the user is
-        # signed in.
-        if request.user.is_authenticated():
-            # We raise a signal to indicate that the user has entered the
-            # checkout process so analytics tools can track this event.
-            signals.start_checkout.send_robust(
-                sender=self, request=request)
-            return self.get_success_response()
-        return super(IndexView, self).get(request, *args, **kwargs)
 
     def get_form_kwargs(self):
-        kwargs = super(IndexView, self).get_form_kwargs()
+        kwargs = super(IdentifyUserView, self).get_form_kwargs()
         email = self.checkout_session.get_guest_email()
         if email:
             kwargs['initial'] = {
@@ -75,38 +66,30 @@ class IndexView(CheckoutSessionMixin, generic.FormView):
         return kwargs
 
     def form_valid(self, form):
-        if form.is_guest_checkout() or form.is_new_account_checkout():
-            email = form.cleaned_data['username']
+        email = form.cleaned_data['username']
+
+        if form.is_guest_checkout():
             self.checkout_session.set_guest_email(email)
 
-            # We raise a signal to indicate that the user has entered the
-            # checkout process by specifying an email address.
-            signals.start_checkout.send_robust(
-                sender=self, request=self.request, email=email)
+        elif form.is_new_account_checkout():
+            # remember guest email if customer decides to abort registration
+            # and checkout as a guest
+            self.checkout_session.set_guest_email(email)
 
-            if form.is_new_account_checkout():
-                messages.info(
-                    self.request,
-                    _("Create your account and then you will be redirected "
-                      "back to the checkout process"))
-                self.success_url = "%s?next=%s&email=%s" % (
-                    reverse('customer:register'),
-                    reverse('checkout:shipping-address'),
-                    urlquote(email)
-                )
+            messages.info(
+                self.request,
+                _("Create your account and then you will be redirected "
+                  "back to the checkout process"))
+            return redirect("%s?next=%s&email=%s" % (
+                reverse('customer:register'),
+                reverse('checkout:index'),
+                urlquote(email)
+            ))
         else:
             user = form.get_user()
             login(self.request, user)
 
-            # We raise a signal to indicate that the user has entered the
-            # checkout process.
-            signals.start_checkout.send_robust(
-                sender=self, request=self.request)
-
-        return redirect(self.get_success_url())
-
-    def get_success_response(self):
-        return redirect(self.get_success_url())
+        return self.checkout()
 
 
 # ================
@@ -114,7 +97,7 @@ class IndexView(CheckoutSessionMixin, generic.FormView):
 # ================
 
 
-class ShippingAddressView(CheckoutSessionMixin, generic.FormView):
+class ShippingAddressView(CheckoutFlow, generic.FormView):
     """
     Determine the shipping address for the order.
 
@@ -127,14 +110,12 @@ class ShippingAddressView(CheckoutSessionMixin, generic.FormView):
     Alternatively, the user can enter a SHIPPING address directly which will be
     saved in the session and later saved as ShippingAddress model when the
     order is successfully submitted.
+
+    Checkout responsibilities:
+        * set shipping address in checkout session
     """
     template_name = 'checkout/shipping_address.html'
     form_class = ShippingAddressForm
-    success_url = reverse_lazy('checkout:shipping-method')
-    pre_conditions = ['check_basket_is_not_empty',
-                      'check_basket_is_valid',
-                      'check_user_email_is_captured']
-    skip_conditions = ['skip_unless_basket_requires_shipping']
 
     def get_initial(self):
         initial = self.checkout_session.new_shipping_address_fields()
@@ -176,7 +157,7 @@ class ShippingAddressView(CheckoutSessionMixin, generic.FormView):
             if action == 'ship_to':
                 # User has selected a previous address to ship to
                 self.checkout_session.ship_to_user_address(address)
-                return redirect(self.get_success_url())
+                return self.checkout()
             else:
                 return http.HttpResponseBadRequest()
         else:
@@ -189,10 +170,10 @@ class ShippingAddressView(CheckoutSessionMixin, generic.FormView):
             (k, v) for (k, v) in form.instance.__dict__.items()
             if not k.startswith('_'))
         self.checkout_session.ship_to_new_address(address_fields)
-        return super(ShippingAddressView, self).form_valid(form)
+        return self.checkout()
 
 
-class UserAddressUpdateView(CheckoutSessionMixin, generic.UpdateView):
+class UserAddressUpdateView(CheckoutFlow, generic.UpdateView):
     """
     Update a user address
     """
@@ -213,7 +194,7 @@ class UserAddressUpdateView(CheckoutSessionMixin, generic.UpdateView):
         return super(UserAddressUpdateView, self).get_success_url()
 
 
-class UserAddressDeleteView(CheckoutSessionMixin, generic.DeleteView):
+class UserAddressDeleteView(CheckoutFlow, generic.DeleteView):
     """
     Delete an address from a user's addressbook.
     """
@@ -233,9 +214,9 @@ class UserAddressDeleteView(CheckoutSessionMixin, generic.DeleteView):
 # ===============
 
 
-class ShippingMethodView(CheckoutSessionMixin, generic.TemplateView):
+class ShippingMethodView(CheckoutFlow, generic.TemplateView):
     """
-    View for allowing a user to choose a shipping method.
+    Determine the shipping method for the order.
 
     Shipping methods are largely domain-specific and so this view
     will commonly need to be subclassed and customised.
@@ -246,124 +227,39 @@ class ShippingMethodView(CheckoutSessionMixin, generic.TemplateView):
     the user can choose the appropriate one.
     """
     template_name = 'checkout/shipping_methods.html'
-    pre_conditions = ['check_basket_is_not_empty',
-                      'check_basket_is_valid',
-                      'check_user_email_is_captured']
-
-    def get(self, request, *args, **kwargs):
-        # These pre-conditions can't easily be factored out into the normal
-        # pre-conditions as they do more than run a test and then raise an
-        # exception on failure.
-
-        # Check that shipping is required at all
-        if not request.basket.is_shipping_required():
-            # No shipping required - we store a special code to indicate so.
-            self.checkout_session.use_shipping_method(
-                NoShippingRequired().code)
-            return self.get_success_response()
-
-        # Check that shipping address has been completed
-        if not self.checkout_session.is_shipping_address_set():
-            messages.error(request, _("Please choose a shipping address"))
-            return redirect('checkout:shipping-address')
-
-        # Save shipping methods as instance var as we need them both here
-        # and when setting the context vars.
-        self._methods = self.get_available_shipping_methods()
-        if len(self._methods) == 0:
-            # No shipping methods available for given address
-            messages.warning(request, _(
-                "Shipping is unavailable for your chosen address - please "
-                "choose another"))
-            return redirect('checkout:shipping-address')
-        elif len(self._methods) == 1:
-            # Only one shipping method - set this and redirect onto the next
-            # step
-            self.checkout_session.use_shipping_method(self._methods[0].code)
-            return self.get_success_response()
-
-        # Must be more than one available shipping method, we present them to
-        # the user to make a choice.
-        return super(ShippingMethodView, self).get(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         kwargs = super(ShippingMethodView, self).get_context_data(**kwargs)
-        kwargs['methods'] = self._methods
+        kwargs['methods'] = self.get_available_shipping_methods(
+            self.request.basket)
         return kwargs
-
-    def get_available_shipping_methods(self):
-        """
-        Returns all applicable shipping method objects for a given basket.
-        """
-        # Shipping methods can depend on the user, the contents of the basket
-        # and the shipping address (so we pass all these things to the
-        # repository).  I haven't come across a scenario that doesn't fit this
-        # system.
-        return Repository().get_shipping_methods(
-            basket=self.request.basket, user=self.request.user,
-            shipping_addr=self.get_shipping_address(self.request.basket),
-            request=self.request)
-
-    def is_valid_shipping_method(self, method_code):
-        for method in self.get_available_shipping_methods():
-            if method.code == method_code:
-                return True
-        return False
 
     def post(self, request, *args, **kwargs):
         # Need to check that this code is valid for this user
         method_code = request.POST.get('method_code', None)
-        if not self.is_valid_shipping_method(method_code):
+        if not self.is_valid_shipping_method(self.request.basket, method_code):
             messages.error(request, _("Your submitted shipping method is not"
                                       " permitted"))
-            return redirect('checkout:shipping-method')
+        else:
+            # Save the code for the chosen shipping method in the session and
+            # continue to the next step.
+            self.checkout_session.use_shipping_method(method_code)
 
-        # Save the code for the chosen shipping method in the session
-        # and continue to the next step.
-        self.checkout_session.use_shipping_method(method_code)
+        return self.checkout()
 
-        return self.get_success_response()
-
-    def get_success_response(self):
-        return redirect('checkout:payment-method')
-
-
-# ==============
-# Payment method
-# ==============
-
-
-class PaymentMethodView(CheckoutSessionMixin, generic.TemplateView):
-    """
-    View for a user to choose which payment method(s) they want to use.
-
-    This would include setting allocations if payment is to be split
-    between multiple sources. It's not the place for entering sensitive details
-    like bankcard numbers though - that belongs on the payment details view.
-    """
-    pre_conditions = [
-        'check_basket_is_not_empty',
-        'check_basket_is_valid',
-        'check_user_email_is_captured',
-        'check_shipping_data_is_captured']
-    skip_conditions = ['skip_unless_payment_is_required']
-
-    def get(self, request, *args, **kwargs):
-        # By default we redirect straight onto the payment details view. Shops
-        # that require a choice of payment method may want to override this
-        # method to implement their specific logic.
-        return self.get_success_response()
-
-    def get_success_response(self):
-        return redirect('checkout:payment-details')
+    def is_valid_shipping_method(self, basket, method_code,
+                                 shipping_address=None):
+        for method in self.get_available_shipping_methods(basket):
+            if method.code == method_code:
+                return True
+        return False
 
 
 # ================
 # Order submission
 # ================
 
-
-class PaymentDetailsView(OrderPlacementMixin, generic.TemplateView):
+class PaymentDetailsView(CheckoutFlow, generic.TemplateView):
     """
     For taking the details of payment and creating the order.
 
@@ -398,30 +294,9 @@ class PaymentDetailsView(OrderPlacementMixin, generic.TemplateView):
     template_name = 'checkout/payment_details.html'
     template_name_preview = 'checkout/preview.html'
 
-    # These conditions are extended at runtime depending on whether we are in
-    # 'preview' mode or not.
-    pre_conditions = [
-        'check_basket_is_not_empty',
-        'check_basket_is_valid',
-        'check_user_email_is_captured',
-        'check_shipping_data_is_captured']
-
     # If preview=True, then we render a preview template that shows all order
     # details ready for submission.
     preview = False
-
-    def get_pre_conditions(self, request):
-        if self.preview:
-            # The preview view needs to ensure payment information has been
-            # correctly captured.
-            return self.pre_conditions + ['check_payment_data_is_captured']
-        return super(PaymentDetailsView, self).get_pre_conditions(request)
-
-    def get_skip_conditions(self, request):
-        if not self.preview:
-            # Payment details should only be collected if necessary
-            return ['skip_unless_payment_is_required']
-        return super(PaymentDetailsView, self).get_skip_conditions(request)
 
     def post(self, request, *args, **kwargs):
         # Posting to payment-details isn't the right thing to do.  Form
@@ -435,6 +310,7 @@ class PaymentDetailsView(OrderPlacementMixin, generic.TemplateView):
         # this case, the form needs validating and the order preview shown.
         if request.POST.get('action', '') == 'place_order':
             return self.handle_place_order_submission(request)
+
         return self.handle_payment_details_submission(request)
 
     def handle_place_order_submission(self, request):
@@ -450,7 +326,8 @@ class PaymentDetailsView(OrderPlacementMixin, generic.TemplateView):
         override this method to ensure they are valid before extracting their
         data into the submission dict and passing it onto `submit`.
         """
-        return self.submit(**self.build_submission())
+        self.checkout_session.confirm_preview()
+        return self.checkout()
 
     def handle_payment_details_submission(self, request):
         """
@@ -510,132 +387,6 @@ class PaymentDetailsView(OrderPlacementMixin, generic.TemplateView):
             return self.request.user.addresses.get(is_default_for_billing=True)
         except UserAddress.DoesNotExist:
             return None
-
-    def submit(self, user, basket, shipping_address, shipping_method,  # noqa (too complex (10))
-               shipping_charge, billing_address, order_total,
-               payment_kwargs=None, order_kwargs=None):
-        """
-        Submit a basket for order placement.
-
-        The process runs as follows:
-
-         * Generate an order number
-         * Freeze the basket so it cannot be modified any more (important when
-           redirecting the user to another site for payment as it prevents the
-           basket being manipulated during the payment process).
-         * Attempt to take payment for the order
-           - If payment is successful, place the order
-           - If a redirect is required (eg PayPal, 3DSecure), redirect
-           - If payment is unsuccessful, show an appropriate error message
-
-        :basket: The basket to submit.
-        :payment_kwargs: Additional kwargs to pass to the handle_payment
-                         method. It normally makes sense to pass form
-                         instances (rather than model instances) so that the
-                         forms can be re-rendered correctly if payment fails.
-        :order_kwargs: Additional kwargs to pass to the place_order method
-        """
-        if payment_kwargs is None:
-            payment_kwargs = {}
-        if order_kwargs is None:
-            order_kwargs = {}
-
-        # Taxes must be known at this point
-        assert basket.is_tax_known, (
-            "Basket tax must be set before a user can place an order")
-        assert shipping_charge.is_tax_known, (
-            "Shipping charge tax must be set before a user can place an order")
-
-        # We generate the order number first as this will be used
-        # in payment requests (ie before the order model has been
-        # created).  We also save it in the session for multi-stage
-        # checkouts (eg where we redirect to a 3rd party site and place
-        # the order on a different request).
-        order_number = self.generate_order_number(basket)
-        self.checkout_session.set_order_number(order_number)
-        logger.info("Order #%s: beginning submission process for basket #%d",
-                    order_number, basket.id)
-
-        # Freeze the basket so it cannot be manipulated while the customer is
-        # completing payment on a 3rd party site.  Also, store a reference to
-        # the basket in the session so that we know which basket to thaw if we
-        # get an unsuccessful payment response when redirecting to a 3rd party
-        # site.
-        self.freeze_basket(basket)
-        self.checkout_session.set_submitted_basket(basket)
-
-        # We define a general error message for when an unanticipated payment
-        # error occurs.
-        error_msg = _("A problem occurred while processing payment for this "
-                      "order - no payment has been taken.  Please "
-                      "contact customer services if this problem persists")
-
-        signals.pre_payment.send_robust(sender=self, view=self)
-
-        try:
-            self.handle_payment(order_number, order_total, **payment_kwargs)
-        except RedirectRequired as e:
-            # Redirect required (eg PayPal, 3DS)
-            logger.info("Order #%s: redirecting to %s", order_number, e.url)
-            return http.HttpResponseRedirect(e.url)
-        except UnableToTakePayment as e:
-            # Something went wrong with payment but in an anticipated way.  Eg
-            # their bankcard has expired, wrong card number - that kind of
-            # thing. This type of exception is supposed to set a friendly error
-            # message that makes sense to the customer.
-            msg = six.text_type(e)
-            logger.warning(
-                "Order #%s: unable to take payment (%s) - restoring basket",
-                order_number, msg)
-            self.restore_frozen_basket()
-
-            # We assume that the details submitted on the payment details view
-            # were invalid (eg expired bankcard).
-            return self.render_payment_details(
-                self.request, error=msg, **payment_kwargs)
-        except PaymentError as e:
-            # A general payment error - Something went wrong which wasn't
-            # anticipated.  Eg, the payment gateway is down (it happens), your
-            # credentials are wrong - that king of thing.
-            # It makes sense to configure the checkout logger to
-            # mail admins on an error as this issue warrants some further
-            # investigation.
-            msg = six.text_type(e)
-            logger.error("Order #%s: payment error (%s)", order_number, msg,
-                         exc_info=True)
-            self.restore_frozen_basket()
-            return self.render_preview(
-                self.request, error=error_msg, **payment_kwargs)
-        except Exception as e:
-            # Unhandled exception - hopefully, you will only ever see this in
-            # development...
-            logger.error(
-                "Order #%s: unhandled exception while taking payment (%s)",
-                order_number, e, exc_info=True)
-            self.restore_frozen_basket()
-            return self.render_preview(
-                self.request, error=error_msg, **payment_kwargs)
-
-        signals.post_payment.send_robust(sender=self, view=self)
-
-        # If all is ok with payment, try and place order
-        logger.info("Order #%s: payment successful, placing order",
-                    order_number)
-        try:
-            return self.handle_order_placement(
-                order_number, user, basket, shipping_address, shipping_method,
-                shipping_charge, billing_address, order_total, **order_kwargs)
-        except UnableToPlaceOrder as e:
-            # It's possible that something will go wrong while trying to
-            # actually place an order.  Not a good situation to be in as a
-            # payment transaction may already have taken place, but needs
-            # to be handled gracefully.
-            msg = six.text_type(e)
-            logger.error("Order #%s: unable to place order - %s",
-                         order_number, msg, exc_info=True)
-            self.restore_frozen_basket()
-            return self.render_preview(
-                self.request, error=msg, **payment_kwargs)
 
     def get_template_names(self):
         return [self.template_name_preview] if self.preview else [


### PR DESCRIPTION
Our oscar implementation sells only non-corporal products (=no shipping), customers buy only one product at a time (=no basket with several products in different quantities) and there's only one payment method (=no payment method selection or data input). Currently when a customer buys a product, she has to click "continue" a number of times for no good reason (for our use case) and some automatic redirects for shipping shipping method and address and the like are also involved. I'd like to streamline this so that the process is shorter:

1. product-detail: click "buy"
2. basket: can add voucher; click "pay"
3. redirect to payment provider

That'll probably involve separating the checkout steps from the checkout views. I'm working on that right now.