### PR TITLE
i18n order search filters

### DIFF
--- a/src/oscar/static/oscar/js/oscar/dashboard.js
+++ b/src/oscar/static/oscar/js/oscar/dashboard.js
@@ -271,6 +271,19 @@ var oscar = (function(o, $) {
                         $('td:first input', this).prop("checked", $(input).is(':checked'));
                     });
                 });
+            },
+            initFilterToggle: function() {
+                $("#show_filters").on('click', function() {
+                    $("#filters").collapse('show');
+                    $("#show_filters").hide();
+                    $("#hide_filters").show();
+                });
+
+                $("#hide_filters").on('click', function() {
+                    $("#filters").collapse('hide');
+                    $("#hide_filters").hide();
+                    $("#show_filters").show();
+                });
             }
         },
         reordering: (function() {

--- a/src/oscar/templates/oscar/dashboard/orders/order_list.html
+++ b/src/oscar/templates/oscar/dashboard/orders/order_list.html
@@ -70,6 +70,18 @@
         </div>
     </div>
 
+    {% if search_filters %}
+        <a id="show_filters" href="#filters">{% trans "Show Filters" %}</a>
+        <a id="hide_filters" href="#filters" style="display:none">{% trans "Hide Filters" %}</a>
+        <div id="filters" class="collapse">
+            <ul>
+            {% for filter in search_filters %}
+                <li>{{ filter }}</li>
+            {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
+
     {% if orders %}
         <form action="." method="post" class="order_table" id="orders_form">
             {% csrf_token %}
@@ -78,7 +90,13 @@
             {% block order_list %}
             <table class="table table-striped table-bordered table-hover">
                 <caption>
-                    <h3 class="pull-left"><i class="icon-shopping-cart icon-large"></i>{{ queryset_description }}</h3>
+                    <h3 class="pull-left"><i class="icon-shopping-cart icon-large"></i>
+                        {% if search_filters %}
+                        {% trans "Order Search Results" %}
+                        {% else %}
+                        {% trans "All Orders" %}
+                        {% endif %}
+                    </h3>
                     <div class="pull-right">
                         <div class="form-inline">
                             <label>{% trans "Download selected orders as a CSV" %}</label>
@@ -129,7 +147,6 @@
                 </tbody>
             </table>
             {% endblock order_list %}
-
             {% block order_actions %}
                 <div class="well">
                     <h3><i class="icon-warning"></i> {% trans "Change order status" %}:</h3>
@@ -143,7 +160,6 @@
                                     <option>{{ status }}</option>
                                 {% endfor %}
                             </select>
-
                             </div>
                         </div>
                         <button type="submit" name="action" value="change_order_statuses" class="btn btn-primary" data-loading-text="{% trans 'Changing...' %}">{% trans "Change status" %}</button>
@@ -153,13 +169,18 @@
                 </div>
             {% endblock %}
 
-
             {% include "dashboard/orders/partials/bulk_edit_form.html" with status=active_status %}
             {% include "partials/pagination.html" %}
         </form>
     {% else %}
         <table class="table table-striped table-bordered">
-            <caption><i class="icon-shopping-cart icon-large"></i>{{ queryset_description }}</caption>
+            <caption><i class="icon-shopping-cart icon-large"></i>
+                {% if search_filters %}
+                {% trans "Order Search Results" %}
+                {% else %}
+                {% trans "All Orders" %}
+                {% endif %}
+            </caption>
             <tr><td>{% trans "No orders found." %}</td></tr>
         </table>
     {% endif %}
@@ -169,5 +190,6 @@
     {% block onbodyload %}
         {{ block.super }}
         oscar.dashboard.orders.initTable();
+        oscar.dashboard.orders.initFilterToggle();
         oscar.dashboard.search.init();
     {% endblock onbodyload %}

--- a/tests/integration/dashboard/order_search_tests.py
+++ b/tests/integration/dashboard/order_search_tests.py
@@ -1,0 +1,156 @@
+"""Tests for the dashboard orders search. """
+
+import warnings
+from bs4 import BeautifulSoup
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from oscar.core.compat import get_user_model, get_model
+
+
+User = get_user_model()
+SourceType = get_model('payment', 'SourceType')
+
+
+class TestOrderSearch(TestCase):
+    """Test the order search page. """
+
+    USERNAME = "staff"
+    EMAIL = "staff@example.com"
+    PASSWORD = "password"
+
+    TEST_CASES = [
+        ({}, []),
+        (
+            {'order_number': 'abcd1234'},
+            ['Order number starts with "abcd1234"']
+        ),
+        (
+            {'name': 'Bob Smith'},
+            ['Customer name matches "Bob Smith"']
+        ),
+        (
+            {'product_title': 'The Art of War'},
+            ['Product name matches "The Art of War"']
+        ),
+        (
+            {'upc': 'abcd1234'},
+            ['Includes an item with UPC "abcd1234"']
+        ),
+        (
+            {'partner_sku': 'abcd1234'},
+            ['Includes an item with partner SKU "abcd1234"']
+        ),
+        (
+            {'date_from': '2015-01-01'},
+            ['Placed after 2015-01-01']
+        ),
+        (
+            {'date_to': '2015-01-01'},
+            ['Placed before 2015-01-02']
+        ),
+        (
+            {'date_from': '2014-01-02', 'date_to': '2015-03-04'},
+            ['Placed between 2014-01-02 and 2015-03-04']
+        ),
+        (
+            {'voucher': 'abcd1234'},
+            ['Used voucher code "abcd1234"']
+        ),
+        (
+            {'payment_method': 'visa'},
+            ['Paid using Visa']
+        ),
+        (
+            # Assumes that the test settings (OSCAR_ORDER_STATUS_PIPELINE)
+            # include a state called 'A'
+            {'status': 'A'},
+            ['Order status is A']
+        ),
+        (
+            {
+                'name': 'Bob Smith',
+                'product_title': 'The Art of War',
+                'upc': 'upc_abcd1234',
+                'partner_sku': 'partner_avcd1234',
+                'date_from': '2014-01-02',
+                'date_to': '2015-03-04',
+                'voucher': 'voucher_abcd1234',
+                'payment_method': 'visa',
+                'status': 'A'
+            },
+            [
+                'Customer name matches "Bob Smith"',
+                'Product name matches "The Art of War"',
+                'Includes an item with UPC "upc_abcd1234"',
+                'Includes an item with partner SKU "partner_avcd1234"',
+                'Placed between 2014-01-02 and 2015-03-04',
+                'Used voucher code "voucher_abcd1234"',
+                'Paid using Visa',
+                'Order status is A',
+            ]
+        ),
+    ]
+
+    def setUp(self):
+        self._create_payment_source()
+        self._create_staff_account_and_login()
+
+    def test_search_filter_descriptions(self):
+        for params, expected_filters in self.TEST_CASES:
+            # Need to provide the order number parameter to avoid
+            # being short-circuited to "all results".
+            if 'order_number' not in params:
+                params['order_number'] = ''
+
+            response = self._search_with_params(**params)
+            self.assertEqual(response.status_code, 200)
+            self._assert_filters(response, expected_filters)
+
+    def _create_payment_source(self):
+        """Ensure that a payment source type exists. """
+        SourceType.objects.create(name="Visa", code="visa")
+
+    def _create_staff_account_and_login(self):
+        """Create a staff account and log in using the test client. """
+        self.user = User.objects.create_user(self.USERNAME, self.EMAIL, self.PASSWORD)
+        self.user.is_staff = True
+        self.user.save()
+        result = self.client.login(email=self.EMAIL, password=self.PASSWORD)
+        self.assertTrue(result, msg="Could not log in as a staff user.")
+
+    def _search_with_params(self, **kwargs):
+        """Perform the search with the specified parameters.
+
+        Keyword arguments are the GET parameters to
+        the order-list view.
+
+        Returns:
+            HttpResponse
+
+        """
+        url = reverse('dashboard:order-list')
+
+        # Django raises a warning about using a naive datetime
+        # when querying the Order model.  This occurs because
+        # the form field is a date, but the model field is a
+        # datetime, so when we convert from a date to a datetime
+        # there isn't any timezone information.
+        # To avoid halting the test, we suppress the warning.
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=RuntimeWarning)
+            return self.client.get(url, kwargs)
+
+    def _assert_filters(self, response, expected_filters):
+        """Check filter descriptions displayed on the search results page.
+
+        Arguments:
+            response (HttpResponse)
+            expected_filters (list)
+
+        Raises:
+            AssertionError
+
+        """
+        doc = BeautifulSoup(response.content)
+        filters = [el.text.strip() for el in doc.select('#filters li')]
+        self.assertEqual(filters, expected_filters)


### PR DESCRIPTION
This is an attempt to address #1530.  In the current implementation, search filters are concatenated together and displayed in the header of the search results table.  This is problematic for translators, since other languages have different grammar rules for combining fragments like these.

Since there are 10 different possible filters, it seemed unreasonable to create translation strings for each possible combinations of filters.  Instead, I made a slight change to the UI in order to display each applied filter separately:

![image](https://cloud.githubusercontent.com/assets/2948394/5892576/3e20e13e-a492-11e4-8cc6-0a268044fcc4.png)

By default, the filter display is toggled off so users aren't distracted from the search results.

I have also added integration tests for this feature using the Django test client.  To avoid defining a lot of repetitive test cases, I added `ddt` (Data Driven Tests) as a dependency and used it in the new test.  I'm a fan of `ddt` because it makes tests more succinct; but I can remove it if you'd prefer not to introduce another dependency.

I'm happy to make any changes necessary to get this merged, so please let me know!

Thanks!
-- Will