### PR TITLE
Update phonenumber dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(name='django-oscar',
           # For manipulating search URLs
           'purl>=0.7',
           # For phone number field
-          'phonenumbers>=5.9.2,<=6.0.0a',
+          'phonenumbers>=6.3.0,<7.0.0',
           # Used for oscar.test.contextmanagers.mock_signal_receiver
           'mock>=1.0.1,<1.1',
           # Used for oscar.test.newfactories


### PR DESCRIPTION
This is to avoid https://github.com/nvie/pip-tools/issues/50 so that
pip-compile (from pip-tools' future branch) can be used to pin
dependencies. See also http://nvie.com/posts/better-package-management/.
