### PR TITLE
Explicitly pass the billing address around checkout

### DIFF
--- a/docs/source/releases/v0.8.rst
+++ b/docs/source/releases/v0.8.rst
@@ -24,7 +24,7 @@ two versions of Django, support for Django 1.5 has been dropped.
 
 This release also adds full Python 3.3 and 3.4 support. But due to South
 not supporting Python 3, Python 3 support is only supported in combination
-with Django 1.7 and it's new migration framework.
+with Django 1.7 and its new migration framework.
 
 If you're using ``pysolr`` for search, you need to upgrade to version 3.2 or
 later.
@@ -88,6 +88,15 @@ Unfortunately, the changes in Django required a few breaking changes when
 upgrading Oscar both for users staying on Django 1.6 and for users upgrading to
 Django 1.7 at the same time. These are detailed in the section for
 backwards-incompatible changes.
+
+Billing addresses explicitly passed around checkout
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``build_submission`` method used in checkout now has a ``billing_address``
+key and the signatures for the ``submit`` and ``handle_order_placement`` methods
+have been extended to include it as a keyword argument. While this change should
+be backwards compatible, it's worth being aware of the method signature changes
+in case it affects your checkout implementation.
 
 Dashboard for weight-based shipping methods
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/oscar/apps/checkout/mixins.py
+++ b/oscar/apps/checkout/mixins.py
@@ -97,7 +97,8 @@ class OrderPlacementMixin(CheckoutSessionMixin):
 
     def handle_order_placement(self, order_number, user, basket,
                                shipping_address, shipping_method,
-                               shipping_charge, order_total, **kwargs):
+                               shipping_charge, billing_address, order_total,
+                               **kwargs):
         """
         Write out the order models and return the appropriate HTTP response
 

--- a/oscar/apps/checkout/views.py
+++ b/oscar/apps/checkout/views.py
@@ -517,8 +517,8 @@ class PaymentDetailsView(OrderPlacementMixin, generic.TemplateView):
             return None
 
     def submit(self, user, basket, shipping_address, shipping_method,  # noqa (too complex (10))
-               shipping_charge, order_total, payment_kwargs=None,
-               order_kwargs=None):
+               shipping_charge, billing_address, order_total,
+               payment_kwargs=None, order_kwargs=None):
         """
         Submit a basket for order placement.
 
@@ -534,7 +534,10 @@ class PaymentDetailsView(OrderPlacementMixin, generic.TemplateView):
            - If payment is unsuccessful, show an appropriate error message
 
         :basket: The basket to submit.
-        :payment_kwargs: Additional kwargs to pass to the handle_payment method
+        :payment_kwargs: Additional kwargs to pass to the handle_payment
+        method. It normally makes sense to pass form instances (rather than
+        model instances) so that the forms can be re-rendered correctly if
+        payment fails.
         :order_kwargs: Additional kwargs to pass to the place_order method
         """
         if payment_kwargs is None:
@@ -626,7 +629,7 @@ class PaymentDetailsView(OrderPlacementMixin, generic.TemplateView):
         try:
             return self.handle_order_placement(
                 order_number, user, basket, shipping_address, shipping_method,
-                shipping_charge, order_total, **order_kwargs)
+                shipping_charge, billing_address, order_total, **order_kwargs)
         except UnableToPlaceOrder as e:
             # It's possible that something will go wrong while trying to
             # actually place an order.  Not a good situation to be in as a


### PR DESCRIPTION
This changeset adjusts `build_submission` to include the billing address.
This also requires changes to a few method signatures to handle the
billing address explicitly.

This only works when the billing address is stored in the session (as
that's where it is looked up from when building the submission data in
`build_submission`). In many cases (such as Oscar's demo site), we don't
store the billing address in the session - instead, it is captured via
the payment-details forms. Hence, the billing address will still need to
be explicitly set within the submission data.

Fixes #1508
