### PR TITLE
google analytics moved to head

### DIFF
--- a/oscar/templates/oscar/base.html
+++ b/oscar/templates/oscar/base.html
@@ -54,16 +54,16 @@
         {% block extrastyles %}{% endblock %}
 
         {% block extrahead %}{% endblock %}
-    </head>
-
-    <body id="{% block body_id %}default{% endblock %}" class="{% block body_class %}default{% endblock %}">
-        {# Main content goes in this 'layout' block #}
-        {% block layout %}{% endblock %}
 
         {% block tracking %}
             {# Default to using Google analytics #}
             {% include "partials/google_analytics.html" %}
         {% endblock %}
+    </head>
+
+    <body id="{% block body_id %}default{% endblock %}" class="{% block body_class %}default{% endblock %}">
+        {# Main content goes in this 'layout' block #}
+        {% block layout %}{% endblock %}
 
         {% comment %}
         Scripts loaded from a CDN.  These can't be wrapped by the 'compress' tag and so we


### PR DESCRIPTION
Google analytics tracking script moved from body to head as it is recommended by google:

https://support.google.com/analytics/answer/1008080?hl=en#GA

I don't know if proposed before but just to comment I don't find useful to track dashboard pages. Dashboard might use other base.html