### PR TITLE
Update docs to include all shipping methods, fix typo on config shipping page

### DIFF
--- a/docs/source/howto/how_to_configure_shipping.rst
+++ b/docs/source/howto/how_to_configure_shipping.rst
@@ -85,7 +85,7 @@ For more complex logic, override the ``get_available_shipping_methods`` method:
                self, basket, user=None, shipping_addr=None, 
                request=None, **kwargs):
            methods = (methods.Standard())
-           if shipping_addr and shipping.addr.country.code == 'GB':
+           if shipping_addr and shipping_addr.country.code == 'GB':
                # Express is only available in the UK
                methods = (methods.Standard(), methods.Express())
            return methods

--- a/oscar/apps/shipping/methods.py
+++ b/oscar/apps/shipping/methods.py
@@ -44,6 +44,9 @@ class Base(object):
 
 
 class Free(Base):
+    """
+    This shipping method specifies that shipping is free.
+    """
     code = 'free-shipping'
     name = _('Free shipping')
 
@@ -65,6 +68,10 @@ class NoShippingRequired(Free):
 
 
 class FixedPrice(Base):
+    """
+    This shipping method indicates that shipping costs a fixed price and
+    requires no special calculation.
+    """
     code = 'fixed-price-shipping'
     name = _('Fixed price shipping')
 
@@ -88,8 +95,8 @@ class FixedPrice(Base):
 
 class OfferDiscount(Base):
     """
-    Wrapper class that applies a discount to an existing shipping method's
-    charges
+    Wrapper class that applies a discount to an existing shipping 
+    method's charges.
     """
     is_discounted = True
 
@@ -120,6 +127,9 @@ class OfferDiscount(Base):
 
 
 class TaxExclusiveOfferDiscount(OfferDiscount):
+    """
+    Wrapper class which extends OfferDiscount to be exclusive of tax.
+    """
 
     def calculate(self, basket):
         base_charge = self.method.calculate(basket)
@@ -135,6 +145,9 @@ class TaxExclusiveOfferDiscount(OfferDiscount):
 
 
 class TaxInclusiveOfferDiscount(OfferDiscount):
+    """
+    Wrapper class which extends OfferDiscount to be inclusive of tax.
+    """
 
     def calculate(self, basket):
         base_charge = self.method.calculate(basket)


### PR DESCRIPTION
Add docstrings to the following classes in 'oscar.apps.shipping.methods':
- Free
- FixedPrice
- TaxExclusiveOfferDiscount
- TaxInclusiveOfferDiscount

Fix typo in 'docs/source/howto/how_to_configure_shipping.rst':
- Change 'shipping.addr' to 'shipping_addr'
