### PR TITLE
Fix typo for unsuspend alters_data

### DIFF
--- a/src/oscar/apps/offer/models.py
+++ b/src/oscar/apps/offer/models.py
@@ -221,7 +221,7 @@ class ConditionalOffer(models.Model):
     def unsuspend(self):
         self.status = self.OPEN
         self.save()
-    suspend.alters_data = True
+    unsuspend.alters_data = True
 
     def is_available(self, user=None, test_date=None):
         """


### PR DESCRIPTION
The alters_data attribute on unsuspend is mistakenly written as suspend. This patch fixes this typo.