### PR TITLE
Fix path in sandbox missing image symlink

### DIFF
--- a/sites/sandbox/public/media/image_not_found.jpg
+++ b/sites/sandbox/public/media/image_not_found.jpg
@@ -1,1 +1,1 @@
-../../../../oscar/static/oscar/img/image_not_found.jpg
+../../../../src/oscar/static/oscar/img/image_not_found.jpg


### PR DESCRIPTION
Steps to reproduce:
1) Follow the steps in the documentation to set up a sandbox (create the virtualenv, create the sandbox, and start the server).
2) Log in to `/dashboard` as the superuser.
3) Click "Manage" under "Catalogue and Stock"

Currently in master, this produces the following error: "Improperly configured at "/en-gb/dashboard/catalogue/"
![image](https://cloud.githubusercontent.com/assets/2948394/5868984/dae42ffe-a27f-11e4-93bb-4da08356902a.png)

This PR updates the path in the symlink so that the image displays correctly.

Please let me know if there is anything I can improve to get this merged.  Thanks!
-- Will
