### PR TITLE
Fix is_safe_url checks

### DIFF
--- a/docs/source/releases/v1.0.1.rst
+++ b/docs/source/releases/v1.0.1.rst
@@ -9,6 +9,13 @@ Bug fixes
 
 * `#1556`_: Dashboard order table headers shifted
 
+* `#1557`_: Fixed an issue where Oscar wrongly used Django's ``is_safe_url``.
+  Hence some redirects might not have worked as expected. This change
+  unfortunately meant updating the notation of
+  :meth:`oscar.core.utils.safe_referrer` and
+  :meth:`oscar.core.utils.redirect_to_referrer` to accept the request instead
+  of request.META.
+
 * `#1577`_: The billing address was not being correctly passed through to the
   `place_order` method.
 
@@ -17,6 +24,7 @@ Bug fixes
 
 
   .. _#1556: https://github.com/django-oscar/django-oscar/issues/1556
+  .. _#1557: https://github.com/django-oscar/django-oscar/issues/1557
   .. _#1553: https://github.com/django-oscar/django-oscar/issues/1553
   .. _#1577: https://github.com/django-oscar/django-oscar/issues/1577
 

--- a/oscar/apps/basket/views.py
+++ b/oscar/apps/basket/views.py
@@ -187,7 +187,7 @@ class BasketView(ModelFormSetView):
         return context
 
     def get_success_url(self):
-        return safe_referrer(self.request.META, 'basket:summary')
+        return safe_referrer(self.request, 'basket:summary')
 
     def formset_valid(self, formset):
         # Store offers before any changes are made so we can inform the user of
@@ -316,7 +316,7 @@ class BasketAddView(FormView):
         clean_msgs = [m.replace('* ', '') for m in msgs if m.startswith('* ')]
         messages.error(self.request, ",".join(clean_msgs))
 
-        return redirect_to_referrer(self.request.META, 'basket:summary')
+        return redirect_to_referrer(self.request, 'basket:summary')
 
     def form_valid(self, form):
         offers_before = self.request.basket.applied_offers()
@@ -346,9 +346,9 @@ class BasketAddView(FormView):
 
     def get_success_url(self):
         post_url = self.request.POST.get('next')
-        if post_url and is_safe_url(post_url):
+        if post_url and is_safe_url(post_url, self.request.get_host()):
             return post_url
-        return safe_referrer(self.request.META, 'basket:summary')
+        return safe_referrer(self.request, 'basket:summary')
 
 
 class VoucherAddView(FormView):
@@ -402,7 +402,7 @@ class VoucherAddView(FormView):
     def form_valid(self, form):
         code = form.cleaned_data['code']
         if not self.request.basket.id:
-            return redirect_to_referrer(self.request.META, 'basket:summary')
+            return redirect_to_referrer(self.request, 'basket:summary')
         if self.request.basket.contains_voucher(code):
             messages.error(
                 self.request,
@@ -418,7 +418,7 @@ class VoucherAddView(FormView):
                         'code': code})
             else:
                 self.apply_voucher_to_basket(voucher)
-        return redirect_to_referrer(self.request.META, 'basket:summary')
+        return redirect_to_referrer(self.request, 'basket:summary')
 
     def form_invalid(self, form):
         messages.error(self.request, _("Please enter a voucher code"))
@@ -474,7 +474,7 @@ class SavedView(ModelFormSetView):
             return []
 
     def get_success_url(self):
-        return safe_referrer(self.request.META, 'basket:summary')
+        return safe_referrer(self.request, 'basket:summary')
 
     def get_formset_kwargs(self):
         kwargs = super(SavedView, self).get_formset_kwargs()
@@ -512,4 +512,4 @@ class SavedView(ModelFormSetView):
             '\n'.join(
                 error for ed in formset.errors for el
                 in ed.values() for error in el))
-        return redirect_to_referrer(self.request.META, 'basket:summary')
+        return redirect_to_referrer(self.request, 'basket:summary')

--- a/oscar/apps/catalogue/reviews/views.py
+++ b/oscar/apps/catalogue/reviews/views.py
@@ -99,7 +99,7 @@ class AddVoteView(View):
             for error_list in form.errors.values():
                 for msg in error_list:
                     messages.error(request, msg)
-        return redirect_to_referrer(request.META, product.get_absolute_url())
+        return redirect_to_referrer(request, product.get_absolute_url())
 
 
 class ProductReviewList(ListView):

--- a/oscar/apps/customer/forms.py
+++ b/oscar/apps/customer/forms.py
@@ -107,7 +107,7 @@ class EmailAuthenticationForm(AuthenticationForm):
 
     def clean_redirect_url(self):
         url = self.cleaned_data['redirect_url'].strip()
-        if url and is_safe_url(url):
+        if url and is_safe_url(url, self.host):
             return url
 
 
@@ -169,7 +169,7 @@ class EmailUserCreationForm(forms.ModelForm):
 
     def clean_redirect_url(self):
         url = self.cleaned_data['redirect_url'].strip()
-        if url and is_safe_url(url):
+        if url and is_safe_url(url, self.host):
             return url
         return settings.LOGIN_REDIRECT_URL
 

--- a/oscar/apps/customer/notifications/views.py
+++ b/oscar/apps/customer/notifications/views.py
@@ -82,7 +82,7 @@ class UpdateView(BulkEditMixin, generic.RedirectView):
 
     def get_success_response(self):
         return redirect_to_referrer(
-            self.request.META, 'customer:notifications-inbox')
+            self.request, 'customer:notifications-inbox')
 
     def archive(self, request, notifications):
         for notification in notifications:

--- a/oscar/apps/customer/views.py
+++ b/oscar/apps/customer/views.py
@@ -79,7 +79,7 @@ class AccountRegistrationView(RegisterUserMixin, generic.FormView):
     def get_context_data(self, *args, **kwargs):
         ctx = super(AccountRegistrationView, self).get_context_data(
             *args, **kwargs)
-        ctx['cancel_url'] = safe_referrer(self.request.META, '')
+        ctx['cancel_url'] = safe_referrer(self.request, '')
         return ctx
 
     def form_valid(self, form):

--- a/oscar/apps/customer/wishlists/views.py
+++ b/oscar/apps/customer/wishlists/views.py
@@ -146,7 +146,7 @@ class WishListCreateWithProductView(View):
         messages.success(
             request, _("%(title)s has been added to your wishlist") % {
                 'title': product.get_title()})
-        return redirect_to_referrer(request.META, wishlist.get_absolute_url())
+        return redirect_to_referrer(request, wishlist.get_absolute_url())
 
 
 class WishListUpdateView(PageTitleMixin, UpdateView):
@@ -236,7 +236,7 @@ class WishListAddProduct(View):
         msg = _("'%s' was added to your wish list.") % self.product.get_title()
         messages.success(self.request, msg)
         return redirect_to_referrer(
-            self.request.META, self.product.get_absolute_url())
+            self.request, self.product.get_absolute_url())
 
 
 class LineMixin(object):
@@ -289,7 +289,7 @@ class WishListRemoveProduct(LineMixin, PageTitleMixin, DeleteView):
 
         # We post directly to this view on product pages; and should send the
         # user back there if that was the case
-        referrer = safe_referrer(self.request.META, '')
+        referrer = safe_referrer(self.request, '')
         if (referrer and self.product and
                 self.product.get_absolute_url() in referrer):
             return referrer
@@ -322,4 +322,4 @@ class WishListMoveProductToAnotherWishList(LineMixin, View):
 
         default_url = reverse(
             'customer:wishlists-detail', kwargs={'key': self.wishlist.key})
-        return redirect_to_referrer(self.request.META, default_url)
+        return redirect_to_referrer(self.request, default_url)

--- a/oscar/core/utils.py
+++ b/oscar/core/utils.py
@@ -85,33 +85,33 @@ def format_datetime(dt, format=None):
     return date_filter(localtime, format)
 
 
-def safe_referrer(meta, default):
+def safe_referrer(request, default):
     """
-    Takes request.META and a default URL. Returns HTTP_REFERER if it's safe
+    Takes the request and a default URL. Returns HTTP_REFERER if it's safe
     to use and set, and the default URL otherwise.
 
     The default URL can be a model with get_absolute_url defined, a urlname
     or a regular URL
     """
-    referrer = meta.get('HTTP_REFERER')
-    if referrer and is_safe_url(referrer):
+    referrer = request.META.get('HTTP_REFERER')
+    if referrer and is_safe_url(referrer, request.get_host()):
         return referrer
     if default:
-        # try to resolve
+        # Try to resolve. Can take a model instance, Django URL name or URL.
         return resolve_url(default)
     else:
         # Allow passing in '' and None as default
         return default
 
 
-def redirect_to_referrer(meta, default):
+def redirect_to_referrer(request, default):
     """
     Takes request.META and a default URL to redirect to.
 
     Returns a HttpResponseRedirect to HTTP_REFERER if it exists and is a safe
     URL; to the default URL otherwise.
     """
-    return redirect(safe_referrer(meta, default))
+    return redirect(safe_referrer(request, default))
 
 
 def get_default_currency():

--- a/oscar/views/generic.py
+++ b/oscar/views/generic.py
@@ -58,10 +58,10 @@ class BulkEditMixin(object):
         return smart_str(self.model._meta.object_name.lower())
 
     def get_error_url(self, request):
-        return safe_referrer(request.META, '.')
+        return safe_referrer(request, '.')
 
     def get_success_url(self, request):
-        return safe_referrer(request.META, '.')
+        return safe_referrer(request, '.')
 
     def post(self, request, *args, **kwargs):
         # Dynamic dispatch pattern - we forward POST requests onto a method


### PR DESCRIPTION
Unfortunately, I completely missed the host argument to is_safe_url.
Without it, the check will have always returned False (see #1557).

This change fixes this behaviour. Unfortunately, it does require
changing the notation of the safe_referrer and redirect_to_referrer
utility functions.
