### PR TITLE
Allow ProductAttributes to be edited from the ProductClass form in the dashboard.

### DIFF
--- a/oscar/apps/dashboard/catalogue/app.py
+++ b/oscar/apps/dashboard/catalogue/app.py
@@ -30,8 +30,10 @@ class CatalogueApplication(Application):
     product_delete_view = get_class('dashboard.catalogue.views',
                                     'ProductDeleteView')
 
-    product_class_createupdate_view = get_class('dashboard.catalogue.views',
-                                                'ProductClassCreateUpdateView')
+    product_class_create_view = get_class('dashboard.catalogue.views',
+                                          'ProductClassCreateView')
+    product_class_update_view = get_class('dashboard.catalogue.views',
+                                          'ProductClassUpdateView')
     product_class_list_view = get_class('dashboard.catalogue.views',
                                         'ProductClassListView')
     product_class_delete_view = get_class('dashboard.catalogue.views',
@@ -91,13 +93,13 @@ class CatalogueApplication(Application):
                 self.category_delete_view.as_view(),
                 name='catalogue-category-delete'),
             url(r'^product-type/create/$',
-                self.product_class_createupdate_view.as_view(),
+                self.product_class_create_view.as_view(),
                 name='catalogue-class-create'),
             url(r'^product-types/$',
                 self.product_class_list_view.as_view(),
                 name='catalogue-class-list'),
             url(r'^product-type/(?P<pk>\d+)/update/$',
-                self.product_class_createupdate_view.as_view(),
+                self.product_class_update_view.as_view(),
                 name='catalogue-class-update'),
             url(r'^product-type/(?P<pk>\d+)/delete/$',
                 self.product_class_delete_view.as_view(),

--- a/oscar/apps/dashboard/catalogue/app.py
+++ b/oscar/apps/dashboard/catalogue/app.py
@@ -30,12 +30,10 @@ class CatalogueApplication(Application):
     product_delete_view = get_class('dashboard.catalogue.views',
                                     'ProductDeleteView')
 
-    product_class_create_view = get_class('dashboard.catalogue.views',
-                                          'ProductClassCreateView')
+    product_class_createupdate_view = get_class('dashboard.catalogue.views',
+                                                'ProductClassCreateUpdateView')
     product_class_list_view = get_class('dashboard.catalogue.views',
                                         'ProductClassListView')
-    product_class_update_view = get_class('dashboard.catalogue.views',
-                                          'ProductClassUpdateView')
     product_class_delete_view = get_class('dashboard.catalogue.views',
                                           'ProductClassDeleteView')
 
@@ -93,13 +91,13 @@ class CatalogueApplication(Application):
                 self.category_delete_view.as_view(),
                 name='catalogue-category-delete'),
             url(r'^product-type/create/$',
-                self.product_class_create_view.as_view(),
+                self.product_class_createupdate_view.as_view(),
                 name='catalogue-class-create'),
             url(r'^product-types/$',
                 self.product_class_list_view.as_view(),
                 name='catalogue-class-list'),
             url(r'^product-type/(?P<pk>\d+)/update/$',
-                self.product_class_update_view.as_view(),
+                self.product_class_createupdate_view.as_view(),
                 name='catalogue-class-update'),
             url(r'^product-type/(?P<pk>\d+)/delete/$',
                 self.product_class_delete_view.as_view(),

--- a/oscar/apps/dashboard/catalogue/forms.py
+++ b/oscar/apps/dashboard/catalogue/forms.py
@@ -10,6 +10,7 @@ from oscar.forms.widgets import ImageInput
 
 Product = get_model('catalogue', 'Product')
 ProductClass = get_model('catalogue', 'ProductClass')
+ProductAttribute = get_model('catalogue', 'ProductAttribute')
 Category = get_model('catalogue', 'Category')
 StockRecord = get_model('partner', 'StockRecord')
 ProductCategory = get_model('catalogue', 'ProductCategory')
@@ -465,3 +466,33 @@ class ProductClassForm(forms.ModelForm):
     class Meta:
         model = ProductClass
         fields = ['name', 'requires_shipping', 'track_stock', 'options']
+
+
+class ProductAttributesForm(forms.ModelForm):
+
+    def __init__(self, *args, **kwargs):
+        super(ProductAttributesForm, self).__init__(*args, **kwargs)
+
+        # because we'll allow submission of the form with blank
+        # codes so that we can generate them.
+        self.fields["code"].required = False
+
+        self.fields["option_group"].help_text = _("Select an option group")
+
+    def clean_code(self):
+        code = self.cleaned_data.get("code")
+        title = self.cleaned_data.get("name")
+
+        if not code and title:
+            code = slugify(title)
+
+        return code
+
+    class Meta:
+        model = ProductAttribute
+        fields = ["name", "code", "type", "option_group", "required"]
+
+ProductAttributesFormSet = inlineformset_factory(ProductClass,
+                                                 ProductAttribute,
+                                                 form=ProductAttributesForm,
+                                                 extra=3)

--- a/oscar/apps/dashboard/catalogue/views.py
+++ b/oscar/apps/dashboard/catalogue/views.py
@@ -656,31 +656,6 @@ class ProductClassCreateUpdateView(generic.UpdateView):
 
     form_valid = form_invalid = process_all_forms
 
-    def get_title(self):
-        if self.creating:
-            title = _("Add a new product type")
-        else:
-            title = _("Update product type '%s'") % self.object.name
-
-        return title
-
-    def get_success_url(self):
-        if self.creating:
-            messages.info(self.request, _("Product type created successfully"))
-            return reverse("dashboard:catalogue-class-list")
-        else:
-            messages.info(self.request, _("Product type updated successfully"))
-            return reverse("dashboard:catalogue-class-list")
-
-    def get_object(self, queryset=None):
-        self.creating = 'pk' not in self.kwargs
-        if self.creating:
-            return None
-
-        product_class = get_object_or_404(ProductClass, pk=self.kwargs['pk'])
-
-        return product_class
-
     def get_context_data(self, *args, **kwargs):
         ctx = super(ProductClassCreateUpdateView, self).get_context_data(
             *args, **kwargs)
@@ -692,6 +667,37 @@ class ProductClassCreateUpdateView(generic.UpdateView):
         ctx["title"] = self.get_title()
 
         return ctx
+
+
+class ProductClassCreateView(ProductClassCreateUpdateView):
+
+    creating = True
+
+    def get_object(self):
+        return None
+
+    def get_title(self):
+        return _("Add a new product type")
+
+    def get_success_url(self):
+        messages.info(self.request, _("Product type created successfully"))
+        return reverse("dashboard:catalogue-class-list")
+
+
+class ProductClassUpdateView(ProductClassCreateUpdateView):
+
+    creating = False
+
+    def get_title(self):
+        return _("Update product type '%s'") % self.object.name
+
+    def get_success_url(self):
+        messages.info(self.request, _("Product type updated successfully"))
+        return reverse("dashboard:catalogue-class-list")
+
+    def get_object(self):
+        product_class = get_object_or_404(ProductClass, pk=self.kwargs['pk'])
+        return product_class
 
 
 class ProductClassListView(generic.ListView):

--- a/oscar/static/oscar/js/oscar/dashboard.js
+++ b/oscar/static/oscar/js/oscar/dashboard.js
@@ -207,16 +207,16 @@ var oscar = (function(o, $) {
                 }
             }
         },
-        product_classes: {
+        product_attributes: {
             init: function(){
                 var type_selects = $("select[name$=type]");
 
                 type_selects.each(function(index){
-                    o.dashboard.product_classes.toggleOptionGroup($(this));
+                    o.dashboard.product_attributes.toggleOptionGroup($(this));
                 });
 
                 type_selects.change(function(e){
-                    o.dashboard.product_classes.toggleOptionGroup($(this));
+                    o.dashboard.product_attributes.toggleOptionGroup($(this));
                 });
             },
 
@@ -224,13 +224,9 @@ var oscar = (function(o, $) {
                 var option_group_select = $('#' + type_select.attr('id').replace('type', 'option_group'));
 
                 if(type_select.val() === 'option'){
-                    option_group_select.show();
-
-                    // show the help-text.
-                    option_group_select.siblings().show();
+                    option_group_select.closest('.control-group').show();
                 }else{
-                    option_group_select.hide();
-                    option_group_select.siblings().hide();
+                    option_group_select.closest('.control-group').hide();
                 }
             }
         },

--- a/oscar/static/oscar/js/oscar/dashboard.js
+++ b/oscar/static/oscar/js/oscar/dashboard.js
@@ -207,6 +207,33 @@ var oscar = (function(o, $) {
                 }
             }
         },
+        product_classes: {
+            init: function(){
+                var type_selects = $("select[name$=type]");
+
+                type_selects.each(function(index){
+                    o.dashboard.product_classes.toggleOptionGroup($(this));
+                });
+
+                type_selects.change(function(e){
+                    o.dashboard.product_classes.toggleOptionGroup($(this));
+                });
+            },
+
+            toggleOptionGroup: function(type_select){
+                var option_group_select = $('#' + type_select.attr('id').replace('type', 'option_group'));
+
+                if(type_select.val() === 'option'){
+                    option_group_select.show();
+
+                    // show the help-text.
+                    option_group_select.siblings().show();
+                }else{
+                    option_group_select.hide();
+                    option_group_select.siblings().hide();
+                }
+            }
+        },
         ranges: {
             init: function() {
                 $('[data-behaviours~="remove"]').click(function() {

--- a/oscar/templates/oscar/dashboard/catalogue/product_class_form.html
+++ b/oscar/templates/oscar/dashboard/catalogue/product_class_form.html
@@ -6,6 +6,8 @@
     {{ title }} | {% trans "Create product type" %} | {{ block.super }}
 {% endblock %}
 
+{% block body_class %}{{ block.super }} create-page{% endblock %}
+
 {% block breadcrumbs %}
     <ul class="breadcrumb">
         <li>
@@ -23,10 +25,128 @@
 {% block headertext %}{{ title }}{% endblock %}
 
 {% block dashboard_content %}
-    <div class="table-header">
-        <h2>{{ title }}</h2>
-    </div>
-    <div class="well">
-        {% include 'partials/form.html' with includes_files=1 class='wysiwyg' %}
-    </div>
+    <form class="form-stacked wysiwyg fixed-actions" method="post" data-behaviour="affix-nav-errors">
+        {% csrf_token %}
+
+        {% comment %}
+            If the ProductClass form has field_errors, partials/form_fields.html
+            will render an error message.
+            This means that there'll be 2 error messages,
+            one from the partial and one from the view. Perhaps there should be
+            an option allowing hiding of the error message in the template.
+            For now we copy paste what we need from the template.
+        {% endcomment %}
+
+        <div class="row-fluid">
+
+            {% block tab_nav %}
+                <div class="span3">
+                    <div data-spy="affix" class="affix-top" data-offset-top="200">
+                        <div class="table-header">
+                            <h3>{% trans "Sections" %}</h3>
+                        </div>
+                        <ul class="nav nav-list bs-docs-sidenav" id="product_update_tabs">
+
+                            {% block tabs %}
+                                <li class="active"><a href="#product_class_details" data-toggle="tab">{% trans 'Product Class details' %}</a></li>
+                                <li><a href="#product_attributes" data-toggle="tab">{% trans 'Product attributes' %}</a></li>
+
+                            {% endblock tabs %}
+                        </ul>
+                    </div>
+                </div>
+            {% endblock tab_nav %}
+
+            <div class="span9">
+                <div class="tab-content">
+                    {% block product_class_details %}
+                        <div class="tab-pane active" id="product_class_details">
+                            <div class="table-header">
+                                <h3>{% trans "Product Class details" %}</h3>
+                            </div>
+                            <div class="well product-class-details">
+                                {% if form.non_field_errors %}
+                                    {% for error in form.non_field_errors %}
+                                        <div class="alert alert-error control-group error">
+                                            <span class="error-block"><i class="icon-exclamation-sign"></i> {{ error }}</span>
+                                        </div>
+                                    {% endfor %}
+                                {% endif %}
+
+                                {% for field in form %}
+                                    {% include 'partials/form_field.html' with field=field %}
+                                {% endfor %}
+                            </div>
+                        </div>
+                    {% endblock %}
+
+                    {% block product_attributes %}
+                        <div class="tab-pane" id="product_attributes">
+                            <div class="table-header">
+                                <h3>{% trans "Product attributes" %}</h3>
+                            </div>
+                            <div class="product-attributes">
+                                <table class="table table-striped table-bordered">
+                                    {{ attributes_formset.management_form }}
+                                    {{ attributes_formset.non_form_errors }}
+                                    <col width="20%">
+                                    <col width="20%">
+                                    <col width="20%">
+                                    <thead>
+                                        <tr>
+                                            <th>{% trans "Name" %}</th>
+                                            <th>{% trans "Code" %}</th>
+                                            <th>{% trans "Type" %}</th>
+                                            <th>{% trans "Required" %}</th>
+                                            <th>{% trans "Delete?" %}</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {% for attribute_form in attributes_formset %}
+                                            <tr>
+                                                {% for hidden_field in attribute_form.hidden_fields %}
+                                                 {{ hidden_field }}
+                                                {% endfor %}
+                                                <td>{% include 'partials/form_field.html' with field=attribute_form.name nolabel=True %}</td>
+                                                <td>{% include 'partials/form_field.html' with field=attribute_form.code nolabel=True %}</td>
+                                                <td>
+                                                    {% include 'partials/form_field.html' with field=attribute_form.type nolabel=True %}
+
+                                                    {% include 'partials/form_field.html' with field=attribute_form.option_group nolabel=True %}
+                                                </td>
+                                                <td>{% include 'partials/form_field.html' with field=attribute_form.required nolabel=True %}</td>
+                                                <td>{% include 'partials/form_field.html' with field=attribute_form.DELETE nolabel=True %}</td>
+                                            </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    {% endblock %}
+                </div>
+            </div>
+        </div>
+
+        {% block fixed_actions_group %}
+            <div class="fixed-actions-group">
+                <div class="form-actions">
+                    <div class="pull-right">
+                        <a href="#" onclick="window.history.go(-1);return false" >
+                            {% trans "Cancel" %}
+                        </a>
+                        {% trans "or" %}
+                        <button class="btn btn-large btn-primary" type="submit">
+                            {% trans "Save" %}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        {% endblock fixed_actions_group %}
+    </form>
+
 {% endblock dashboard_content %}
+
+{% block onbodyload %}
+    {{ block.super }}
+    oscar.dashboard.product_classes.init();
+{% endblock %}

--- a/oscar/templates/oscar/dashboard/catalogue/product_class_form.html
+++ b/oscar/templates/oscar/dashboard/catalogue/product_class_form.html
@@ -28,15 +28,6 @@
     <form class="form-stacked wysiwyg fixed-actions" method="post" data-behaviour="affix-nav-errors">
         {% csrf_token %}
 
-        {% comment %}
-            If the ProductClass form has field_errors, partials/form_fields.html
-            will render an error message.
-            This means that there'll be 2 error messages,
-            one from the partial and one from the view. Perhaps there should be
-            an option allowing hiding of the error message in the template.
-            For now we copy paste what we need from the template.
-        {% endcomment %}
-
         <div class="row-fluid">
 
             {% block tab_nav %}
@@ -65,6 +56,16 @@
                                 <h3>{% trans "Product Class details" %}</h3>
                             </div>
                             <div class="well product-class-details">
+
+                                {% comment %}
+                                    If the ProductClass form has field_errors, partials/form_fields.html
+                                    will render an error message.
+                                    This means that there'll be 2 error messages,
+                                    one from the partial and one from the view. Perhaps there should be
+                                    an option allowing hiding of the error message in the template.
+                                    For now we copy paste what we need from the template.
+                                {% endcomment %}
+
                                 {% if form.non_field_errors %}
                                     {% for error in form.non_field_errors %}
                                         <div class="alert alert-error control-group error">

--- a/oscar/templates/oscar/dashboard/catalogue/product_class_form.html
+++ b/oscar/templates/oscar/dashboard/catalogue/product_class_form.html
@@ -149,5 +149,5 @@
 
 {% block onbodyload %}
     {{ block.super }}
-    oscar.dashboard.product_classes.init();
+    oscar.dashboard.product_attributes.init();
 {% endblock %}

--- a/tests/unit/dashboard/catalogue_form_tests.py
+++ b/tests/unit/dashboard/catalogue_form_tests.py
@@ -23,3 +23,19 @@ class TestCreateProductForm(TestCase):
             product_class=self.product_class, structure='parent')
         form = self.submit({'structure': 'child'}, parent=parent)
         self.assertTrue(form.is_valid())
+
+
+class TestCreateProductAttributeForm(TestCase):
+
+    def test_can_create_without_code(self):
+        form = forms.ProductAttributesForm(data={
+            "name": "Attr",
+            "type": "text"
+        })
+
+        self.assertTrue(form.is_valid())
+
+        product_attribute = form.save()
+
+        # check that code is not None or empty string
+        self.assertTrue(product_attribute.code)


### PR DESCRIPTION
Summary:
* Ui has tabbed navigation like the product edit form.
* The option_group select field is hidden unless you select `type=option`

In the first commit, the `ProductClassCreateView` and `ProductClassUpdateView` have been merged into `ProductClassCreateUpdateView` but this may be incompatible with sites that expect the Create and Update views to exist separately, in the 2nd commit `ProductClassCreateView` have been returned `ProductClassUpdateView`. There might still be some issues for people using the stock form since it now expects `attributes_formset`.

Finally if this gets approved, I can get started on the ui for editing ProductAttributeOptions when creating/editing ProductAttributes. Following [this discussion](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/django-oscar/-LmhwpAxgaU), I believe implementing as many features as possible within the dashboard would really help oscar get a larger community.