### PR TITLE
Allow currency filter to take a provided currency

### DIFF
--- a/oscar/templatetags/currency_filters.py
+++ b/oscar/templatetags/currency_filters.py
@@ -8,7 +8,7 @@ register = template.Library()
 
 
 @register.filter(name='currency')
-def currency(value):
+def currency(value, currency=None):
     """
     Format decimal value as currency
     """
@@ -19,7 +19,7 @@ def currency(value):
     # Using Babel's currency formatting
     # http://packages.python.org/Babel/api/babel.numbers-module.html#format_currency
     kwargs = {
-        'currency': settings.OSCAR_DEFAULT_CURRENCY,
+        'currency': currency if currency else settings.OSCAR_DEFAULT_CURRENCY,
         'format': getattr(settings, 'OSCAR_CURRENCY_FORMAT', None)}
     locale = getattr(settings, 'OSCAR_CURRENCY_LOCALE', None)
     if locale:


### PR DESCRIPTION
Backporting from Oscar 0.6, allowing the currency template filter to
take a supplied currency, falling back to OSCAR_DEFAULT_CURRENCY.

As changed by commit 04b7a17
