### PR TITLE
Correct plural form translation for table caption

### DIFF
--- a/src/oscar/apps/dashboard/catalogue/tables.py
+++ b/src/oscar/apps/dashboard/catalogue/tables.py
@@ -1,5 +1,5 @@
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _, ugettext_noop
+from django.utils.translation import ugettext_lazy as _, ungettext_lazy
 
 from django_tables2 import Column, LinkColumn, TemplateColumn, A
 
@@ -64,8 +64,7 @@ class CategoryTable(DashboardTable):
         orderable=False)
 
     icon = "sitemap"
-    caption_singular = ugettext_noop("{count} Category")
-    caption_plural = ugettext_noop("{count} Categories")
+    caption = ungettext_lazy("%s Category",  "%s Categories")
 
     class Meta(DashboardTable.Meta):
         model = Category

--- a/src/oscar/apps/dashboard/tables.py
+++ b/src/oscar/apps/dashboard/tables.py
@@ -1,25 +1,19 @@
-from django.utils.translation import ungettext, ugettext_noop
+from django.utils.translation import ungettext_lazy
 
 from django_tables2 import Table
 
 
 class DashboardTable(Table):
-    _caption = None
-    caption_singular = ugettext_noop('{count} Row')
-    caption_plural = ugettext_noop('{count} Rows')
+    caption = ungettext_lazy('%d Row', '%d Rows')
 
-    @property
-    def caption(self):
-        if self._caption:
-            return self._caption
-
-        return (ungettext(self.caption_singular, self.caption_plural,
-                          self.paginator.count)
-                .format(count=self.paginator.count))
-
-    @caption.setter
-    def caption(self, caption):
-        self._caption = caption
+    def get_caption_display(self):
+        # Allow overriding the caption with an arbitrary string that we cannot
+        # interpolate the number of rows in
+        try:
+            return self.caption % self.paginator.count
+        except TypeError:
+            pass
+        return self.caption
 
     class Meta:
         template = 'dashboard/table.html'

--- a/src/oscar/templates/oscar/dashboard/table.html
+++ b/src/oscar/templates/oscar/dashboard/table.html
@@ -9,7 +9,7 @@
             {% if table.icon %}
               <i class="icon-{{ table.icon }} icon-large"></i>
             {% endif %}
-            {{ table.caption }}
+            {{ table.get_caption_display }}
         </h3>
     {% endblock %}
 </caption>


### PR DESCRIPTION
See https://github.com/django-oscar/django-oscar/commit/f51fa04d7fa0b12d59d4d1793593c490bf03b7bb#commitcomment-9330335

Thanks to @jerzyk for reporting

I'll test this at work and merge if it works.