### PR TITLE
Unlinking User from Partner removes 'dashboard_access' Permission from database

### DIFF
--- a/src/oscar/apps/dashboard/partners/views.py
+++ b/src/oscar/apps/dashboard/partners/views.py
@@ -241,9 +241,10 @@ class PartnerUserUnlinkView(generic.View):
             return False
         partner.users.remove(user)
         if not user.is_staff and not user.partners.exists():
-            user.user_permissions.filter(
+            dashboard_access_perm = Permission.objects.get(
                 codename='dashboard_access',
-                content_type__app_label='partner').delete()
+                content_type__app_label='partner')
+            user.user_permissions.remove(dashboard_access_perm)
         return True
 
     def post(self, request, user_pk, partner_pk):


### PR DESCRIPTION
It happens in apps.dashboard.partners.views.PartnerUserUnlinkView:

```
if not user.is_staff and not user.partners.exists():
    user.user_permissions.filter(
        codename='dashboard_access',
        content_type__app_label='partner').delete()
```