### PR TITLE
Switched mimetype to content_type because of deprecation

### DIFF
--- a/oscar/views/generic.py
+++ b/oscar/views/generic.py
@@ -145,7 +145,7 @@ class ObjectLookupView(View):
         return HttpResponse(json.dumps({
             'results': [self.format_object(obj) for obj in qs],
             'more': more,
-        }), mimetype='application/json')
+        }), content_type='application/json')
 
 
 class PhoneNumberMixin(object):


### PR DESCRIPTION
The mimetype keyword was deprecated in Django 1.5,
https://docs.djangoproject.com/en/1.5/ref/request-response/#django.http.HttpResponse.__init__

The content_type keyword should be used instead.
