### PR TITLE
Avoid excess unoptimizable queries within property

### DIFF
--- a/oscar/apps/order/abstract_models.py
+++ b/oscar/apps/order/abstract_models.py
@@ -631,7 +631,22 @@ class AbstractLine(models.Model):
         for event in self.shipping_events.all():
             event_type = event.event_type
             event_name = event_type.name
-            event_quantity = event.line_quantities.get(line=self).quantity
+            event_quantities = []
+
+            for line_quantity in event.line_quantities.all():
+                if line_quantity.line == self:
+                    event_quantities.append(line_quantity)
+
+            if len(event_quantities) > 1:
+                raise ValueError(
+                    _(
+                        'More than one line_quantity found matching '
+                        'line with pk of '
+                    ) + str(self.pk)
+                )
+
+            event_quantity = event_quantities[0]
+
             if event_name in status_map:
                 status_map[event_name]['quantity'] += event_quantity
             else:


### PR DESCRIPTION
Iterating objects manually here avoids an excess query that developers can't optimize out of the method. This is an example that was noted in https://github.com/tangentlabs/django-oscar/issues/1467
- [x] Implement initial prototype
- [x] Receive feedback
- [x] Production implementation considering provided feedback
- [x] Ensure that tests are not broken
