### PR TITLE
Fix after user registration, the page does not redirect to checkout page...

### DIFF
--- a/src/oscar/apps/customer/views.py
+++ b/src/oscar/apps/customer/views.py
@@ -217,6 +217,10 @@ class AccountAuthView(RegisterUserMixin, generic.TemplateView):
         return _("Thanks for registering!")
 
     def get_registration_success_url(self, form):
+        redirect_url = form.cleaned_data['redirect_url']
+        if redirect_url:
+            return redirect_url
+
         return settings.LOGIN_REDIRECT_URL
 
 


### PR DESCRIPTION
... as url requested bug.

Happens when an anonymous user buying and checking out, the user will be asked to login or register. After the registration, the page will be redirected to account profile page instead of finishing the checkout process.