### PR TITLE
Remove django-compressor

### DIFF
--- a/docs/source/howto/how_to_handle_statics.rst
+++ b/docs/source/howto/how_to_handle_statics.rst
@@ -27,43 +27,22 @@ Frontend vs. Dashboard
 
 The frontend and dashboard are intentionally kept very separate. They
 incidentally both use Bootstrap, but may be updated individually.
+
 The frontend is based on Bootstrap's LESS files and ties it together with
 Oscar-specific styling in ``styles.less``.
 
-On the other hand, ``dashboard.less`` just contains a few customisations that
-are included alongside a copy of stock Bootstrap CSS - and at the time of
-writing, using a different Bootstrap version.
+The dashboard's styles are in ``dashboard.less``. It contains just a few
+customizations to stock Bootstrap CSS.
 
 LESS/CSS
 --------
 
-By default, CSS files compiled from their LESS sources are used rather than the
-LESS ones.  To use Less directly, set ``USE_LESS = True`` in your settings file.
-You will also need to ensure that the ``lessc`` executable is installed and is
-configured using a setting like::
+Compiling the LESS files to CSS happens offline using lessc. The Makefile
+contains a target that compiles all LESS files::
 
-    COMPRESS_PRECOMPILERS = (
-        ('text/less', 'lessc {infile} {outfile}'),
-    )
+    $ make css
 
 A few other CSS files are used to provide styles for javascript libraries.
-
-Using offline compression
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Django compressor also provides a way of running offline compression which can
-be used during deployment to automatically generate CSS files from your LESS
-files. To make sure that compressor is obeying the ``USE_LESS`` setting and
-is not trying to compress CSS files that are not available, the setting has to
-be passed into the ``COMPRESS_OFFLINE_CONTEXT``. You should add something like
-this to your settings file::
-
-    COMPRESS_OFFLINE_CONTEXT = {
-        # this is the only default value from compressor itself
-        'STATIC_URL': STATIC_URL,
-        'use_less': USE_LESS,
-    }
-
 
 Javascript
 ----------
@@ -124,6 +103,6 @@ and replace the 'less' block::
 
     # project/base.html
 
-    {% block less %}
-        <link rel="stylesheet" type="text/less" href="{{ STATIC_URL }}myproject/less/styles.less" />
+    {% block mainstyles %}
+        <link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}myproject/css/styles.css" />
     {% endblock %}

--- a/docs/source/internals/contributing/development-environment.rst
+++ b/docs/source/internals/contributing/development-environment.rst
@@ -43,26 +43,17 @@ against::
 Writing LESS/CSS
 ----------------
 
-Oscar's CSS files are built using LESS_ V1.  However, the sandbox defaults to
-serving CSS files directly, bypassing LESS compilation.
+Oscar's CSS files are built with LESS_ V1.  However, the LESS files are
+compiled offline, and the resulting CSS files are served directly.
 
 .. _LESS: http://lesscss.org/
 
-If you want to develop the LESS files, set::
+If you want to develop the LESS files, make sure you get the 1.x version::
 
-    USE_LESS = True
-    COMPRESS_ENABLED = False
+    $ npm install -g less@'<2'
 
-in ``sites/sandbox/settings_local.py``.  This will cause Oscar to use
-`django-compressor`_ to compile the LESS files as they are requested.  For this to
-work, you will need to ensure that the LESS compiler ``lessc`` is installed.
-Using npm, install LESS using::
 
-    npm install less@'<2.0.0'
-
-.. _`django-compressor`: http://django_compressor.readthedocs.org/en/latest/
-
-You can manually compile the CSS files by running::
+You can now compile the LESS files by running::
 
     make css
 

--- a/docs/source/internals/getting_started.rst
+++ b/docs/source/internals/getting_started.rst
@@ -68,8 +68,9 @@ Edit your settings file ``frobshop.frobshop.settings.py`` to specify
         'oscar.core.context_processors.metadata',
     )
 
-Next, modify ``INSTALLED_APPS`` to be a list, add ``django.contrib.sites``, ``django.contrib.flatpages`` and ``compressor``
-and append Oscar's core apps. Also set ``SITE_ID``:
+Next, modify ``INSTALLED_APPS`` to be a list, add ``django.contrib.sites`` and
+``django.contrib.flatpages`` and append Oscar's core apps. Also set
+``SITE_ID``:
 
 .. code-block:: django
 
@@ -84,7 +85,6 @@ and append Oscar's core apps. Also set ``SITE_ID``:
         'django.contrib.staticfiles',
         'django.contrib.flatpages',
         ...
-        'compressor',
     ] + get_core_apps()
 
     SITE_ID = 1
@@ -95,14 +95,6 @@ which won't be enabled by default when using Django 1.6 or upwards.
 More info about installing ``flatpages`` is in the `Django docs`_.
 
 .. _`Django docs`: https://docs.djangoproject.com/en/dev/ref/contrib/flatpages/#installation
-
-.. tip::
-
-    Oscar's default templates use django-compressor_ but it's optional really.
-    You may decide to use your own templates that don't use compressor.  Hence
-    why it is not one of the 'core apps'.
-
-.. _django-compressor: https://github.com/jezdez/django_compressor
 
 Next, add ``oscar.apps.basket.middleware.BasketMiddleware`` and
 ``django.contrib.flatpages.middleware.FlatpageFallbackMiddleware`` to

--- a/docs/source/releases/v1.1.rst
+++ b/docs/source/releases/v1.1.rst
@@ -46,6 +46,8 @@ Minor changes
 
 - The `Order.date_placed` field can now be set explicitly rather than using the
   `auto_now_add` behaviour (`#1558`_).
+- ``django-compressor`` has been removed in favor of offline compilation of
+  LESS files (`#1568`_).
 
 - The settings ``OSCAR_BASKET_COOKIE_SECURE`` and ``OSCAR_RECENTLY_VIEWED_COOKIE_SECURE``
   are introduced to set the ``secure`` flag on the relevant cookies.
@@ -59,6 +61,7 @@ Minor changes
   account.
 
 .. _`#1558`: https://github.com/django-oscar/django-oscar/pull/1558
+.. _`#1568`: https://github.com/django-oscar/django-oscar/pull/1568
 
 
 .. _incompatible_changes_in_1.1:

--- a/setup.py
+++ b/setup.py
@@ -50,9 +50,6 @@ setup(name='django-oscar',
           'sorl-thumbnail>=11.12.1b,<=12.2',
           # Babel is used for currency formatting
           'Babel>=1.0,<1.4',
-          # Oscar's default templates use compressor (but you can override
-          # this)
-          'django-compressor>=1.4',
           # For converting non-ASCII to ASCII when creating slugs
           'Unidecode>=0.04.12,<0.05',
           # For manipulating search URLs

--- a/sites/demo/settings.py
+++ b/sites/demo/settings.py
@@ -86,11 +86,6 @@ STATICFILES_DIRS = (
     location('static'),
 )
 STATIC_ROOT = location('public/static')
-STATICFILES_FINDERS = (
-    'django.contrib.staticfiles.finders.FileSystemFinder',
-    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-    'compressor.finders.CompressorFinder',
-)
 
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = '$)a7n&o80u!6y5t-+jrd3)3!%vh&shg$wqpjpxc!ar&p#!)n1a'
@@ -233,7 +228,6 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django.contrib.gis',
     # Oscar dependencies
-    'compressor',
     'widget_tweaks',
     # Oscar extensions
     'stores',
@@ -288,11 +282,6 @@ OSCAR_ALLOW_ANON_CHECKOUT = True
 
 OSCAR_SHOP_NAME = 'Oscar'
 OSCAR_SHOP_TAGLINE = 'Demo'
-
-COMPRESS_ENABLED = False
-COMPRESS_PRECOMPILERS = (
-    ('text/less', 'lessc {infile} {outfile}'),
-)
 
 THUMBNAIL_KEY_PREFIX = 'oscar-demo'
 

--- a/sites/demo/settings_docker.py
+++ b/sites/demo/settings_docker.py
@@ -1,6 +1,3 @@
-USE_LESS = False
-COMPRESS_ENABLED = False
-
 HAYSTACK_CONNECTIONS = {
     'default': {
         'ENGINE': 'haystack.backends.solr_backend.SolrEngine',

--- a/sites/demo/templates/base.html
+++ b/sites/demo/templates/base.html
@@ -3,10 +3,8 @@
 {% load staticfiles %}
 
 {% block mainstyles %}
-    {% block styles %}
-        <link rel="stylesheet" type="text/css" href="{% static "demo/css/styles.css" %}" />
-        <link rel="stylesheet" type="text/css" href="{% static "demo/css/responsive.css" %}" />
-    {% endblock %}
+    <link rel="stylesheet" type="text/css" href="{% static "demo/css/styles.css" %}" />
+    <link rel="stylesheet" type="text/css" href="{% static "demo/css/responsive.css" %}" />
 {% endblock %}
 
 

--- a/sites/demo/templates/base.html
+++ b/sites/demo/templates/base.html
@@ -1,27 +1,18 @@
 {% extends "oscar/base.html" %}
-{% load i18n compress %}
+{% load i18n %}
 {% load staticfiles %}
 
 {% block mainstyles %}
     {% block styles %}
-        {% compress css %}
-            {% if use_less %}
-                <link rel="stylesheet" type="text/less" href="{% static "demo/less/styles.less" %}" />
-                <link rel="stylesheet" type="text/less" href="{% static "demo/less/responsive.less" %}" />
-            {% else %}
-                <link rel="stylesheet" type="text/css" href="{% static "demo/css/styles.css" %}" />
-                <link rel="stylesheet" type="text/css" href="{% static "demo/css/responsive.css" %}" />
-            {% endif %}
-        {% endcompress %}
+        <link rel="stylesheet" type="text/css" href="{% static "demo/css/styles.css" %}" />
+        <link rel="stylesheet" type="text/css" href="{% static "demo/css/responsive.css" %}" />
     {% endblock %}
 {% endblock %}
 
 
 {% block scripts %}
-{% compress js %}
 <!-- Twitter Bootstrap -->
 <script type="text/javascript" src="{% static "oscar/js/bootstrap/bootstrap.min.js" %}"></script>
 <!-- Oscar -->
 <script src="{% static "oscar/js/oscar/ui.js" %}" type="text/javascript" charset="utf-8"></script>
-{% endcompress %}
 {% endblock scripts %}

--- a/sites/demo/templates/catalogue/detail.html
+++ b/sites/demo/templates/catalogue/detail.html
@@ -1,6 +1,5 @@
 {% extends "oscar/catalogue/detail.html" %}
 
-{% load compress %}
 {% load currency_filters %}
 {% load history_tags %}
 {% load reviews_tags %}
@@ -186,7 +185,5 @@
 {% endblock content %}
 
 {% block extrascripts %}
-{% compress js %}
     {% include "partials/extrascripts.html" %}
-{% endcompress %}
 {% endblock %}

--- a/sites/demo/templates/checkout/layout.html
+++ b/sites/demo/templates/checkout/layout.html
@@ -3,7 +3,6 @@
 {% load currency_filters %}
 {% load promotion_tags %}
 {% load category_tags %}
-{% load compress %}
 {% load staticfiles %}
 {% load i18n %}
 
@@ -75,7 +74,5 @@
 {% endblock %}
 
 {% block extrascripts %}
-{% compress js %}
     {% include "partials/extrascripts.html" %}
-{% endcompress %}
 {% endblock %}

--- a/sites/demo/templates/layout.html
+++ b/sites/demo/templates/layout.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load compress %}
 {% load category_tags %}
 {% load staticfiles %}
 {% load i18n %}
@@ -63,7 +62,5 @@
 {% endblock %}
 
 {% block extrascripts %}
-{% compress js %}
     {% include "partials/extrascripts.html" %}
-{% endcompress %}
 {% endblock %}

--- a/sites/sandbox/settings.py
+++ b/sites/sandbox/settings.py
@@ -114,11 +114,6 @@ STATIC_ROOT = location('public/static')
 STATICFILES_DIRS = (
     location('static/'),
 )
-STATICFILES_FINDERS = (
-    'django.contrib.staticfiles.finders.FileSystemFinder',
-    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-    'compressor.finders.CompressorFinder',
-)
 
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = '$)a7n&o80u!6y5t-+jrd3)3!%vh&shg$wqpjpxc!ar&p#!)n1a'
@@ -310,7 +305,6 @@ INSTALLED_APPS = [
     # Debug toolbar + extensions
     'debug_toolbar',
     'template_timings_panel',
-    'compressor',       # Oscar's templates use compressor
     'apps.gateway',     # For allowing dashboard access
     'widget_tweaks',
 ]
@@ -426,31 +420,6 @@ OSCAR_ORDER_STATUS_CASCADE = {
     'Cancelled': 'Cancelled',
     'Complete': 'Shipped',
 }
-
-# LESS/CSS/statics
-# ================
-
-# We default to using CSS files, rather than the LESS files that generate them.
-# If you want to develop Oscar's CSS, then set USE_LESS=True and
-# COMPRESS_ENABLED=False in your settings_local module and ensure you have
-# 'lessc' installed.
-
-USE_LESS = False
-
-COMPRESS_ENABLED = True
-COMPRESS_PRECOMPILERS = (
-    ('text/less', 'lessc {infile} {outfile}'),
-)
-COMPRESS_OFFLINE_CONTEXT = {
-    'STATIC_URL': 'STATIC_URL',
-    'use_less': USE_LESS,
-}
-
-# We do this to work around an issue in compressor where the LESS files are
-# compiled but compression isn't enabled.  When this happens, the relative URL
-# is wrong between the generated CSS file and other assets:
-# https://github.com/jezdez/django_compressor/issues/226
-COMPRESS_OUTPUT_DIR = 'oscar'
 
 # Logging
 # =======

--- a/sites/us/settings.py
+++ b/sites/us/settings.py
@@ -82,11 +82,6 @@ STATIC_ROOT = location('public/static')
 STATICFILES_DIRS = (
     location('static/'),
 )
-STATICFILES_FINDERS = (
-    'django.contrib.staticfiles.finders.FileSystemFinder',
-    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-    'compressor.finders.CompressorFinder',
-)
 
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = '$)a6n&o80u!6y5t-+jrd3)3!%vh&shg$wqpjpxc!ar&p#!)n1a'
@@ -278,7 +273,6 @@ INSTALLED_APPS = [
     # Debug toolbar + extensions
     'debug_toolbar',
     'template_timings_panel',
-    'compressor',       # Oscar's templates use compressor
     'widget_tweaks',
 ]
 from oscar import get_core_apps
@@ -343,30 +337,6 @@ from oscar.defaults import *  # noqa
 OSCAR_SHOP_TAGLINE = 'US Sandbox'
 OSCAR_DEFAULT_CURRENCY = 'USD'
 OSCAR_ALLOW_ANON_CHECKOUT = True
-
-# LESS/CSS/statics
-# ================
-
-# We default to using CSS files, rather than the LESS files that generate them.
-# If you want to develop Oscar's CSS, then set USE_LESS=True and
-# COMPRESS_ENABLED=False in your settings_local module and ensure you have
-# 'lessc' installed.
-USE_LESS = False
-
-COMPRESS_ENABLED = True
-COMPRESS_PRECOMPILERS = (
-    ('text/less', 'lessc {infile} {outfile}'),
-)
-COMPRESS_OFFLINE_CONTEXT = {
-    'STATIC_URL': 'STATIC_URL',
-    'use_less': USE_LESS,
-}
-
-# We do this to work around an issue in compressor where the LESS files are
-# compiled but compression isn't enabled.  When this happens, the relative URL
-# is wrong between the generated CSS file and other assets:
-# https://github.com/jezdez/django_compressor/issues/226
-COMPRESS_OUTPUT_DIR = 'oscar'
 
 # Logging
 # =======

--- a/src/oscar/core/context_processors.py
+++ b/src/oscar/core/context_processors.py
@@ -50,7 +50,6 @@ def metadata(request):
             'shop_name': settings.OSCAR_SHOP_NAME,
             'shop_tagline': settings.OSCAR_SHOP_TAGLINE,
             'homepage_url': settings.OSCAR_HOMEPAGE,
-            'use_less': getattr(settings, 'USE_LESS', False),
             'call_home': usage_statistics_string(),
             'language_neutral_url_path': strip_language_code(request),
             'google_analytics_id': getattr(settings,

--- a/src/oscar/templates/oscar/base.html
+++ b/src/oscar/templates/oscar/base.html
@@ -1,4 +1,4 @@
-{% load i18n compress %}
+{% load i18n %}
 {% load staticfiles %}
 <!DOCTYPE html>
 <!--[if lt IE 7]>      <html lang="{{ LANGUAGE_CODE|default:"en-gb" }}" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
@@ -31,13 +31,6 @@
             expect it to compress CSS files added in child templates.
             {% endcomment %}
             {% block styles %}
-                {% comment %}
-                If you are developing Oscar's CSS, or overriding Oscar's CSS
-                files in your project, then set USE_LESS = True in your
-                settings file.  You will also need to ensure that the 'lessc'
-                executable is available and you have COMPRESS_PRECOMPILERS specified
-                correctly.
-                {% endcomment %}
             {% endblock %}
         {% endblock %}
 

--- a/src/oscar/templates/oscar/base.html
+++ b/src/oscar/templates/oscar/base.html
@@ -25,13 +25,6 @@
         {% endblock %}
 
         {% block mainstyles %}
-            {% comment %}
-            We use an inner block to work-around the fact that django-compressor doesn't work with
-            template inheritance.  Ie, we can't just wrap the {% block mainstyles %} with compress tags and
-            expect it to compress CSS files added in child templates.
-            {% endcomment %}
-            {% block styles %}
-            {% endblock %}
         {% endblock %}
 
         {# Additional CSS - specific to certain pages #}
@@ -49,18 +42,11 @@
         {# Main content goes in this 'layout' block #}
         {% block layout %}{% endblock %}
 
-        {% comment %}
-        Scripts loaded from a CDN.  These can't be wrapped by the 'compress' tag and so we
-        use a separate block for them.
-        {% endcomment %}
-        {% block cdn_scripts %}
+        {# Local scripts #}
+        {% block scripts %}
             <!-- jQuery -->
             <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
             <script>window.jQuery || document.write('<script src="{% static "oscar/js/jquery/jquery-1.9.1.min.js" %}"><\/script>')</script>
-        {% endblock %}
-
-        {# Local scripts #}
-        {% block scripts %}
         {% endblock %}
 
         {# Additional JS scripts #}

--- a/src/oscar/templates/oscar/customer/order/order_list.html
+++ b/src/oscar/templates/oscar/customer/order/order_list.html
@@ -64,7 +64,7 @@
     <link rel="stylesheet" href="//code.jquery.com/ui/1.10.3/themes/cupertino/jquery-ui.css">
 {% endblock %}
 
-{% block cdn_scripts %}
+{% block scripts %}
     {{ block.super }}
     <script src="//code.jquery.com/ui/1.10.3/jquery-ui.min.js" type="text/javascript" charset="utf-8"></script>
 {% endblock %}

--- a/src/oscar/templates/oscar/dashboard/layout.html
+++ b/src/oscar/templates/oscar/dashboard/layout.html
@@ -3,32 +3,22 @@
 {% load category_tags %}
 {% load dashboard_tags %}
 {% load i18n %}
-{% load compress %}
 {% load staticfiles %}
 
 {% block mainstyles %}
-    {% compress css %}
-        <link rel="stylesheet" href="{% static "oscar/css/bootstrap.min.css" %}" />
-        {% if use_less %}
-            <link rel="stylesheet" type="text/less" href="{% static "oscar/less/dashboard.less" %}" />
-            <link rel="stylesheet" type="text/less" href="{% static "oscar/less/responsive.less" %}" />
-        {% else %}
-            <link rel="stylesheet" type="text/css" href="{% static "oscar/css/dashboard.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "oscar/css/responsive.css" %}" />
-        {% endif %}
-    {% endcompress %}
+    <link rel="stylesheet" href="{% static "oscar/css/bootstrap.min.css" %}" />
+    <link rel="stylesheet" type="text/css" href="{% static "oscar/css/dashboard.css" %}" />
+    <link rel="stylesheet" type="text/css" href="{% static "oscar/css/responsive.css" %}" />
 {% endblock %}
 
 {% block extrastyles %}
     {{ block.super }}
-    {% compress css %}
-        {% block jquery-ui-css %}
-            <link rel="stylesheet" href="{% static "oscar/js/jquery-ui/jquery-ui.css" %}">
-        {% endblock %}
-        <link rel="stylesheet" href="{% static "oscar/js/select2/select2.css" %}" />
-        <link rel="stylesheet" href="{% static "oscar/css/select2-bootstrap.css" %}" />
-        <link rel="stylesheet" href="{% static "oscar/js/bootstrap-datetimepicker/bootstrap-datetimepicker.css" %}" />
-    {% endcompress %}
+    {% block jquery-ui-css %}
+        <link rel="stylesheet" href="{% static "oscar/js/jquery-ui/jquery-ui.css" %}">
+    {% endblock %}
+    <link rel="stylesheet" href="{% static "oscar/js/select2/select2.css" %}" />
+    <link rel="stylesheet" href="{% static "oscar/css/select2-bootstrap.css" %}" />
+    <link rel="stylesheet" href="{% static "oscar/js/bootstrap-datetimepicker/bootstrap-datetimepicker.css" %}" />
 {% endblock %}
 
 {% block title %}
@@ -150,30 +140,26 @@
 
 {# Local scripts #}
 {% block scripts %}
-    {% compress js %}
     <!-- Twitter Bootstrap -->
     <script type="text/javascript" src="{% static "oscar/js/bootstrap/bootstrap.min.js" %}"></script>
     <!-- Oscar -->
     <script src="{% static "oscar/js/oscar/ui.js" %}" type="text/javascript" charset="utf-8"></script>
-    {% endcompress %}
 {% endblock %}
 
 {% block extrascripts %}
     {{ block.super }}
 
 
-    {% compress js %}
-        {# jQuery plugins #}
-        {% block jquery-ui-js %}
-            <script src="{% static "oscar/js/jquery-ui/jquery-ui.js" %}" type="text/javascript" charset="utf-8"></script>
-        {% endblock %}
-        <script src="{% static "oscar/js/mousewheel/jquery.mousewheel.min.js" %}" type="text/javascript" charset="utf-8"></script>
-        <script src="{% static "oscar/js/bootstrap-datetimepicker/bootstrap-datetimepicker.js" %}" type="text/javascript" charset="utf-8"></script>
-        <script src="{% static "oscar/js/bootstrap-datetimepicker/locales/bootstrap-datetimepicker.all.js" %}" type="text/javascript" charset="utf-8"></script>
-        <script src="{% static "oscar/js/inputmask/jquery.inputmask.bundle.min.js" %}" type="text/javascript" charset="utf-8"></script>
-        <script src="{% static "oscar/js/select2/select2.js" %}" type="text/javascript" charset="utf-8"></script>
-        <script src="{% static "oscar/js/oscar/dashboard.js" %}" type="text/javascript" charset="utf-8"></script>
-    {% endcompress %}
+    {# jQuery plugins #}
+    {% block jquery-ui-js %}
+        <script src="{% static "oscar/js/jquery-ui/jquery-ui.js" %}" type="text/javascript" charset="utf-8"></script>
+    {% endblock %}
+    <script src="{% static "oscar/js/mousewheel/jquery.mousewheel.min.js" %}" type="text/javascript" charset="utf-8"></script>
+    <script src="{% static "oscar/js/bootstrap-datetimepicker/bootstrap-datetimepicker.js" %}" type="text/javascript" charset="utf-8"></script>
+    <script src="{% static "oscar/js/bootstrap-datetimepicker/locales/bootstrap-datetimepicker.all.js" %}" type="text/javascript" charset="utf-8"></script>
+    <script src="{% static "oscar/js/inputmask/jquery.inputmask.bundle.min.js" %}" type="text/javascript" charset="utf-8"></script>
+    <script src="{% static "oscar/js/select2/select2.js" %}" type="text/javascript" charset="utf-8"></script>
+    <script src="{% static "oscar/js/oscar/dashboard.js" %}" type="text/javascript" charset="utf-8"></script>
 
     {# We don't use a fallback for tinyMCE as it dynamically loads several other files #}
     <script src="//tinymce.cachefly.net/4.0/tinymce.min.js" type="text/javascript" charset="utf-8"></script>

--- a/src/oscar/templates/oscar/dashboard/layout.html
+++ b/src/oscar/templates/oscar/dashboard/layout.html
@@ -140,6 +140,7 @@
 
 {# Local scripts #}
 {% block scripts %}
+    {{ block.super }}
     <!-- Twitter Bootstrap -->
     <script type="text/javascript" src="{% static "oscar/js/bootstrap/bootstrap.min.js" %}"></script>
     <!-- Oscar -->

--- a/src/oscar/templates/oscar/dashboard/layout.html
+++ b/src/oscar/templates/oscar/dashboard/layout.html
@@ -14,11 +14,11 @@
 {% block extrastyles %}
     {{ block.super }}
     {% block jquery-ui-css %}
-        <link rel="stylesheet" href="{% static "oscar/js/jquery-ui/jquery-ui.css" %}">
+        <link rel="stylesheet" href="{% static "oscar/js/jquery-ui/jquery-ui.min.css" %}">
     {% endblock %}
     <link rel="stylesheet" href="{% static "oscar/js/select2/select2.css" %}" />
     <link rel="stylesheet" href="{% static "oscar/css/select2-bootstrap.css" %}" />
-    <link rel="stylesheet" href="{% static "oscar/js/bootstrap-datetimepicker/bootstrap-datetimepicker.css" %}" />
+    <link rel="stylesheet" href="{% static "oscar/js/bootstrap-datetimepicker/bootstrap-datetimepicker.min.css" %}" />
 {% endblock %}
 
 {% block title %}
@@ -153,10 +153,10 @@
 
     {# jQuery plugins #}
     {% block jquery-ui-js %}
-        <script src="{% static "oscar/js/jquery-ui/jquery-ui.js" %}" type="text/javascript" charset="utf-8"></script>
+        <script src="{% static "oscar/js/jquery-ui/jquery-ui.min.js" %}" type="text/javascript" charset="utf-8"></script>
     {% endblock %}
     <script src="{% static "oscar/js/mousewheel/jquery.mousewheel.min.js" %}" type="text/javascript" charset="utf-8"></script>
-    <script src="{% static "oscar/js/bootstrap-datetimepicker/bootstrap-datetimepicker.js" %}" type="text/javascript" charset="utf-8"></script>
+    <script src="{% static "oscar/js/bootstrap-datetimepicker/bootstrap-datetimepicker.min.js" %}" type="text/javascript" charset="utf-8"></script>
     <script src="{% static "oscar/js/bootstrap-datetimepicker/locales/bootstrap-datetimepicker.all.js" %}" type="text/javascript" charset="utf-8"></script>
     <script src="{% static "oscar/js/inputmask/jquery.inputmask.bundle.min.js" %}" type="text/javascript" charset="utf-8"></script>
     <script src="{% static "oscar/js/select2/select2.js" %}" type="text/javascript" charset="utf-8"></script>

--- a/src/oscar/templates/oscar/layout.html
+++ b/src/oscar/templates/oscar/layout.html
@@ -1,17 +1,10 @@
 {% extends "base.html" %}
 {% load staticfiles %}
-{% load compress %}
 {% load promotion_tags %}
 
 {% block mainstyles %}
     {% block styles %}
-        {% compress css %}
-            {% if use_less %}
-                <link rel="stylesheet" type="text/less" href="{% static "oscar/less/styles.less" %}" />
-            {% else %}
-                <link rel="stylesheet" type="text/css" href="{% static "oscar/css/styles.css" %}" />
-            {% endif %}
-        {% endcompress %}
+        <link rel="stylesheet" type="text/css" href="{% static "oscar/css/styles.css" %}" />
     {% endblock %}
 {% endblock %}
 
@@ -68,12 +61,10 @@
 {# Local scripts #}
 {% block scripts %}
     {{ block.super }}
-    {% compress js %}
     <!-- Twitter Bootstrap -->
     <script type="text/javascript" src="{% static "oscar/js/bootstrap3/bootstrap.min.js" %}"></script>
     <!-- Oscar -->
     <script src="{% static "oscar/js/oscar/ui.js" %}" type="text/javascript" charset="utf-8"></script>
-    {% endcompress %}
 {% endblock %}
 
 {% block extrascripts %}

--- a/src/oscar/templates/oscar/partials/extrascripts.html
+++ b/src/oscar/templates/oscar/partials/extrascripts.html
@@ -1,5 +1,1 @@
 {% load staticfiles %}
-{% load compress %}
-
-{% compress js %}
-{% endcompress %}

--- a/tests/config.py
+++ b/tests/config.py
@@ -30,7 +30,6 @@ def configure():
               'django.contrib.sites',
                 'django.contrib.flatpages',
                 'django.contrib.staticfiles',
-                'compressor',
                 'widget_tweaks',
                 'tests._site.model_tests_app',  # contains models we need for testing
                 'tests._site.myauth',
@@ -86,8 +85,6 @@ def configure():
             'ROOT_URLCONF': 'tests._site.urls',
             'LOGIN_REDIRECT_URL': '/accounts/',
             'STATIC_URL': '/static/',
-            'COMPRESS_ENABLED': False,
-            'COMPRESS_ROOT': '',  # needed to avoid issue #1214
             'DEBUG': False,
             'SITE_ID': 1,
             'USE_TZ': 1,


### PR DESCRIPTION
And replace it with a gulp file that automatically rebuilds the css when the less files change and possibly more bells and whistles.

I feel that django-compressor adds too much runtime complexity for frontend developer convenience that she is now used to getting from gulp and friends. Also, gulp and friends do a much better job at being convenient for the modern frontend developer:

- sourcemap support
- freedom of choice to use or not use django-compressor in the frontend. Right now if you want to use django-compressor in the frontend, you have to use it in the dashboard as well.
- no confusion and complexity arising from the fact that django-compressor parses templates outside of their normal context, bypassing inheritance (Blocks `jquery-ui-(js|css)` by yours truly)

I'm implementing this as we speak.

Concerns #796.