### PR TITLE
max recursion depth reached when creating offer with condition range but no condition type

### DIFF
--- a/oscar/apps/offer/models.py
+++ b/oscar/apps/offer/models.py
@@ -413,6 +413,10 @@ class ConditionalOffer(models.Model):
 
 @python_2_unicode_compatible
 class Condition(models.Model):
+    """
+    A condition for an offer to be applied. You can either specify a custom
+    proxy class, or need to specify a type, range and value.
+    """
     COUNT, VALUE, COVERAGE = ("Count", "Value", "Coverage")
     TYPE_CHOICES = (
         (COUNT, _("Depends on number of items in basket that are in "
@@ -454,7 +458,7 @@ class Condition(models.Model):
             self.COVERAGE: CoverageCondition}
         if self.type in klassmap:
             return klassmap[self.type](**field_dict)
-        return self
+        raise RuntimeError("Unrecognised condition type (%s)" % self.type)
 
     def __str__(self):
         return self.proxy().name


### PR DESCRIPTION
The reason is that `Condition.description` is called on a non-proxy object, which then tries to resolve to the proxy using `proxy()` which falls back to `self`. Then `description` is called on `self` again, completing the circle.

This can be recreated in the admin. The incomplete conditional offer stays in the session until the user logs out and back in again.

Oscar 0.7
