### PR TITLE
Css/less and javascript  blocks are not available for checkout templates.

### DIFF
--- a/oscar/templates/oscar/checkout/layout.html
+++ b/oscar/templates/oscar/checkout/layout.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "layout.html" %}
 {% load i18n %}
 {% load promotion_tags %}
 {% load category_tags %}


### PR DESCRIPTION
The `checkout/layout.html` template should not bypass the `layout.html` template.
