### PR TITLE
Add title to "sort_by"-field in search-form, and make it translatable

### DIFF
--- a/oscar/apps/search/forms.py
+++ b/oscar/apps/search/forms.py
@@ -76,7 +76,7 @@ class SearchForm(FacetedSearchForm):
         SORT_BY_MAP[TITLE_A_TO_Z] = 'title'
         SORT_BY_MAP[TITLE_Z_TO_A] = '-title'
 
-    sort_by = forms.ChoiceField(
+    sort_by = forms.ChoiceField( label=_("Sort by"),
         choices=SORT_BY_CHOICES, widget=forms.Select(), required=False)
 
     @property


### PR DESCRIPTION
It's currently not possible to translate the "sort by"-lable on the search-page, since this label is generated by django. Add a label so that we can translate it.
