### PR TITLE
Use the django 1.7 final release in Tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,14 +28,14 @@ deps = -r{toxinidir}/requirements.txt
 [testenv:py27-1.7]
 basepython = python2.7
 deps = -r{toxinidir}/requirements_py2.txt
-       https://www.djangoproject.com/download/1.7c3/tarball/
+       https://www.djangoproject.com/download/1.7/tarball/
 
 [testenv:py33-1.7]
 basepython = python3.3
 deps = -r{toxinidir}/requirements.txt
-       https://www.djangoproject.com/download/1.7c3/tarball/
+       https://www.djangoproject.com/download/1.7/tarball/
 
 [testenv:py34-1.7]
 basepython = python3.4
 deps = -r{toxinidir}/requirements.txt
-       https://www.djangoproject.com/download/1.7c3/tarball/
+       https://www.djangoproject.com/download/1.7/tarball/


### PR DESCRIPTION
Django 1.7 is now released, so changed tox to download the final instead of the rc
