### PR TITLE
Fix and deprecate min_child_price_* properties

### DIFF
--- a/docs/source/releases/v1.0.1.rst
+++ b/docs/source/releases/v1.0.1.rst
@@ -7,16 +7,20 @@ This is Oscar 1.0.1, a bug fix release.
 Bug fixes
 =========
 
+* `#1553`_: ``from oscar.apps.partner.models import *`` could lead to the
+  wrong models being imported.
+
 * `#1556`_: Dashboard order table headers shifted
 
 * `#1577`_: The billing address was not being correctly passed through to the
   `place_order` method.
 
-* `#1553`_: ``from oscar.apps.partner.models import *`` could lead to the
-  wrong models being imported.
+* `#1592`_: ``Product.min_child_price_[excl|incl]_tax`` were broken and
+  failing loudly. They are not recommended any more, but to ensure
+  backwards-compatibility, they have been fixed.
 
-
-  .. _#1556: https://github.com/django-oscar/django-oscar/issues/1556
   .. _#1553: https://github.com/django-oscar/django-oscar/issues/1553
+  .. _#1556: https://github.com/django-oscar/django-oscar/issues/1556
   .. _#1577: https://github.com/django-oscar/django-oscar/issues/1577
+  .. _#1592: https://github.com/django-oscar/django-oscar/issues/1592
 


### PR DESCRIPTION
They are from a time when we had one stockrecord per product, and no
strategy classes. They're used for visual purposes only, and were
forgotten when the codebase was updated. They failed loudly, as reported
in #1592.

We really need to either drop them or add a helper method to the
strategy class, but to ensure backwards-compatibility, I've
re-implemented the naive approach of just sorting by price; blindly
ignoring the many shortcomings.

I also added a deprecation notice.
