### PR TITLE
Pass correct format to JS widget

### DIFF
--- a/oscar/apps/dashboard/offers/forms.py
+++ b/oscar/apps/dashboard/offers/forms.py
@@ -29,8 +29,7 @@ class RestrictionsForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super(RestrictionsForm, self).__init__(*args, **kwargs)
         today = datetime.date.today()
-        self.fields['start_datetime'].initial = today.strftime(
-            self.fields['start_datetime'].widget.format)
+        self.fields['start_datetime'].initial = today
 
     class Meta:
         model = ConditionalOffer

--- a/oscar/forms/widgets.py
+++ b/oscar/forms/widgets.py
@@ -9,6 +9,7 @@ from django.forms.util import flatatt
 from django.forms.widgets import FileInput
 from django.template import Context
 from django.template.loader import render_to_string
+from django.utils import formats
 from django.utils.encoding import force_text
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
@@ -61,15 +62,15 @@ class WYSIWYGTextArea(forms.Textarea):
 
 def datetime_format_to_js_date_format(format):
     """
-    Convert a Python datetime format to a date format suitable for use with JS
-    date pickers
+    Convert a Python datetime format to a date format suitable for use with
+    the JS date picker we use.
     """
+    format = format.split()[0]
     converted = format
     replacements = {
         '%Y': 'yy',
         '%m': 'mm',
         '%d': 'dd',
-        '%H:%M': '',
     }
     for search, replace in six.iteritems(replacements):
         converted = converted.replace(search, replace)
@@ -78,59 +79,87 @@ def datetime_format_to_js_date_format(format):
 
 def datetime_format_to_js_time_format(format):
     """
-    Convert a Python datetime format to a time format suitable for use with JS
-    date pickers
+    Convert a Python datetime format to a time format suitable for use with the
+    JS time picker we use.
     """
+    try:
+        format = format.split()[1]
+    except IndexError:
+        pass
     converted = format
     replacements = {
-        '%Y': '',
-        '%m': '',
-        '%d': '',
         '%H': 'HH',
         '%M': 'mm',
+        '%S': 'ss',
     }
     for search, replace in six.iteritems(replacements):
         converted = converted.replace(search, replace)
-
-    converted = re.sub('[-/][^%]', '', converted)
-
     return converted.strip()
-
-
-def add_js_formats(widget):
-    """
-    Set data attributes for date and time format on a widget
-    """
-    attrs = {
-        'data-dateFormat': datetime_format_to_js_date_format(
-            widget.format),
-        'data-timeFormat': datetime_format_to_js_time_format(
-            widget.format)
-    }
-    widget.attrs.update(attrs)
 
 
 class DatePickerInput(forms.DateInput):
     """
-    DatePicker input that uses the jQuery UI datepicker.  Data attributes are
-    used to pass the date format to the JS
+    A widget that passes the date format to the JS date picker in a data
+    attribute.
     """
-    def __init__(self, *args, **kwargs):
-        super(DatePickerInput, self).__init__(*args, **kwargs)
-        add_js_formats(self)
+    def render(self, name, value, attrs=None):
+        if attrs is None:
+            attrs = {}
+
+        format = self.format
+        if hasattr(self, 'manual_format'):
+            # For django <= 1.6.5, see https://code.djangoproject.com/ticket/21173
+            if self.is_localized and not self.manual_format:
+                format = force_text(formats.get_format('DATE_INPUT_FORMATS')[0])
+        else:
+            # For django >= 1.7
+            format = format or formats.get_format(self.format_key)[0]
+
+        attrs.update({
+            'data-dateFormat': datetime_format_to_js_date_format(format)
+        })
+
+        return super(DatePickerInput, self).render(name, value, attrs)
 
 
 class DateTimePickerInput(forms.DateTimeInput):
-    # Build a widget which uses the locale datetime format but without seconds.
-    # We also use data attributes to pass these formats to the JS datepicker.
+    """
+    A widget that passes the datetime format to the JS datetime picker in a
+    data attribute.
 
+    It also removes seconds by default. However this only works with widgets
+    without localize=True.
+
+    For localized widgets refer to
+    https://docs.djangoproject.com/en/1.6/topics/i18n/formatting/#creating-custom-format-files # noqa
+    instead to override the format.
+    """
     def __init__(self, *args, **kwargs):
         include_seconds = kwargs.pop('include_seconds', False)
         super(DateTimePickerInput, self).__init__(*args, **kwargs)
 
-        if not include_seconds:
+        if not include_seconds and self.format:
             self.format = re.sub(':?%S', '', self.format)
-        add_js_formats(self)
+
+    def render(self, name, value, attrs=None):
+        if attrs is None:
+            attrs = {}
+
+        format = self.format
+        if hasattr(self, 'manual_format'):
+            # For django <= 1.6.5, see https://code.djangoproject.com/ticket/21173
+            if self.is_localized and not self.manual_format:
+                format = force_text(formats.get_format('DATETIME_INPUT_FORMATS')[0])
+        else:
+            # For django >= 1.7
+            format = format or formats.get_format(self.format_key)[0]
+
+        attrs.update({
+            'data-dateFormat': datetime_format_to_js_date_format(format),
+            'data-timeFormat': datetime_format_to_js_time_format(format)
+        })
+
+        return super(DateTimePickerInput, self).render(name, value, attrs)
 
 
 class AdvancedSelect(forms.Select):

--- a/tests/unit/forms/widget_tests.py
+++ b/tests/unit/forms/widget_tests.py
@@ -24,9 +24,8 @@ def compare_time_format(format, expected):
 
 def test_datetime_to_time_format_conversion():
     format_testcases = (
-        ('%Y-%m-%d', ''),
         ('%Y-%m-%d %H:%M', 'HH:mm'),
-        ('%d/%m/%Y', ''),
+        ('%H:%M', 'HH:mm'),
     )
     for format, expected in format_testcases:
         yield compare_time_format, format, expected


### PR DESCRIPTION
This fixes two issues:

1) The code didn't take into account that self.format will be ignored by
   Django if `USE_L10N=True`, unless a format was specified when constructing
   the Widget. Remedied by moving the code to `render()` because the current
   language is determined at request time, not at object construction time,
   and looking up the format in the same way that `django.forms.widgets.DateTimeInput` does it in its `_format_value()` method.

2) The code couldn't handle date formats that include dots, like
   31.12.2014.

Fixes #1440.
