### PR TITLE
Raise a ValueError if a string is passed to get_core_apps

### DIFF
--- a/src/oscar/__init__.py
+++ b/src/oscar/__init__.py
@@ -1,4 +1,5 @@
 import os
+import six
 
 # Use 'dev', 'beta', or 'final' as the 4th element to indicate release type.
 
@@ -73,6 +74,11 @@ def get_core_apps(overrides=None):
     """
     if not overrides:
         return OSCAR_CORE_APPS
+
+    if isinstance(overrides, six.string_types):
+        raise ValueError(
+            "get_core_apps expects a list or tuple of apps "
+            "to override")
 
     def get_app_label(app_label, overrides):
         pattern = app_label.replace('oscar.apps.', '')

--- a/tests/unit/settings_tests.py
+++ b/tests/unit/settings_tests.py
@@ -19,6 +19,10 @@ class TestOscarCoreAppsList(TestCase):
         self.assertTrue('apps.shipping' in apps)
         self.assertTrue('oscar.apps.shipping' not in apps)
 
+    def test_raises_exception_for_string_arg(self):
+        with self.assertRaises(ValueError):
+            oscar.get_core_apps('forks.catalogue')
+
 
 class TestOscarTemplateSettings(TestCase):
     """


### PR DESCRIPTION
It's such a common error, we should try and give a friendly error message when it occurs.