### PR TITLE
Correctly handle the update_fields kwarg on Category.save()

### DIFF
--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -129,10 +129,11 @@ class AbstractCategory(MP_Node):
         if update_slugs:
             self.update_slug(commit=False)
 
-        # If the slug fieldd is updated then validate that it is unique and
-        # update the child categories
-        update_fields = kwargs.get('update_fields')
-        if not update_fields or 'slug' in update_fields:
+        # If update_fields is specified and name or slug are listed then
+        # validate that it is unique and update the child categories
+        update_fields = kwargs.get('update_fields', None)
+        slug_fields = set(['name', 'slug'])
+        if not update_fields or slug_fields & set(update_fields):
             # Enforce slug uniqueness here as MySQL can't handle a unique index
             # on the slug field
             try:

--- a/tests/integration/catalogue/category_tests.py
+++ b/tests/integration/catalogue/category_tests.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-from django.test import TestCase
-from django.core.exceptions import ValidationError
 from django import template
+from django.core.exceptions import ValidationError
+from django.test import TestCase
 
 from oscar.apps.catalogue import models
 from oscar.apps.catalogue.categories import create_from_breadcrumbs
@@ -26,6 +26,17 @@ class TestCategory(TestCase):
     def test_enforces_slug_uniqueness(self):
         with self.assertRaises(ValidationError):
             self.products.add_child(name=u"Bücher")
+
+    def test_save_update_slug(self):
+        with self.assertNumQueries(2):
+            self.books.name = 'Books'
+            self.books.save()
+
+    def test_save_update_fields(self):
+        with self.assertNumQueries(1):
+            self.books.description = 'Something new'
+            self.books.save(update_fields=['description'])
+
 
 
 class TestMovingACategory(TestCase):


### PR DESCRIPTION
If the update_fields is given as kwarg and doesn’t contain the slug as
field to update then skip validating uniqueness of the slug and updating
the children categories.

I also think that we can deprecate the update_slugs kwarg from the save method and move it within the added condition. 