### PR TITLE
Dashboard navigation is not easily extendable

### DIFF
--- a/oscar/apps/dashboard/menu.py
+++ b/oscar/apps/dashboard/menu.py
@@ -29,7 +29,7 @@ def create_menu(menu_items, parent=None):
     nodes = []
     default_fn = import_string(
         settings.OSCAR_DASHBOARD_DEFAULT_ACCESS_FUNCTION)
-    for menu_dict in menu_items:
+    for key, menu_dict in menu_items.items():
         try:
             label = menu_dict['label']
         except KeyError:

--- a/oscar/apps/dashboard/nav.py
+++ b/oscar/apps/dashboard/nav.py
@@ -12,7 +12,7 @@ class Node(object):
     """
 
     def __init__(self, label, url_name=None, url_args=None, url_kwargs=None,
-                 access_fn=None, icon=None):
+                 access_fn=None, icon=None, order=None):
         self.label = label
         self.icon = icon
         self.url_name = url_name
@@ -20,6 +20,7 @@ class Node(object):
         self.url_kwargs = url_kwargs
         self.access_fn = access_fn
         self.children = []
+        self.order = order
 
     @property
     def is_heading(self):
@@ -32,6 +33,7 @@ class Node(object):
 
     def add_child(self, node):
         self.children.append(node)
+        self.children.sort(key=lambda node: node.order)
 
     def is_visible(self, user):
         return self.access_fn is None or self.access_fn(

--- a/oscar/defaults.py
+++ b/oscar/defaults.py
@@ -87,48 +87,59 @@ OSCAR_DASHBOARD_NAVIGATION = {
         'label': _('Dashboard'),
         'icon': 'icon-th-list',
         'url_name': 'dashboard:index',
+        'order': 1,
     },
     'catalogue': {
         'label': _('Catalogue'),
         'icon': 'icon-sitemap',
+        'order': 2,
         'children': {
             'products': {
                 'label': _('Products'),
                 'url_name': 'dashboard:catalogue-product-list',
+                'order': 1,
             },
             'product_types': {
                 'label': _('Product Types'),
                 'url_name': 'dashboard:catalogue-class-list',
+                'order': 2,
             },
             'categories': {
                 'label': _('Categories'),
                 'url_name': 'dashboard:catalogue-category-list',
+                'order': 3,
             },
             'ranges': {
                 'label': _('Ranges'),
                 'url_name': 'dashboard:range-list',
+                'order': 4,
             },
             'stock_alerts': {
                 'label': _('Low stock alerts'),
                 'url_name': 'dashboard:stock-alert-list',
+                'order': 5,
             },
         }
     },
     'fulfilment': {
         'label': _('Fulfilment'),
         'icon': 'icon-shopping-cart',
+        'order': 3,
         'children': {
             'orders': {
                 'label': _('Orders'),
                 'url_name': 'dashboard:order-list',
+                'order': 1,
             },
             'statistics': {
                 'label': _('Statistics'),
                 'url_name': 'dashboard:order-stats',
+                'order': 2,
             },
             'partners': {
                 'label': _('Partners'),
                 'url_name': 'dashboard:partner-list',
+                'order': 3,
             },
             # The shipping method dashboard is disabled by default as it might
             # be confusing. Weight-based shipping methods aren't hooked into
@@ -143,54 +154,66 @@ OSCAR_DASHBOARD_NAVIGATION = {
     'customers': {
         'label': _('Customers'),
         'icon': 'icon-group',
+        'order': 4,
         'children': {
             'customers': {
                 'label': _('Customers'),
                 'url_name': 'dashboard:users-index',
+                'order': 1,
             },
             'stock_alerts': {
                 'label': _('Stock alert requests'),
                 'url_name': 'dashboard:user-alert-list',
+                'order': 2,
             },
         }
     },
     'offers': {
         'label': _('Offers'),
         'icon': 'icon-bullhorn',
+        'order': 5,
         'children': {
             'offers': {
                 'label': _('Offers'),
                 'url_name': 'dashboard:offer-list',
+                'order': 1,
             },
             'vouchers': {
                 'label': _('Vouchers'),
                 'url_name': 'dashboard:voucher-list',
+                'order': 2,
             },
         },
     },
     'content': {
         'label': _('Content'),
         'icon': 'icon-folder-close',
+        'order': 6,
         'children': {
             'content_blocks': {
                 'label': _('Content blocks'),
                 'url_name': 'dashboard:promotion-list',
+                'order': 1,
             },
             'content_blocks_by_page': {
                 'label': _('Content blocks by page'),
                 'url_name': 'dashboard:promotion-list-by-page',
+                'order': 2,
             },
             'pages': {
                 'label': _('Pages'),
                 'url_name': 'dashboard:page-list',
+                'order': 3,
             },
             'email_templates': {
                 'label': _('Email templates'),
                 'url_name': 'dashboard:comms-list',
+                'order': 4,
             },
             'reviews': {
                 'label': _('Reviews'),
                 'url_name': 'dashboard:reviews-list',
+                'order': 5,
             },
         }
     },
@@ -198,6 +221,7 @@ OSCAR_DASHBOARD_NAVIGATION = {
         'label': _('Reports'),
         'icon': 'icon-bar-chart',
         'url_name': 'dashboard:reports-index',
+        'order': 7,
     },
 }
 OSCAR_DASHBOARD_DEFAULT_ACCESS_FUNCTION = 'oscar.apps.dashboard.nav.default_access_fn'  # noqa

--- a/oscar/defaults.py
+++ b/oscar/defaults.py
@@ -82,51 +82,51 @@ OSCAR_COOKIES_DELETE_ON_LOGOUT = ['oscar_recently_viewed_products', ]
 OSCAR_HIDDEN_FEATURES = []
 
 # Menu structure of the dashboard navigation
-OSCAR_DASHBOARD_NAVIGATION = [
-    {
+OSCAR_DASHBOARD_NAVIGATION = {
+    'index': {
         'label': _('Dashboard'),
         'icon': 'icon-th-list',
         'url_name': 'dashboard:index',
     },
-    {
+    'catalogue': {
         'label': _('Catalogue'),
         'icon': 'icon-sitemap',
-        'children': [
-            {
+        'children': {
+            'products': {
                 'label': _('Products'),
                 'url_name': 'dashboard:catalogue-product-list',
             },
-            {
+            'product_types': {
                 'label': _('Product Types'),
                 'url_name': 'dashboard:catalogue-class-list',
             },
-            {
+            'categories': {
                 'label': _('Categories'),
                 'url_name': 'dashboard:catalogue-category-list',
             },
-            {
+            'ranges': {
                 'label': _('Ranges'),
                 'url_name': 'dashboard:range-list',
             },
-            {
+            'stock_alerts': {
                 'label': _('Low stock alerts'),
                 'url_name': 'dashboard:stock-alert-list',
             },
-        ]
+        }
     },
-    {
+    'fulfilment': {
         'label': _('Fulfilment'),
         'icon': 'icon-shopping-cart',
-        'children': [
-            {
+        'children': {
+            'orders': {
                 'label': _('Orders'),
                 'url_name': 'dashboard:order-list',
             },
-            {
+            'statistics': {
                 'label': _('Statistics'),
                 'url_name': 'dashboard:order-stats',
             },
-            {
+            'partners': {
                 'label': _('Partners'),
                 'url_name': 'dashboard:partner-list',
             },
@@ -138,68 +138,68 @@ OSCAR_DASHBOARD_NAVIGATION = [
             #     'label': _('Shipping charges'),
             #     'url_name': 'dashboard:shipping-method-list',
             # },
-        ]
+        }
     },
-    {
+    'customers': {
         'label': _('Customers'),
         'icon': 'icon-group',
-        'children': [
-            {
+        'children': {
+            'customers': {
                 'label': _('Customers'),
                 'url_name': 'dashboard:users-index',
             },
-            {
+            'stock_alerts': {
                 'label': _('Stock alert requests'),
                 'url_name': 'dashboard:user-alert-list',
             },
-        ]
+        }
     },
-    {
+    'offers': {
         'label': _('Offers'),
         'icon': 'icon-bullhorn',
-        'children': [
-            {
+        'children': {
+            'offers': {
                 'label': _('Offers'),
                 'url_name': 'dashboard:offer-list',
             },
-            {
+            'vouchers': {
                 'label': _('Vouchers'),
                 'url_name': 'dashboard:voucher-list',
             },
-        ],
+        },
     },
-    {
+    'content': {
         'label': _('Content'),
         'icon': 'icon-folder-close',
-        'children': [
-            {
+        'children': {
+            'content_blocks': {
                 'label': _('Content blocks'),
                 'url_name': 'dashboard:promotion-list',
             },
-            {
+            'content_blocks_by_page': {
                 'label': _('Content blocks by page'),
                 'url_name': 'dashboard:promotion-list-by-page',
             },
-            {
+            'pages': {
                 'label': _('Pages'),
                 'url_name': 'dashboard:page-list',
             },
-            {
+            'email_templates': {
                 'label': _('Email templates'),
                 'url_name': 'dashboard:comms-list',
             },
-            {
+            'reviews': {
                 'label': _('Reviews'),
                 'url_name': 'dashboard:reviews-list',
             },
-        ]
+        }
     },
-    {
+    'reports': {
         'label': _('Reports'),
         'icon': 'icon-bar-chart',
         'url_name': 'dashboard:reports-index',
     },
-]
+}
 OSCAR_DASHBOARD_DEFAULT_ACCESS_FUNCTION = 'oscar.apps.dashboard.nav.default_access_fn'  # noqa
 
 # Search facets

--- a/sites/demo/settings.py
+++ b/sites/demo/settings.py
@@ -312,32 +312,30 @@ GOOGLE_ANALYTICS_ID = 'UA-45363517-4'
 
 # Add stores node to navigation
 new_nav = OSCAR_DASHBOARD_NAVIGATION
-new_nav.append(
-    {
-        'label': 'Stores',
-        'icon': 'icon-shopping-cart',
-        'children': [
-            {
-                'label': 'Stores',
-                'url_name': 'stores-dashboard:store-list',
-            },
-            {
-                'label': 'Store groups',
-                'url_name': 'stores-dashboard:store-group-list',
-            },
-        ]
-    })
-new_nav.append(
-    {
-        'label': 'Datacash',
-        'icon': 'icon-globe',
-        'children': [
-            {
-                'label': 'Transactions',
-                'url_name': 'datacash-transaction-list',
-            },
-        ]
-    })
+new_nav['stores'] = {
+    'label': 'Stores',
+    'icon': 'icon-shopping-cart',
+    'children': [
+        {
+            'label': 'Stores',
+            'url_name': 'stores-dashboard:store-list',
+        },
+        {
+            'label': 'Store groups',
+            'url_name': 'stores-dashboard:store-group-list',
+        },
+    ]
+}
+new_nav['datacash'] = {
+    'label': 'Datacash',
+    'icon': 'icon-globe',
+    'children': [
+        {
+            'label': 'Transactions',
+            'url_name': 'datacash-transaction-list',
+        },
+    ]
+}
 OSCAR_DASHBOARD_NAVIGATION = new_nav
 
 GEOIP_PATH = os.path.join(os.path.dirname(__file__), 'geoip')


### PR DESCRIPTION
The dashboard navigation setting OSCAR_DASHBOARD_NAVIGATION was not
easily extendable due to being a list of dicts.  This commit changes it
to be a dict of dicts so that it can easily be extended, like so:

```
OSCAR_DASHBOARD_NAVIGATION['catalogue']['children']['new'] = {'label':...}
```

This means we do not need to copy the entire catalogue section from
defaults into our own project settings if we only want to add a new
child to the Node
