### PR TITLE
Fix small typo in `login_forbidden.html`.

### DIFF
--- a/oscar/templates/oscar/login_forbidden.html
+++ b/oscar/templates/oscar/login_forbidden.html
@@ -1,6 +1,6 @@
 {% extends "403.html" %}
 {% load i18n %}
 
-{% block explanation %}
+{% block error_message %}
 <p>{% trans "This page is only available to users who aren't logged in." %}</p>
 {% endblock %}


### PR DESCRIPTION
The block "error_message" was erroneously referred to as "explanation". As a result, the `login_forbidden.html` template displayed the generic 403 error message.
