### PR TITLE
dynamically load PROMOTION_CLASSES

### DIFF
--- a/oscar/apps/dashboard/promotions/app.py
+++ b/oscar/apps/dashboard/promotions/app.py
@@ -2,7 +2,7 @@ from django.conf.urls import url
 
 from oscar.core.application import Application
 from oscar.core.loading import get_class
-from oscar.apps.promotions.conf import PROMOTION_CLASSES
+PROMOTION_CLASSES = get_class('promotions.conf', 'PROMOTION_CLASSES')
 
 
 class PromotionsDashboardApplication(Application):

--- a/oscar/apps/dashboard/promotions/forms.py
+++ b/oscar/apps/dashboard/promotions/forms.py
@@ -2,7 +2,8 @@ from django import forms
 from django.conf import settings
 from django.forms.models import inlineformset_factory
 from django.utils.translation import ugettext_lazy as _
-from oscar.apps.promotions.conf import PROMOTION_CLASSES
+from oscar.core.loading import get_class
+PROMOTION_CLASSES = get_class('promotions.conf', 'PROMOTION_CLASSES')
 
 from oscar.forms.fields import ExtendedURLField
 from oscar.core.loading import get_classes, get_class

--- a/oscar/apps/dashboard/promotions/views.py
+++ b/oscar/apps/dashboard/promotions/views.py
@@ -10,8 +10,8 @@ from django.http import HttpResponseRedirect
 from django.db.models import Count
 from django.shortcuts import HttpResponse
 
-from oscar.core.loading import get_classes
-from oscar.apps.promotions.conf import PROMOTION_CLASSES
+from oscar.core.loading import get_classes, get_class
+PROMOTION_CLASSES = get_class('promotions.conf', 'PROMOTION_CLASSES')
 
 SingleProduct, RawHTML, Image, MultiImage, AutomaticProductList, \
     PagePromotion, HandPickedProductList \


### PR DESCRIPTION
This addresses the question I asked in #1560. It's a nice addition because it requires less forking if I want to add a custom promotion type.
