### PR TITLE
Better abstract forms

### DIFF
--- a/oscar/apps/address/abstract_forms.py
+++ b/oscar/apps/address/abstract_forms.py
@@ -1,0 +1,14 @@
+from django.conf import settings
+from django import forms
+
+class AbstractAddressForm(forms.ModelForm):
+
+    def __init__(self, *args, **kwargs):
+        """
+        Set fields in OSCAR_REQUIRED_ADDRESS_FIELDS as required.
+        """
+        super(AbstractAddressForm, self).__init__(*args, **kwargs)
+        field_names = (set(self.fields) &
+                       set(settings.OSCAR_REQUIRED_ADDRESS_FIELDS))
+        for field_name in field_names:
+            self.fields[field_name].required = True

--- a/oscar/apps/address/forms.py
+++ b/oscar/apps/address/forms.py
@@ -1,23 +1,10 @@
-from django.conf import settings
-from django import forms
 
-from oscar.core.loading import get_model
+from oscar.core.loading import get_class, get_model
 from oscar.views.generic import PhoneNumberMixin
 
 UserAddress = get_model('address', 'useraddress')
 
-
-class AbstractAddressForm(forms.ModelForm):
-
-    def __init__(self, *args, **kwargs):
-        """
-        Set fields in OSCAR_REQUIRED_ADDRESS_FIELDS as required.
-        """
-        super(AbstractAddressForm, self).__init__(*args, **kwargs)
-        field_names = (set(self.fields) &
-                       set(settings.OSCAR_REQUIRED_ADDRESS_FIELDS))
-        for field_name in field_names:
-            self.fields[field_name].required = True
+AbstractAddressForm = get_class('address.abstract_forms', 'AbstractAddressForm')
 
 
 class UserAddressForm(PhoneNumberMixin, AbstractAddressForm):

--- a/oscar/apps/checkout/forms.py
+++ b/oscar/apps/checkout/forms.py
@@ -3,15 +3,16 @@ from oscar.core.loading import get_model
 from django.contrib.auth.forms import AuthenticationForm
 from django.utils.translation import ugettext_lazy as _
 
-from oscar.apps.address.forms import AbstractAddressForm
 from oscar.apps.customer.utils import normalise_email
 from oscar.core.compat import get_user_model
+from oscar.core.loading import get_class
 
 from oscar.views.generic import PhoneNumberMixin
 
 User = get_user_model()
 Country = get_model('address', 'Country')
 
+AbstractAddressForm = get_class('address.abstract_forms', 'AbstractAddressForm')
 
 class ShippingAddressForm(PhoneNumberMixin, AbstractAddressForm):
 

--- a/oscar/apps/checkout/views.py
+++ b/oscar/apps/checkout/views.py
@@ -7,7 +7,6 @@ from django.contrib.auth import login
 from django.core.urlresolvers import reverse, reverse_lazy
 from django.utils.translation import ugettext as _
 from django.utils import six
-from django.utils.http import urlquote
 from django.views import generic
 
 from oscar.apps.shipping.methods import NoShippingRequired
@@ -92,7 +91,7 @@ class IndexView(CheckoutSessionMixin, generic.FormView):
                 self.success_url = "%s?next=%s&email=%s" % (
                     reverse('customer:register'),
                     reverse('checkout:shipping-address'),
-                    urlquote(email)
+                    email
                 )
         else:
             user = form.get_user()

--- a/oscar/apps/checkout/views.py
+++ b/oscar/apps/checkout/views.py
@@ -8,7 +8,6 @@ from django.core.urlresolvers import reverse, reverse_lazy
 from django.utils.translation import ugettext as _
 from django.utils import six
 from django.utils.http import urlquote
-
 from django.views import generic
 
 from oscar.apps.shipping.methods import NoShippingRequired

--- a/oscar/apps/checkout/views.py
+++ b/oscar/apps/checkout/views.py
@@ -7,6 +7,8 @@ from django.contrib.auth import login
 from django.core.urlresolvers import reverse, reverse_lazy
 from django.utils.translation import ugettext as _
 from django.utils import six
+from django.utils.http import urlquote
+
 from django.views import generic
 
 from oscar.apps.shipping.methods import NoShippingRequired
@@ -91,7 +93,7 @@ class IndexView(CheckoutSessionMixin, generic.FormView):
                 self.success_url = "%s?next=%s&email=%s" % (
                     reverse('customer:register'),
                     reverse('checkout:shipping-address'),
-                    email
+                    urlquote(email)
                 )
         else:
             user = form.get_user()


### PR DESCRIPTION
Move `AbstractAddressForm` to its own file and have `UserAddressForm` and `ShippingAddressForm` subclass `AbstractAddressForm` dynamically.

This will let a user to override `AbstractAddressForm`, so that both forms can be customized simultaneously.

Fixes https://github.com/django-oscar/django-oscar/issues/1609