### PR TITLE
Improve test coverage in checkout views

### DIFF
--- a/tests/_site/templates/checkout/payment_details.html
+++ b/tests/_site/templates/checkout/payment_details.html
@@ -1,0 +1,17 @@
+{% extends 'oscar/checkout/payment_details.html' %}
+{% load url from future %}
+{% load i18n %}
+
+{% block payment_details %}
+    {{ block.super }}
+
+    <div class="well">
+        <div class="sub-header">
+            <h3>{% trans "PayTest" %}</h3>
+        </div>
+        <form method="post" action="{% url 'checkout:preview' %}" id="sensible_data">
+            {% csrf_token %}
+         <button type="submit" class="btn btn-large btn-primary">Submit</button>
+        </form>
+    </div>
+{% endblock %}

--- a/tests/functional/checkout/__init__.py
+++ b/tests/functional/checkout/__init__.py
@@ -67,11 +67,14 @@ class CheckoutMixin(object):
         preview = payment_details.click(linkid="view_preview")
         return preview.forms['place_order_form'].submit().follow()
 
-    def ready_to_place_an_order(self, is_guest=False):
+    def reach_payment_details_page(self, is_guest=False):
         self.add_product_to_basket()
         if is_guest:
             self.enter_guest_details('hello@egg.com')
         self.enter_shipping_address()
-        payment_details = self.get(
+        return self.get(
             reverse('checkout:shipping-method')).follow().follow()
+
+    def ready_to_place_an_order(self, is_guest=False):
+        payment_details = self.reach_payment_details_page(is_guest)
         return payment_details.click(linkid="view_preview")


### PR DESCRIPTION
This is the second part of #1645.

This PR adds new functional tests for ShippingAddressView, PaymentDetailsView and ThankYouView.
I had to use a custom template to be able to test some functionalities of PaymentDetailsView.
