### PR TITLE
Fix `TEMPLATE_DIRS` test config

### DIFF
--- a/tests/_site/templates/base.html
+++ b/tests/_site/templates/base.html
@@ -1,7 +1,8 @@
+{% load i18n %}
 <!DOCTYPE html>
 <html lang="{% block language %}en-gb{% endblock %}">
     <head>
-        <title>{% block title %}{% trans "Oscar :: Flexible ecommerce for Django" %}{% endblock %}</title>
+        <title>{% block title %}{% trans "Oscar Test Shop" %}{% endblock %}</title>
         <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
         <meta name="created" content='{% now "jS M Y h:i" %}' />
         <meta name="description" content="{% block description %}{% endblock %}" />

--- a/tests/_site/templates/layout.html
+++ b/tests/_site/templates/layout.html
@@ -3,66 +3,67 @@
 {% load currency_filters %}
 {% load promotion_tags %}
 {% load category_tags %}
+{% load i18n %}
 
 {% block layout %}
-    <div id="container">
-        <div id="header">
-            <p><a href="{{ homepage_url }}">{% trans "Oscar // Flexible e-commerce for Django" %}</a></p>
+<div id="container">
+    <div id="header">
+        <p><a href="{{ homepage_url }}">{% trans "Oscar // Flexible e-commerce for Django" %}</a></p>
 
-            <form method="get" action="{% url 'search:search' %}">
-                {{ search_form.as_p }}
-                <input type="submit" value="{% trans "Go!" %}" />
-            </form>
+        <form method="get" action="{% url 'search:search' %}">
+            {{ search_form.as_p }}
+            <input type="submit" value="{% trans "Go!" %}" />
+        </form>
 
-            {% if user.is_authenticated %}
-                <a href="{% url 'customer:summary' %}">{% trans "Profile" %}</a>
-                <a href="{% url 'customer:logout' %}">{% trans "Logout" %}</a>
-            {% else %}
-                <a href="{% url 'customer:login' %}">{% trans "Login" %}</a>
-            {% endif %}
+        {% if user.is_authenticated %}
+        <a href="{% url 'customer:summary' %}">{% trans "Profile" %}</a>
+        <a href="{% url 'customer:logout' %}">{% trans "Logout" %}</a>
+        {% else %}
+        <a href="{% url 'customer:login' %}">{% trans "Login" %}</a>
+        {% endif %}
 
-            {% blocktrans with total=basket.total_incl_tax|currency %}Basket total: {{ total }}{% endblocktrans %}
-            <a href="{% url 'basket:summary' %}">{% trans "View basket" %}</a>
+        {% blocktrans with total=basket.total_incl_tax|currency %}Basket total: {{ total }}{% endblocktrans %}
+        <a href="{% url 'basket:summary' %}">{% trans "View basket" %}</a>
 
-			{% category_tree depth=2 as categories %}
+        {% category_tree depth=2 as categories %}
 
-			{% if categories %}
-			<ul>
-			{% for category in categories %}
-			<li><a href="{{ category.0.get_absolute_url }}">{{ category.0.name }}</a>
-				{% if category.1 %}
-				<ul>
-				{% for subcategory in category.1 %}
-				<li><a href="{{ subcategory.0.get_absolute_url }}">{{ subcategory.0.name }}</a>
-				{% endfor %}
-				</ul>
-				{% endif %}
-			</li>
-			{% endfor %}
-			</ul>
-			{% endif %}
+        {% if categories %}
+        <ul>
+            {% for category in categories %}
+            <li><a href="{{ category.0.get_absolute_url }}">{{ category.0.name }}</a>
+                {% if category.1 %}
+                <ul>
+                    {% for subcategory in category.1 %}
+                    <li><a href="{{ subcategory.0.get_absolute_url }}">{{ subcategory.0.name }}</a>
+                        {% endfor %}
+                </ul>
+                {% endif %}
+            </li>
+            {% endfor %}
+        </ul>
+        {% endif %}
 
-            {% block header %}
-            {% endblock %}
-        </div>
-        <div id="content">
-
-            {% if messages %}
-            <ul class="messages">
-                {% for message in messages %}
-                <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
-                {% endfor %}
-            </ul>
-            {% endif %}
-
-            <div id="promotions">
-                {% for promotion in promotions_page %}
-                    {% render_promotion promotion %}
-                {% endfor %}
-            </div>
-
-            {% block content %}{% endblock %}
-        </div>
-        <div id="footer">{% block footer %}{% endblock %}</div>
+        {% block header %}
+        {% endblock %}
     </div>
+    <div id="content">
+
+        {% if messages %}
+        <ul class="messages">
+            {% for message in messages %}
+            <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+            {% endfor %}
+        </ul>
+        {% endif %}
+
+        <div id="promotions">
+            {% for promotion in promotions_page %}
+            {% render_promotion promotion %}
+            {% endfor %}
+        </div>
+
+        {% block content %}{% endblock %}
+    </div>
+    <div id="footer">{% block footer %}{% endblock %}</div>
+</div>
 {% endblock %}

--- a/tests/config.py
+++ b/tests/config.py
@@ -57,7 +57,7 @@ def configure():
                 'oscar.core.context_processors.metadata',
             ),
             'TEMPLATE_DIRS': (
-                location('templates'),
+                location('_site/templates'),
                 oscar.OSCAR_MAIN_TEMPLATE_DIR,
             ),
             'TEMPLATE_LOADERS': (

--- a/tests/unit/settings_tests.py
+++ b/tests/unit/settings_tests.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-from django.template import loader, base
+from django.template import loader, base, Context
 
 import oscar
 
@@ -31,3 +31,15 @@ class TestOscarTemplateSettings(TestCase):
                 loader.get_template(path)
             except base.TemplateDoesNotExist:
                 self.fail("Template %s should exist" % path)
+
+    def test_allows_a_template_to_be_customized(self):
+        path = 'base.html'
+        template = loader.get_template(path)
+        rendered_template = template.render(Context())
+        self.assertIn('Oscar Test Shop', rendered_template)
+
+    def test_default_oscar_templates_are_accessible(self):
+        path = 'oscar/base.html'
+        template = loader.get_template(path)
+        rendered_template = template.render(Context())
+        self.assertNotIn('Oscar Test Shop', rendered_template)


### PR DESCRIPTION
The config was picking the wrong directory so the custom test templates were not used during tests.

Notes

- Fix missing i18n load tags
- Remove mixed tab/space indentation
- Add two settings tests