### PR TITLE
Issue/1648/price range

### DIFF
--- a/oscar/apps/partner/prices.py
+++ b/oscar/apps/partner/prices.py
@@ -33,6 +33,11 @@ class Base(object):
     #: Price currency (3 char code)
     currency = None
 
+    # Used to enable sorting of prices
+    # Ignores currency, but is otherwise correct if all Base instances are the same price
+    def __cmp__(self, other):
+        return self.effective_price - other.effective_price
+
     def __repr__(self):
         return "%s(%r)" % (self.__class__.__name__, self.__dict__)
 

--- a/oscar/apps/partner/prices.py
+++ b/oscar/apps/partner/prices.py
@@ -34,7 +34,7 @@ class Base(object):
     currency = None
 
     # Used to enable sorting of prices
-    # Ignores currency, but is otherwise correct if all Base instances are the same price
+    # Ignores currency, but is correct if all Base instances are the same currency
     def __cmp__(self, other):
         return self.effective_price - other.effective_price
 

--- a/oscar/apps/partner/strategy.py
+++ b/oscar/apps/partner/strategy.py
@@ -7,8 +7,13 @@ from . import availability, prices
 # A container for policies
 from oscar.core.decorators import deprecated
 
-PurchaseInfo = namedtuple(
-    'PurchaseInfo', ['price', 'availability', 'stockrecord'])
+BasePurchaseInfo = namedtuple(
+    'BasePurchaseInfo', ['min_price', 'max_price', 'availability', 'stockrecord'])
+
+class PurchaseInfo(BasePurchaseInfo):
+    @property
+    def price(self):
+        return self.min_price
 
 
 class Selector(object):
@@ -119,16 +124,25 @@ class Structured(Base):
         """
         if stockrecord is None:
             stockrecord = self.select_stockrecord(product)
+        price = self.pricing_policy(product, stockrecord)
         return PurchaseInfo(
-            price=self.pricing_policy(product, stockrecord),
+            min_price=price,
+            max_price=price,
             availability=self.availability_policy(product, stockrecord),
             stockrecord=stockrecord)
 
     def fetch_for_parent(self, product):
         # Select children and associated stockrecords
         children_stock = self.select_children_stockrecords(product)
+        pricing = self.parent_pricing_policy(product, children_stock)
+        if isinstance(pricing, prices.Unavailable):
+            min_price, max_price = prices.Unavailable(), pricing.Unavailable()
+        else:
+            pricing.sort()
+            min_price, max_price = pricing[0], pricing[-1]
         return PurchaseInfo(
-            price=self.parent_pricing_policy(product, children_stock),
+            min_price=min_price,
+            max_price=max_price,
             availability=self.parent_availability_policy(
                 product, children_stock),
             stockrecord=None)
@@ -245,15 +259,16 @@ class NoTax(object):
             tax=D('0.00'))
 
     def parent_pricing_policy(self, product, children_stock):
-        stockrecords = [x[1] for x in children_stock if x[1] is not None]
-        if not stockrecords:
-            return prices.Unavailable()
-        # We take price from first record
-        stockrecord = stockrecords[0]
-        return prices.FixedPrice(
-            currency=stockrecord.price_currency,
-            excl_tax=stockrecord.price_excl_tax,
-            tax=D('0.00'))
+        pricing = []
+        for child, stockrecord in children_stock:
+            if stockrecord:
+                pricing.append(
+                    prices.FixedPrice(
+                        currency=stockrecord.price_currency,
+                        excl_tax=stockrecord.price_excl_tax,
+                        tax=D('0.00'))
+                    )
+        return pricing or prices.Unavailable()
 
 
 class FixedRateTax(object):
@@ -276,18 +291,17 @@ class FixedRateTax(object):
             tax=tax)
 
     def parent_pricing_policy(self, product, children_stock):
-        stockrecords = [x[1] for x in children_stock if x[1] is not None]
-        if not stockrecords:
-            return prices.Unavailable()
-
-        # We take price from first record
-        stockrecord = stockrecords[0]
-        tax = (stockrecord.price_excl_tax * self.rate).quantize(self.exponent)
-
-        return prices.FixedPrice(
-            currency=stockrecord.price_currency,
-            excl_tax=stockrecord.price_excl_tax,
-            tax=tax)
+        pricing = []
+        for child, stockrecord in children_stock:
+            if stockrecord:
+                tax = (stockrecord.price_excl_tax * self.rate).quantize(self.exponent)
+                pricing.append(
+                    prices.FixedPrice(
+                        currency=stockrecord.price_currency,
+                        excl_tax=stockrecord.price_excl_tax,
+                        tax=tax)
+                    )
+        return pricing or prices.Unavailable()
 
 
 class DeferredTax(object):
@@ -305,16 +319,15 @@ class DeferredTax(object):
             excl_tax=stockrecord.price_excl_tax)
 
     def parent_pricing_policy(self, product, children_stock):
-        stockrecords = [x[1] for x in children_stock if x[1] is not None]
-        if not stockrecords:
-            return prices.Unavailable()
-
-        # We take price from first record
-        stockrecord = stockrecords[0]
-
-        return prices.FixedPrice(
-            currency=stockrecord.price_currency,
-            excl_tax=stockrecord.price_excl_tax)
+        pricing = []
+        for child, stockrecord in children_stock:
+            if stockrecord:
+                pricing.append(
+                    prices.FixedPrice(
+                        currency=stockrecord.price_currency,
+                        excl_tax=stockrecord.price_excl_tax)
+                    )
+        return pricing or prices.Unavailable()
 
 
 # Example strategy composed of above mixins.  For real projects, it's likely

--- a/oscar/apps/partner/strategy.py
+++ b/oscar/apps/partner/strategy.py
@@ -124,22 +124,22 @@ class Structured(Base):
         """
         if stockrecord is None:
             stockrecord = self.select_stockrecord(product)
-        price = self.pricing_policy(product, stockrecord)
+        pricing_policy = self.pricing_policy(product, stockrecord)
         return PurchaseInfo(
-            min_price=price,
-            max_price=price,
+            min_price=pricing_policy,
+            max_price=pricing_policy,
             availability=self.availability_policy(product, stockrecord),
             stockrecord=stockrecord)
 
     def fetch_for_parent(self, product):
         # Select children and associated stockrecords
         children_stock = self.select_children_stockrecords(product)
-        pricing = self.parent_pricing_policy(product, children_stock)
-        if isinstance(pricing, prices.Unavailable):
-            min_price, max_price = prices.Unavailable(), pricing.Unavailable()
+        pricing_policy = self.parent_pricing_policy(product, children_stock)
+        if isinstance(pricing_policy, prices.Unavailable):
+            min_price, max_price = prices.Unavailable(), pricing_policy.Unavailable()
         else:
-            pricing.sort()
-            min_price, max_price = pricing[0], pricing[-1]
+            pricing_policy.sort()
+            min_price, max_price = pricing_policy[0], pricing_policy[-1]
         return PurchaseInfo(
             min_price=min_price,
             max_price=max_price,

--- a/oscar/templates/oscar/catalogue/partials/stock_record.html
+++ b/oscar/templates/oscar/catalogue/partials/stock_record.html
@@ -4,14 +4,27 @@
 
 {% purchase_info_for_product request product as session %}
 
-{% if session.price.exists %}
-    {% if session.price.excl_tax == 0 %}
-        <p class="price_color">{% trans "Free" %}</p>
-    {% elif session.price.is_tax_known %}
-        <p class="price_color">{{ session.price.incl_tax|currency:session.price.currency }}</p>
-    {% else %}
-        <p class="price_color">{{ session.price.excl_tax|currency:session.price.currency }}</p>
-    {% endif %}
+{% if session.min_price.exists %}
+    <p class="price_color">
+        {% if session.min_price.excl_tax == 0 %}
+            {% trans "Free" %}
+        {% elif session.min_price.is_tax_known %}
+            {{ session.min_price.incl_tax|currency:session.min_price.currency }}
+        {% else %}
+            {{ session.min_price.excl_tax|currency:session.min_price.currency }}
+        {% endif %}
+
+        {% if session.max_price.exists and session.max_price != session.min_price %}
+           - 
+            {% if session.max_price.excl_tax == 0 %}
+                {% trans "Free" %}
+            {% elif session.max_price.is_tax_known %}
+                {{ session.max_price.incl_tax|currency:session.max_price.currency }}
+            {% else %}
+                {{ session.max_price.excl_tax|currency:session.max_price.currency }}
+            {% endif %}
+        {% endif %}
+    </p>
 {% else %}
     <p class="price_color">&nbsp;</p>
 {% endif %}


### PR DESCRIPTION
This is a fix for https://github.com/django-oscar/django-oscar/issues/1648

* Added a `__cmp__` method to `partner.prices.Base` so that prices can be sorted and compared in templates.
* `PurchaseInfo` is now a `namedtuple` with `min_price` and `max_price` instead of `price`
    * `price` is still a property that aliases `min_price` (to emulate old behavior for backwards compatability)
* `Selector.parent_pricing_policy` returns a list of prices or `Unavailable` instead of a single price
* `fetch_for_parent` actually looks at the prices returned and determines what the `min_price` and `max_price` should be for `PurchaseInfo`
* `templates/oscar/catalogue/partials/stock_record.html` now looks at `min_price` and `max_price` and renders a single price or a price range as appropriate.