### PR TITLE
Update checkout tests with new factories

### DIFF
--- a/src/oscar/apps/checkout/views.py
+++ b/src/oscar/apps/checkout/views.py
@@ -177,12 +177,6 @@ class ShippingAddressView(CheckoutSessionMixin, generic.FormView):
                 # User has selected a previous address to ship to
                 self.checkout_session.ship_to_user_address(address)
                 return redirect(self.get_success_url())
-            elif action == 'delete':
-                # Delete the selected address
-                address.delete()
-                messages.info(self.request, _("Address deleted from your"
-                                              " address book"))
-                return redirect(self.get_success_url())
             else:
                 return http.HttpResponseBadRequest()
         else:

--- a/src/oscar/templates/oscar/checkout/shipping_address.html
+++ b/src/oscar/templates/oscar/checkout/shipping_address.html
@@ -33,7 +33,7 @@
                                             {% endfor %}
                                         {% endblock %}
                                     </address>
-                                    <form action="{% url 'checkout:shipping-address' %}" method="post">
+                                    <form action="{% url 'checkout:shipping-address' %}" method="post" id="select_shipping_address_{{ address.id }}">
                                         {% csrf_token %}
                                         <input type="hidden" name="action" value="ship_to" />
                                         <input type="hidden" name="address_id" value="{{ address.id }}" />

--- a/src/oscar/templates/oscar/checkout/user_address_delete.html
+++ b/src/oscar/templates/oscar/checkout/user_address_delete.html
@@ -17,7 +17,7 @@
 {% block checkout_title %}{% trans "Delete address?" %}{% endblock %}
 
 {% block shipping_address %}
-    <form action="." method="post">
+    <form action="." method="post" id="delete_address_{{ object.id }}">
         {% csrf_token %}
         <div class="well">
             <address>

--- a/src/oscar/test/newfactories.py
+++ b/src/oscar/test/newfactories.py
@@ -17,6 +17,7 @@ import factory
 
 from oscar.core.loading import get_model, get_class
 from oscar.core.compat import get_user_model
+from oscar.core.phonenumber import PhoneNumber
 
 __all__ = ["UserFactory", "CountryFactory", "UserAddressFactory",
            "BasketFactory", "VoucherFactory", "ProductFactory",
@@ -59,6 +60,7 @@ class UserAddressFactory(factory.DjangoModelFactory):
     line1 = "1 King Road"
     line4 = "London"
     postcode = "SW1 9RE"
+    phone_number = PhoneNumber.from_string('+49 351 3296645')
     country = factory.SubFactory(CountryFactory)
     user = factory.SubFactory(UserFactory)
 

--- a/tests/functional/checkout/__init__.py
+++ b/tests/functional/checkout/__init__.py
@@ -2,23 +2,26 @@ from decimal import Decimal as D
 
 from django.core.urlresolvers import reverse
 
-from oscar.apps.address.models import Country
+from oscar.core.loading import get_model, get_class
 from oscar.test import factories
+
+UserAddress = get_model('address', 'UserAddress')
+Country = get_model('address', 'Country')
+GatewayForm = get_class('checkout.forms', 'GatewayForm')
 
 
 class CheckoutMixin(object):
 
     def create_digital_product(self):
-        product = factories.create_product(price=D('12.00'), num_in_stock=None)
-        product.product_class.requires_shipping = False
-        product.product_class.track_stock = False
-        product.product_class.save()
+        product_class = factories.ProductClassFactory(requires_shipping=False, track_stock=False)
+        product = factories.ProductFactory(product_class=product_class)
+        stock_record = factories.StockRecordFactory(num_in_stock=None, price_excl_tax=D('12.00'), product=product)
         return product
 
     def add_product_to_basket(self, product=None):
         if product is None:
-            product = factories.create_product(price=D('12.00'),
-                                               num_in_stock=10)
+            product = factories.ProductFactory()
+            stock_record = factories.StockRecordFactory(num_in_stock=10, price_excl_tax=D('12.00'), product=product)
         detail_page = self.get(product.get_absolute_url())
         form = detail_page.forms['add_to_basket_form']
         form.submit()
@@ -34,11 +37,12 @@ class CheckoutMixin(object):
     def enter_guest_details(self, email='guest@example.com'):
         index_page = self.get(reverse('checkout:index'))
         index_page.form['username'] = email
-        index_page.form.submit()
+        index_page.form.select('options', GatewayForm.GUEST)
+        return index_page.form.submit()
+
 
     def create_shipping_country(self):
-        Country.objects.get_or_create(
-            iso_3166_1_a2='GB', is_shipping_country=True)
+        return factories.CountryFactory(iso_3166_1_a2='GB', is_shipping_country=True)
 
     def enter_shipping_address(self):
         self.create_shipping_country()
@@ -59,3 +63,4 @@ class CheckoutMixin(object):
             reverse('checkout:shipping-method')).follow().follow()
         preview = payment_details.click(linkid="view_preview")
         return preview.forms['place_order_form'].submit().follow()
+

--- a/tests/functional/checkout/__init__.py
+++ b/tests/functional/checkout/__init__.py
@@ -64,3 +64,10 @@ class CheckoutMixin(object):
         preview = payment_details.click(linkid="view_preview")
         return preview.forms['place_order_form'].submit().follow()
 
+    def ready_to_place_an_order(self, is_guest=False):
+        self.add_product_to_basket()
+        if is_guest:
+            self.enter_guest_details('hello@egg.com')
+        self.enter_shipping_address()
+        payment_details = self.get(reverse('checkout:shipping-method')).follow().follow()
+        return payment_details.click(linkid="view_preview")

--- a/tests/functional/checkout/customer_checkout_tests.py
+++ b/tests/functional/checkout/customer_checkout_tests.py
@@ -1,10 +1,16 @@
+from __future__ import unicode_literals
 from django.core.urlresolvers import reverse
 
+from oscar.core.loading import get_model, get_class
+from oscar.test.newfactories import UserAddressFactory
 from oscar.test.testcases import WebTestCase
 from oscar.test import factories
-from oscar.apps.order.models import Order
-from oscar.apps.offer.models import ConditionalOffer
 from . import CheckoutMixin
+
+Order = get_model('order', 'Order')
+ConditionalOffer = get_model('offer', 'ConditionalOffer')
+UserAddress = get_model('address', 'UserAddress')
+GatewayForm = get_class('checkout.forms', 'GatewayForm')
 
 
 class TestIndexView(CheckoutMixin, WebTestCase):
@@ -26,8 +32,8 @@ class TestIndexView(CheckoutMixin, WebTestCase):
 class TestShippingAddressView(CheckoutMixin, WebTestCase):
 
     def setUp(self):
-        self.create_shipping_country()
         super(TestShippingAddressView, self).setUp()
+        self.user_address = UserAddressFactory(user=self.user, country=self.create_shipping_country())
 
     def test_requires_login(self):
         response = self.get(reverse('checkout:shipping-address'), user=None)
@@ -47,11 +53,50 @@ class TestShippingAddressView(CheckoutMixin, WebTestCase):
 
         session_data = self.app.session['checkout_data']
         session_fields = session_data['shipping']['new_address_fields']
-        self.assertEqual(u'Barry', session_fields['first_name'])
-        self.assertEqual(u'Chuckle', session_fields['last_name'])
-        self.assertEqual(u'1 King Street', session_fields['line1'])
-        self.assertEqual(u'Gotham City', session_fields['line4'])
-        self.assertEqual(u'N1 7RR', session_fields['postcode'])
+        self.assertEqual('Barry', session_fields['first_name'])
+        self.assertEqual('Chuckle', session_fields['last_name'])
+        self.assertEqual('1 King Street', session_fields['line1'])
+        self.assertEqual('Gotham City', session_fields['line4'])
+        self.assertEqual('N1 7RR', session_fields['postcode'])
+
+    def test_only_shipping_address_are_shown(self):
+        not_shipping_country = factories.CountryFactory(
+            iso_3166_1_a2='US', name="UNITED STATES", is_shipping_country=False)
+        not_shipping_address = UserAddressFactory(user=self.user, country=not_shipping_country, line4='New York')
+        self.add_product_to_basket()
+        page = self.get(reverse('checkout:shipping-address'))
+        page.mustcontain(self.user_address.line4, self.user_address.country.name,
+                         no=[not_shipping_address.country.name, not_shipping_address.line4])
+
+    def test_can_select_an_existing_shipping_address(self):
+        self.add_product_to_basket()
+        page = self.get(reverse('checkout:shipping-address'), user=self.user)
+        self.assertIsOk(page)
+        form = page.forms["select_shipping_address_%s" % self.user_address.id]
+        response = form.submit()
+        self.assertRedirectUrlName(response, 'checkout:shipping-method')
+
+
+class TestUserAddressUpdateView(CheckoutMixin, WebTestCase):
+
+    def setUp(self):
+        country = self.create_shipping_country()
+        super(TestUserAddressUpdateView, self).setUp()
+        self.user_address = UserAddressFactory(user=self.user, country=country)
+
+    def test_requires_login(self):
+        response = self.get(reverse('checkout:user-address-update', kwargs={'pk': self.user_address.pk}), user=None)
+        self.assertIsRedirect(response)
+
+    def test_submitting_valid_form_modifies_user_address(self):
+        page = self.get(reverse('checkout:user-address-update', kwargs={'pk': self.user_address.pk}),
+                        user=self.user)
+
+        form = page.forms['update_user_address']
+        form['first_name'] = 'Tom'
+        response = form.submit()
+        self.assertRedirectUrlName(response, 'checkout:shipping-address')
+        self.assertEqual('Tom', UserAddress.objects.get().first_name)
 
 
 class TestShippingMethodView(CheckoutMixin, WebTestCase):
@@ -65,6 +110,29 @@ class TestShippingMethodView(CheckoutMixin, WebTestCase):
         self.enter_shipping_address()
         response = self.get(reverse('checkout:shipping-method'))
         self.assertRedirectUrlName(response, 'checkout:payment-method')
+
+
+class TestDeleteUserAddressView(CheckoutMixin, WebTestCase):
+
+    def setUp(self):
+        super(TestDeleteUserAddressView, self).setUp()
+        self.country = self.create_shipping_country()
+        self.user_address = UserAddressFactory(user=self.user, country=self.country)
+
+    def test_requires_login(self):
+        response = self.get(reverse('checkout:user-address-delete', kwargs={'pk': self.user_address.pk}), user=None)
+        self.assertIsRedirect(response)
+
+    def test_can_delete_a_user_address_from_shipping_address_page(self):
+        self.add_product_to_basket()
+        page = self.get(reverse('checkout:shipping-address'), user=self.user)
+        delete_confirm = page.click(href=reverse('checkout:user-address-delete', kwargs={'pk': self.user_address.pk}))
+        form = delete_confirm.forms["delete_address_%s" % self.user_address.id]
+        form.submit()
+
+        # Ensure address is deleted
+        user_addresses = UserAddress.objects.filter(user=self.user)
+        self.assertEqual(0, len(user_addresses))
 
 
 class TestPreviewView(CheckoutMixin, WebTestCase):

--- a/tests/functional/customer/auth_tests.py
+++ b/tests/functional/customer/auth_tests.py
@@ -101,7 +101,7 @@ class TestAnAnonymousUser(WebTestCase):
         form['login-username'] = email
         form['login-password'] = password
         response = form.submit('login_submit')
-        self.assertRedirectsTo(response, 'customer:summary')
+        self.assertRedirectUrlName(response, 'customer:summary')
 
     def test_can_login(self):
         email, password = 'd@d.com', 'mypassword'
@@ -124,7 +124,7 @@ class TestAnAnonymousUser(WebTestCase):
         form['email'] = 'terry@boom.com'
         form['password1'] = form['password2'] = 'hedgehog'
         response = form.submit()
-        self.assertRedirectsTo(response, 'customer:summary')
+        self.assertRedirectUrlName(response, 'customer:summary')
 
     def test_casing_of_local_part_of_email_is_preserved(self):
         url = reverse('customer:register')
@@ -152,4 +152,4 @@ class TestAStaffUser(WebTestCase):
         form['login-password'] = self.password
         response = form.submit('login_submit')
 
-        self.assertRedirectsTo(response, 'dashboard:index')
+        self.assertRedirectUrlName(response, 'dashboard:index')


### PR DESCRIPTION
I  added fuctional tests to some checkout views: IndexView, ShippingAddressView, UserAddressUpdateView and DeleteUserAddressView.

There are some views left but in the meantime a test highlights that phonenumber is not working as expected with Python 3 and Django 1.6

```python
    def test_submitting_valid_form_modifies_user_address(self):
        page = self.get(reverse('checkout:user-address-update', kwargs={'pk': self.user_address.pk}),
                        user=self.user)
        form = page.forms['update_user_address']
        form['first_name'] = 'Tom'
        response = form.submit()
        self.assertRedirectUrlName(response, 'checkout:shipping-address')
        self.assertEqual('Tom', UserAddress.objects.get().first_name)
```
This test will fail:
```python
(Pdb) response
<200 OK text/html body=b'\n\n<!DO...l>\n'/14519>
(Pdb) response.form['phone_number'].value
'Country Code: 49 National Number: 3513296645 Country Code Source: 1 Preferred Domestic Carrier Code: '
```
It seems that the form is filled with the stringified  phone number object and so the submit fails.

```python
(Pdb) response.html
'(...)<span class="error-block"><i class="icon-exclamation-sign"></i> This is not a valid local or international phone format.</span>(...)'
```
I still have to figure out why this happens