### PR TITLE
Fix currency default value to play nice with django1.7 migrations

### DIFF
--- a/oscar/apps/basket/abstract_models.py
+++ b/oscar/apps/basket/abstract_models.py
@@ -11,6 +11,7 @@ from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 
 from oscar.apps.basket.managers import OpenBasketManager, SavedBasketManager
 from oscar.apps.offer import results
+from oscar.core.utils import get_default_currency
 from oscar.core.compat import AUTH_USER_MODEL
 from oscar.templatetags.currency_filters import currency
 
@@ -569,7 +570,7 @@ class AbstractLine(models.Model):
     # the basket.  This allows us to tell if a product has changed price since
     # a person first added it to their basket.
     price_currency = models.CharField(
-        _("Currency"), max_length=12, default=settings.OSCAR_DEFAULT_CURRENCY)
+        _("Currency"), max_length=12, default=get_default_currency)
     price_excl_tax = models.DecimalField(
         _('Price excl. Tax'), decimal_places=2, max_digits=12,
         null=True)

--- a/oscar/apps/basket/migrations/0004_auto_20141007_2032.py
+++ b/oscar/apps/basket/migrations/0004_auto_20141007_2032.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import oscar.core.utils
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('basket', '0003_basket_vouchers'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='line',
+            name='price_currency',
+            field=models.CharField(default=oscar.core.utils.get_default_currency, max_length=12, verbose_name='Currency'),
+        ),
+    ]

--- a/oscar/apps/order/abstract_models.py
+++ b/oscar/apps/order/abstract_models.py
@@ -10,6 +10,7 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _, pgettext_lazy
 from django.utils.datastructures import SortedDict
 
+from oscar.core.utils import get_default_currency
 from oscar.core.compat import AUTH_USER_MODEL
 from oscar.models.fields import AutoSlugField
 from . import exceptions
@@ -48,7 +49,7 @@ class AbstractOrder(models.Model):
     # prices of the associated lines, but in some circumstances extra
     # order-level charges are added and so we need to store it separately
     currency = models.CharField(
-        _("Currency"), max_length=12, default=settings.OSCAR_DEFAULT_CURRENCY)
+        _("Currency"), max_length=12, default=get_default_currency)
     total_incl_tax = models.DecimalField(
         _("Order total (inc. tax)"), decimal_places=2, max_digits=12)
     total_excl_tax = models.DecimalField(

--- a/oscar/apps/order/migrations/0002_auto_20141007_2032.py
+++ b/oscar/apps/order/migrations/0002_auto_20141007_2032.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import oscar.core.utils
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('order', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='order',
+            name='currency',
+            field=models.CharField(default=oscar.core.utils.get_default_currency, max_length=12, verbose_name='Currency'),
+        ),
+    ]

--- a/oscar/apps/partner/abstract_models.py
+++ b/oscar/apps/partner/abstract_models.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _, pgettext_lazy
 
+from oscar.core.utils import get_default_currency
 from oscar.core.compat import AUTH_USER_MODEL
 from oscar.models.fields import AutoSlugField
 from oscar.apps.partner.exceptions import InvalidStockAdjustment
@@ -100,7 +101,7 @@ class AbstractStockRecord(models.Model):
 
     # Price info:
     price_currency = models.CharField(
-        _("Currency"), max_length=12, default=settings.OSCAR_DEFAULT_CURRENCY)
+        _("Currency"), max_length=12, default=get_default_currency)
 
     # This is the base price for calculations - tax should be applied by the
     # appropriate method.  We don't store tax here as its calculation is highly

--- a/oscar/apps/partner/migrations/0002_auto_20141007_2032.py
+++ b/oscar/apps/partner/migrations/0002_auto_20141007_2032.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import oscar.core.utils
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('partner', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='stockrecord',
+            name='price_currency',
+            field=models.CharField(default=oscar.core.utils.get_default_currency, max_length=12, verbose_name='Currency'),
+        ),
+    ]

--- a/oscar/apps/payment/abstract_models.py
+++ b/oscar/apps/payment/abstract_models.py
@@ -5,6 +5,7 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
 
+from oscar.core.utils import get_default_currency
 from oscar.core.compat import AUTH_USER_MODEL
 from oscar.templatetags.currency_filters import currency
 from oscar.models.fields import AutoSlugField
@@ -73,7 +74,7 @@ class AbstractSource(models.Model):
         'payment.SourceType', verbose_name=_("Source Type"),
         related_name="sources")
     currency = models.CharField(
-        _("Currency"), max_length=12, default=settings.OSCAR_DEFAULT_CURRENCY)
+        _("Currency"), max_length=12, default=get_default_currency)
 
     # Track the various amounts associated with this source
     amount_allocated = models.DecimalField(

--- a/oscar/apps/payment/migrations/0002_auto_20141007_2032.py
+++ b/oscar/apps/payment/migrations/0002_auto_20141007_2032.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import oscar.core.utils
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('payment', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='source',
+            name='currency',
+            field=models.CharField(default=oscar.core.utils.get_default_currency, max_length=12, verbose_name='Currency'),
+        ),
+    ]

--- a/oscar/core/utils.py
+++ b/oscar/core/utils.py
@@ -112,3 +112,12 @@ def redirect_to_referrer(meta, default):
     URL; to the default URL otherwise.
     """
     return redirect(safe_referrer(meta, default))
+
+
+def get_default_currency():
+    """
+    For use as the default value for currency fields.  Use of this function
+    prevents Django's core migration engine from interpreting a change to
+    OSCAR_DEFAULT_CURRENCY as something it needs to generate a migration for.
+    """
+    return settings.OSCAR_DEFAULT_CURRENCY


### PR DESCRIPTION
### What is the problem / feature ?

When running oscar on Django 1.7 in an application where you have modified `OSCAR_DEFAULT_CURRENCY` the new migration engine detects the change as something it needs to generate a migration for.
### How did it get fixed / implemented ?

Changed the default value to be a function instead.  This prevents the migration engine from interpreting a settings change as something it needs to generate a migration for.
### How can someone test / see it ?

Change the `OSCAR_DEFAULT_CURRENCY` setting, run `makemigrations` and see that no new migrations are generated.

_Here is a cute animal picture for your troubles..._

![tumblr_kxwxn9h8od1qa6c5so1_500](https://cloud.githubusercontent.com/assets/824194/4549944/542942b8-4e62-11e4-8b16-bf6ef2248e21.jpg)
