### PR TITLE
Piper/make overriding search handler easier

### DIFF
--- a/docs/source/ref/settings.rst
+++ b/docs/source/ref/settings.rst
@@ -101,6 +101,14 @@ query-type facets.  The default is::
         ]),
     }
 
+``OSCAR_PRODUCT_SEARCH_HANDLER``
+-----------------------
+
+The search handler to be used in the product list views.
+
+Default::
+
+    None
 
 ``OSCAR_PROMOTION_POSITIONS``
 -----------------------------

--- a/src/oscar/apps/catalogue/search_handlers.py
+++ b/src/oscar/apps/catalogue/search_handlers.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.views.generic.list import MultipleObjectMixin
 
-from oscar.core.loading import get_class, get_model
+from oscar.core.loading import get_class, get_model, import_string
 
 BrowseCategoryForm = get_class('search.forms', 'BrowseCategoryForm')
 SearchHandler = get_class('search.search_handlers', 'SearchHandler')
@@ -18,6 +18,8 @@ def get_product_search_handler_class():
     back to rudimentary category browsing if that isn't enabled.
     """
     # Use get_class to ensure overridability
+    if settings.OSCAR_PRODUCT_SEARCH_HANDLER is not None:
+        return import_string(settings.OSCAR_PRODUCT_SEARCH_HANDLER)
     if is_solr_supported():
         return get_class('catalogue.search_handlers', 'ProductSearchHandler')
     elif is_elasticsearch_supported():

--- a/src/oscar/apps/search/features.py
+++ b/src/oscar/apps/search/features.py
@@ -6,3 +6,10 @@ def is_solr_supported():
         return 'Solr' in settings.HAYSTACK_CONNECTIONS['default']['ENGINE']
     except (KeyError, AttributeError):
         return False
+
+
+def is_elasticsearch_supported():
+    try:
+        return 'Elasticsearch' in settings.HAYSTACK_CONNECTIONS['default']['ENGINE']
+    except (KeyError, AttributeError):
+        return False

--- a/src/oscar/defaults.py
+++ b/src/oscar/defaults.py
@@ -236,5 +236,7 @@ OSCAR_SEARCH_FACETS = {
     ]),
 }
 
+OSCAR_PRODUCT_SEARCH_HANDLER = None
+
 OSCAR_SETTINGS = dict(
     [(k, v) for k, v in locals().items() if k.startswith('OSCAR_')])

--- a/tests/unit/catalogue/test_product_search_handler_setting.py
+++ b/tests/unit/catalogue/test_product_search_handler_setting.py
@@ -1,0 +1,23 @@
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from oscar.apps.catalogue.search_handlers import (
+    get_product_search_handler_class,
+)
+
+class TestSearchHandler(object):
+    pass
+
+
+class TestProductSearchHandlerSetting(TestCase):
+    def test_product_search_handler_setting(self):
+        """
+        Test that the `OSCAR_PRODUCT_SEARCH_HANDLER` setting, when set,
+        dictates the return value of the `get_product_search_handler_class`
+        function.
+        """
+        handler_override = 'tests.unit.catalogue.test_product_search_handler_setting.TestSearchHandler'
+        with override_settings(OSCAR_PRODUCT_SEARCH_HANDLER=handler_override):
+            handler_class = get_product_search_handler_class()
+
+        assert handler_class == TestSearchHandler


### PR DESCRIPTION
### What is the problem / feature ?

- No faceting support for the Elasticsearch on product listing pages (`CatalogueView` and `ProductCategoryView`)
- No easy way to specify the desired search handler class without heavy overrides.

### How did it get fixed / implemented ?

- Implemented a new search handler `ElasticsearchSearchHandler` which supports faceting for the Elasticsearch backend.
- Added a new setting `OSCAR_PRODUCT_SEARCH_HANDLER` which can be used to specify exactly what search handle you wish to use for listing pages.

Fixes #1566 


*Here is a cute animal picture for your troubles...*

![thanksgivingday-dog-and-cat 1 _2_crop](https://cloud.githubusercontent.com/assets/824194/5147678/bc1a1c64-7174-11e4-8e87-9d8ae421f582.jpg)
