### PR TITLE
Remove mentions of vagrant from the docs

### DIFF
--- a/docs/source/internals/contributing/development-environment.rst
+++ b/docs/source/internals/contributing/development-environment.rst
@@ -71,64 +71,17 @@ You can manually compile the CSS files by running::
     If you do submit a pull request that changes the LESS files.  Please also
     recompile the CSS files and include them in your pull request.
 
-Vagrant
-=======
-
-Oscar ships with a Vagrant_ virtual machine that can be used to test integration
-with various services in a controlled environment.  For instance, it is used to
-test that the migrations run correctly in both MySQL and Postgres.
-
-.. _Vagrant: http://vagrantup.com/
-
-Building the Vagrant machine
-----------------------------
-
-To create the machine, first ensure that Vagrant and puppet_ are installed.  You will require a
-puppet version that supports ``puppet module install``, that is > 2.7.14.  Now
-run::
-
-    make puppet
-
-.. _puppet: http://docs.puppetlabs.com/guides/installation.html
-
-to fetch the required puppet modules for provisioning.  Finally, run::
-
-    vagrant up
-
-to create the virtual machine and provision it.
-
 Testing migrations against MySQL and Postgres
 ---------------------------------------------
 
-To test the migrations against MySQL and Postgres, do the following:
+To test the migrations against MySQL and Postgres you will need to set
+up an environment with both installed and do the following:
 
-1. SSH onto the VM::
+1. Change to sandbox folder and activate your virtualenv
 
-    vagrant ssh
-
-2. Change to sandbox folder and activate virtualenv::
-
-    cd /vagrant/sites/sandbox
-    source /var/www/virtualenv/bin/activate
-
-3. Run helper script::
+2. Run helper script::
 
     ./test_migrations.sh
 
     This will recreate the Oscar database in both MySQL and Postgres and rebuild
     it using ``syncdb`` and ``migrate``.
-
-Testing WSGI server configurations
-----------------------------------
-
-You can browse the Oscar sandbox site with different deployment setups. Just
-open up http://localhost:808x on your host machine.
-
-* Django's development server runs on port 8080.
-
-* The Vagrant machine runs Apache2 and mod_wsgi on port 8081.
-
-* Nginx acts as a reverse proxy to Apache on port 8082.
-
-* Nginx acts as a reverse proxy to gunicorn on port 8083.
-


### PR DESCRIPTION
Vagrant support was removed from release 1.0. This commit removes mentions of it from the docs.