### PR TITLE
Fix existing_user_fields ordering

### DIFF
--- a/src/oscar/core/compat.py
+++ b/src/oscar/core/compat.py
@@ -67,7 +67,9 @@ def existing_user_fields(fields):
     """
     user_fields = get_user_model()._meta.fields
     user_field_names = [field.name for field in user_fields]
-    return list(set(fields) & set(user_field_names))
+
+    # return only fileds that exist in user model
+    return [field for field in fields if field in user_field_names]
 
 
 # Python3 compatibility layer

--- a/tests/unit/core/compat_tests.py
+++ b/tests/unit/core/compat_tests.py
@@ -7,7 +7,13 @@ import unittest
 import django
 from django.test import TestCase
 
-from oscar.core.compat import UnicodeCSVWriter
+from oscar.core.compat import UnicodeCSVWriter, existing_user_fields
+
+class TestExistingUserFields(TestCase):
+
+    def test_order(self):
+        fields = existing_user_fields(['email', 'first_name', 'last_name'])
+        self.assertEqual(fields, ['email', 'first_name', 'last_name'])
 
 
 class TestUnicodeCSVWriter(TestCase):


### PR DESCRIPTION
Working on sets causes a random order of returned fields while using
existing_user_fields as reported in django-oscar/django-oscar#1597.
Changed to work only on lists, which remain correct
order.