### PR TITLE
Wrong data in orders.csv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ settings_local.py
 /sites/demo/public/
 /sites/demo/whoosh_index/
 /sites/demo/logs/
+/sites/us/*.sqlite
 /sites/us/public/
 /sites/us/logs/
 sites/puppet/modules/

--- a/src/oscar/apps/dashboard/orders/views.py
+++ b/src/oscar/apps/dashboard/orders/views.py
@@ -357,7 +357,7 @@ class OrderListView(BulkEditMixin, ListView):
                 row['billing_address_name'] = order.billing_address.name
             else:
                 row['billing_address_name'] = ''
-            writer.writerow(row)
+            writer.writerow(row.values())
         return response
 
     def change_order_statuses(self, request, orders):

--- a/src/oscar/templates/oscar/dashboard/offers/offer_detail.html
+++ b/src/oscar/templates/oscar/dashboard/offers/offer_detail.html
@@ -122,7 +122,7 @@
                 {% endfor %}
             </tbody>
         </table>
-        {% include 'dashboard/partials/pagination.html' %}
+        {% include 'partials/pagination.html' %}
     {% endif %}
 
 {% endblock dashboard_content %}


### PR DESCRIPTION
When orders are downloaded as CSV in the dashboard, the generated rows contain the keys from <code>metadata</code> rather than orders' values. I updated the line that should pass the values to <code>UnicodeCSVWriter</code>.