### PR TITLE
Build facet data into an OrderedDict, preserving the order if the settin...

### DIFF
--- a/oscar/apps/search/facets.py
+++ b/oscar/apps/search/facets.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 from django.conf import settings
 from purl import URL
 from haystack.query import SearchQuerySet
@@ -25,7 +27,7 @@ class FacetMunger(object):
         self.facet_counts = facet_counts
 
     def facet_data(self):
-        facet_data = {}
+        facet_data = OrderedDict()
         # Haystack can return an empty dict for facet_counts when e.g. Solr
         # isn't running. Skip facet munging in that case.
         if self.facet_counts:


### PR DESCRIPTION
Partially fixes https://github.com/django-oscar/django-oscar/issues/1655

If you set `OSCAR_SEARCH_FACETS['fields']` to an OrderedDict, the facets will be displayed in that order on the search page.  All of the fields come first and then the queries, and there's no way to insert a query in between a field. Ideally, we would be able to specify any order.

Might need documentation?

```python
OSCAR_SEARCH_FACETS = {
    'fields': OrderedDict([
        ('category', {
            'name': _('Category'),
            'field': 'category'
        }),                      
        ('color', {
            'name': _('Color'),
            'field': 'color'
        }),           
        ('fabric', {
            'name': _('Fabric'),
            'field': 'fabric'
        }),  
        ('size', {
            'name': _('Size'),
            'field': 'size'
        }),          
    ]),
    'queries': OrderedDict([
        ('price_range', {
            'name': _('Price range'),
            'field': 'price',
            'queries': [
                (_('$20 or less'), '[0 TO 20]'),
                (_('$20 to $40'), '[20 TO 40]'),
                (_('$40 to $60'), '[40 TO 60]'),
                (_('$60 and up'), '[60 TO *]'),
            ]
        })
    ])
}
```

