### PR TITLE
Generator.generate() does not provide arguments

### DIFF
--- a/src/oscar/apps/dashboard/reports/reports.py
+++ b/src/oscar/apps/dashboard/reports/reports.py
@@ -33,7 +33,7 @@ class ReportGenerator(object):
                'end_date': self.end_date,
                }
 
-    def generate(self, response):
+    def generate(self):
         pass
 
     def filename(self):


### PR DESCRIPTION
Hi,

In a project we've created a custom report which implements this class. the view calling this functionality does not provide a "respose" argument.

https://github.com/django-oscar/django-oscar/blob/master/src/oscar/apps/dashboard/reports/views.py#L43