### PR TITLE
replace reference to django admin with oscar dashboard

### DIFF
--- a/docs/source/internals/getting_started.rst
+++ b/docs/source/internals/getting_started.rst
@@ -309,8 +309,12 @@ and one
 :class:`fulfillment partner <oscar.apps.partner.abstract_models.AbstractPartner>`.
 These aren't created automatically as they're highly specific to the shop you
 want to build.
-The quickest way to set them up is to log into the Django admin
-interface at http://127.0.0.1:8000/admin/ and create instances of both there.
+
+It is important to note that the Django admin site is not fully compatible with
+Oscar's model customisations. When managing your catalogue you should always use
+the Oscar dashboard, which provides the necessary functionality. Login to:
+http://127.0.0.1:8000/dashboard/ and create instances of both there.
+
 For a deployment setup, we recommend creating them as `data migration`_.
 
 .. _`data migration`: http://codeinthehole.com/writing/prefer-data-migrations-to-initial-data/


### PR DESCRIPTION
Current docs were a source of confusion for new users, as noted in this thread:
https://groups.google.com/forum/#!msg/django-oscar/8mfHbZcTAQI/ifpJiegYByoJ
