### PR TITLE
Improve Bootstrap 3 forms in the fontend site.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,9 +98,9 @@ compiledmessages:
 
 css:
 	# Compile CSS files from LESS
-	lessc --source-map --source-map-less-inline src/oscar/static/oscar/less/styles.less oscar/static/oscar/css/styles.css
-	lessc --source-map --source-map-less-inline src/oscar/static/oscar/less/responsive.less oscar/static/oscar/css/responsive.css
-	lessc --source-map --source-map-less-inline src/oscar/static/oscar/less/dashboard.less oscar/static/oscar/css/dashboard.css
+	lessc --source-map --source-map-less-inline src/oscar/static/oscar/less/styles.less src/oscar/static/oscar/css/styles.css
+	lessc --source-map --source-map-less-inline src/oscar/static/oscar/less/responsive.less src/oscar/static/oscar/css/responsive.css
+	lessc --source-map --source-map-less-inline src/oscar/static/oscar/less/dashboard.less src/oscar/static/oscar/css/dashboard.css
 	# Compile CSS for demo site
 	lessc --source-map --source-map-less-inline sites/demo/static/demo/less/styles.less sites/demo/static/demo/css/styles.css
 	lessc --source-map --source-map-less-inline sites/demo/static/demo/less/responsive.less sites/demo/static/demo/css/responsive.css

--- a/sites/demo/static/demo/css/responsive.css
+++ b/sites/demo/static/demo/css/responsive.css
@@ -211,158 +211,158 @@
     -moz-box-sizing: border-box;
     box-sizing: border-box;
     float: left;
-    margin-left: 2.56410256%;
-    *margin-left: 2.51091107%;
+    margin-left: 2.564102564102564%;
+    *margin-left: 2.5109110747408616%;
   }
   .row-fluid [class*="span"]:first-child {
     margin-left: 0;
   }
   .row-fluid .controls-row [class*="span"] + [class*="span"] {
-    margin-left: 2.56410256%;
+    margin-left: 2.564102564102564%;
   }
   .row-fluid .span12 {
     width: 100%;
-    *width: 99.94680851%;
+    *width: 99.94680851063829%;
   }
   .row-fluid .span11 {
-    width: 91.45299145%;
-    *width: 91.39979996%;
+    width: 91.45299145299145%;
+    *width: 91.39979996362975%;
   }
   .row-fluid .span10 {
-    width: 82.90598291%;
-    *width: 82.85279142%;
+    width: 82.90598290598291%;
+    *width: 82.8527914166212%;
   }
   .row-fluid .span9 {
-    width: 74.35897436%;
-    *width: 74.30578287%;
+    width: 74.35897435897436%;
+    *width: 74.30578286961266%;
   }
   .row-fluid .span8 {
-    width: 65.81196581%;
-    *width: 65.75877432%;
+    width: 65.81196581196582%;
+    *width: 65.75877432260411%;
   }
   .row-fluid .span7 {
-    width: 57.26495726%;
-    *width: 57.21176578%;
+    width: 57.26495726495726%;
+    *width: 57.21176577559556%;
   }
   .row-fluid .span6 {
-    width: 48.71794872%;
-    *width: 48.66475723%;
+    width: 48.717948717948715%;
+    *width: 48.664757228587014%;
   }
   .row-fluid .span5 {
-    width: 40.17094017%;
-    *width: 40.11774868%;
+    width: 40.17094017094017%;
+    *width: 40.11774868157847%;
   }
   .row-fluid .span4 {
-    width: 31.62393162%;
-    *width: 31.57074013%;
+    width: 31.623931623931625%;
+    *width: 31.570740134569924%;
   }
   .row-fluid .span3 {
-    width: 23.07692308%;
-    *width: 23.02373159%;
+    width: 23.076923076923077%;
+    *width: 23.023731587561375%;
   }
   .row-fluid .span2 {
-    width: 14.52991453%;
-    *width: 14.47672304%;
+    width: 14.52991452991453%;
+    *width: 14.476723040552828%;
   }
   .row-fluid .span1 {
-    width: 5.98290598%;
-    *width: 5.92971449%;
+    width: 5.982905982905983%;
+    *width: 5.929714493544281%;
   }
   .row-fluid .offset12 {
-    margin-left: 105.12820513%;
-    *margin-left: 105.02182215%;
+    margin-left: 105.12820512820512%;
+    *margin-left: 105.02182214948171%;
   }
   .row-fluid .offset12:first-child {
-    margin-left: 102.56410256%;
-    *margin-left: 102.45771959%;
+    margin-left: 102.56410256410257%;
+    *margin-left: 102.45771958537915%;
   }
   .row-fluid .offset11 {
-    margin-left: 96.58119658%;
-    *margin-left: 96.4748136%;
+    margin-left: 96.58119658119658%;
+    *margin-left: 96.47481360247316%;
   }
   .row-fluid .offset11:first-child {
-    margin-left: 94.01709402%;
-    *margin-left: 93.91071104%;
+    margin-left: 94.01709401709402%;
+    *margin-left: 93.91071103837061%;
   }
   .row-fluid .offset10 {
-    margin-left: 88.03418803%;
-    *margin-left: 87.92780506%;
+    margin-left: 88.03418803418803%;
+    *margin-left: 87.92780505546462%;
   }
   .row-fluid .offset10:first-child {
-    margin-left: 85.47008547%;
-    *margin-left: 85.36370249%;
+    margin-left: 85.47008547008548%;
+    *margin-left: 85.36370249136206%;
   }
   .row-fluid .offset9 {
-    margin-left: 79.48717949%;
-    *margin-left: 79.38079651%;
+    margin-left: 79.48717948717949%;
+    *margin-left: 79.38079650845607%;
   }
   .row-fluid .offset9:first-child {
-    margin-left: 76.92307692%;
-    *margin-left: 76.81669394%;
+    margin-left: 76.92307692307693%;
+    *margin-left: 76.81669394435352%;
   }
   .row-fluid .offset8 {
-    margin-left: 70.94017094%;
-    *margin-left: 70.83378796%;
+    margin-left: 70.94017094017094%;
+    *margin-left: 70.83378796144753%;
   }
   .row-fluid .offset8:first-child {
-    margin-left: 68.37606838%;
-    *margin-left: 68.2696854%;
+    margin-left: 68.37606837606839%;
+    *margin-left: 68.26968539734497%;
   }
   .row-fluid .offset7 {
-    margin-left: 62.39316239%;
-    *margin-left: 62.28677941%;
+    margin-left: 62.393162393162385%;
+    *margin-left: 62.28677941443899%;
   }
   .row-fluid .offset7:first-child {
-    margin-left: 59.82905983%;
-    *margin-left: 59.72267685%;
+    margin-left: 59.82905982905982%;
+    *margin-left: 59.72267685033642%;
   }
   .row-fluid .offset6 {
-    margin-left: 53.84615385%;
-    *margin-left: 53.73977087%;
+    margin-left: 53.84615384615384%;
+    *margin-left: 53.739770867430444%;
   }
   .row-fluid .offset6:first-child {
-    margin-left: 51.28205128%;
-    *margin-left: 51.1756683%;
+    margin-left: 51.28205128205128%;
+    *margin-left: 51.175668303327875%;
   }
   .row-fluid .offset5 {
-    margin-left: 45.2991453%;
-    *margin-left: 45.19276232%;
+    margin-left: 45.299145299145295%;
+    *margin-left: 45.1927623204219%;
   }
   .row-fluid .offset5:first-child {
-    margin-left: 42.73504274%;
-    *margin-left: 42.62865976%;
+    margin-left: 42.73504273504273%;
+    *margin-left: 42.62865975631933%;
   }
   .row-fluid .offset4 {
-    margin-left: 36.75213675%;
-    *margin-left: 36.64575377%;
+    margin-left: 36.75213675213675%;
+    *margin-left: 36.645753773413354%;
   }
   .row-fluid .offset4:first-child {
-    margin-left: 34.18803419%;
-    *margin-left: 34.08165121%;
+    margin-left: 34.18803418803419%;
+    *margin-left: 34.081651209310785%;
   }
   .row-fluid .offset3 {
-    margin-left: 28.20512821%;
-    *margin-left: 28.09874523%;
+    margin-left: 28.205128205128204%;
+    *margin-left: 28.0987452264048%;
   }
   .row-fluid .offset3:first-child {
-    margin-left: 25.64102564%;
-    *margin-left: 25.53464266%;
+    margin-left: 25.641025641025642%;
+    *margin-left: 25.53464266230224%;
   }
   .row-fluid .offset2 {
-    margin-left: 19.65811966%;
-    *margin-left: 19.55173668%;
+    margin-left: 19.65811965811966%;
+    *margin-left: 19.551736679396257%;
   }
   .row-fluid .offset2:first-child {
-    margin-left: 17.09401709%;
-    *margin-left: 16.98763412%;
+    margin-left: 17.094017094017094%;
+    *margin-left: 16.98763411529369%;
   }
   .row-fluid .offset1 {
-    margin-left: 11.11111111%;
-    *margin-left: 11.00472813%;
+    margin-left: 11.11111111111111%;
+    *margin-left: 11.004728132387708%;
   }
   .row-fluid .offset1:first-child {
-    margin-left: 8.54700855%;
-    *margin-left: 8.44062557%;
+    margin-left: 8.547008547008547%;
+    *margin-left: 8.440625568285142%;
   }
   input,
   textarea,
@@ -560,158 +560,158 @@
     -moz-box-sizing: border-box;
     box-sizing: border-box;
     float: left;
-    margin-left: 2.76243094%;
-    *margin-left: 2.70923945%;
+    margin-left: 2.7624309392265194%;
+    *margin-left: 2.709239449864817%;
   }
   .row-fluid [class*="span"]:first-child {
     margin-left: 0;
   }
   .row-fluid .controls-row [class*="span"] + [class*="span"] {
-    margin-left: 2.76243094%;
+    margin-left: 2.7624309392265194%;
   }
   .row-fluid .span12 {
     width: 100%;
-    *width: 99.94680851%;
+    *width: 99.94680851063829%;
   }
   .row-fluid .span11 {
-    width: 91.43646409%;
-    *width: 91.3832726%;
+    width: 91.43646408839778%;
+    *width: 91.38327259903608%;
   }
   .row-fluid .span10 {
-    width: 82.87292818%;
-    *width: 82.81973669%;
+    width: 82.87292817679558%;
+    *width: 82.81973668743387%;
   }
   .row-fluid .span9 {
-    width: 74.30939227%;
-    *width: 74.25620078%;
+    width: 74.30939226519337%;
+    *width: 74.25620077583166%;
   }
   .row-fluid .span8 {
-    width: 65.74585635%;
-    *width: 65.69266486%;
+    width: 65.74585635359117%;
+    *width: 65.69266486422946%;
   }
   .row-fluid .span7 {
-    width: 57.18232044%;
-    *width: 57.12912895%;
+    width: 57.18232044198895%;
+    *width: 57.12912895262725%;
   }
   .row-fluid .span6 {
-    width: 48.61878453%;
-    *width: 48.56559304%;
+    width: 48.61878453038674%;
+    *width: 48.56559304102504%;
   }
   .row-fluid .span5 {
-    width: 40.05524862%;
-    *width: 40.00205713%;
+    width: 40.05524861878453%;
+    *width: 40.00205712942283%;
   }
   .row-fluid .span4 {
-    width: 31.49171271%;
-    *width: 31.43852122%;
+    width: 31.491712707182323%;
+    *width: 31.43852121782062%;
   }
   .row-fluid .span3 {
-    width: 22.9281768%;
-    *width: 22.87498531%;
+    width: 22.92817679558011%;
+    *width: 22.87498530621841%;
   }
   .row-fluid .span2 {
-    width: 14.36464088%;
-    *width: 14.31144939%;
+    width: 14.3646408839779%;
+    *width: 14.311449394616199%;
   }
   .row-fluid .span1 {
-    width: 5.80110497%;
-    *width: 5.74791348%;
+    width: 5.801104972375691%;
+    *width: 5.747913483013988%;
   }
   .row-fluid .offset12 {
-    margin-left: 105.52486188%;
-    *margin-left: 105.4184789%;
+    margin-left: 105.52486187845304%;
+    *margin-left: 105.41847889972962%;
   }
   .row-fluid .offset12:first-child {
-    margin-left: 102.76243094%;
-    *margin-left: 102.65604796%;
+    margin-left: 102.76243093922652%;
+    *margin-left: 102.6560479605031%;
   }
   .row-fluid .offset11 {
-    margin-left: 96.96132597%;
-    *margin-left: 96.85494299%;
+    margin-left: 96.96132596685082%;
+    *margin-left: 96.8549429881274%;
   }
   .row-fluid .offset11:first-child {
-    margin-left: 94.19889503%;
-    *margin-left: 94.09251205%;
+    margin-left: 94.1988950276243%;
+    *margin-left: 94.09251204890089%;
   }
   .row-fluid .offset10 {
-    margin-left: 88.39779006%;
-    *margin-left: 88.29140708%;
+    margin-left: 88.39779005524862%;
+    *margin-left: 88.2914070765252%;
   }
   .row-fluid .offset10:first-child {
-    margin-left: 85.63535912%;
-    *margin-left: 85.52897614%;
+    margin-left: 85.6353591160221%;
+    *margin-left: 85.52897613729868%;
   }
   .row-fluid .offset9 {
-    margin-left: 79.83425414%;
-    *margin-left: 79.72787116%;
+    margin-left: 79.8342541436464%;
+    *margin-left: 79.72787116492299%;
   }
   .row-fluid .offset9:first-child {
-    margin-left: 77.0718232%;
-    *margin-left: 76.96544023%;
+    margin-left: 77.07182320441989%;
+    *margin-left: 76.96544022569647%;
   }
   .row-fluid .offset8 {
-    margin-left: 71.27071823%;
-    *margin-left: 71.16433525%;
+    margin-left: 71.2707182320442%;
+    *margin-left: 71.16433525332079%;
   }
   .row-fluid .offset8:first-child {
-    margin-left: 68.50828729%;
-    *margin-left: 68.40190431%;
+    margin-left: 68.50828729281768%;
+    *margin-left: 68.40190431409427%;
   }
   .row-fluid .offset7 {
-    margin-left: 62.70718232%;
-    *margin-left: 62.60079934%;
+    margin-left: 62.70718232044199%;
+    *margin-left: 62.600799341718584%;
   }
   .row-fluid .offset7:first-child {
-    margin-left: 59.94475138%;
-    *margin-left: 59.8383684%;
+    margin-left: 59.94475138121547%;
+    *margin-left: 59.838368402492065%;
   }
   .row-fluid .offset6 {
-    margin-left: 54.14364641%;
-    *margin-left: 54.03726343%;
+    margin-left: 54.14364640883978%;
+    *margin-left: 54.037263430116376%;
   }
   .row-fluid .offset6:first-child {
-    margin-left: 51.38121547%;
-    *margin-left: 51.27483249%;
+    margin-left: 51.38121546961326%;
+    *margin-left: 51.27483249088986%;
   }
   .row-fluid .offset5 {
-    margin-left: 45.5801105%;
-    *margin-left: 45.47372752%;
+    margin-left: 45.58011049723757%;
+    *margin-left: 45.47372751851417%;
   }
   .row-fluid .offset5:first-child {
-    margin-left: 42.81767956%;
-    *margin-left: 42.71129658%;
+    margin-left: 42.81767955801105%;
+    *margin-left: 42.71129657928765%;
   }
   .row-fluid .offset4 {
-    margin-left: 37.01657459%;
-    *margin-left: 36.91019161%;
+    margin-left: 37.01657458563536%;
+    *margin-left: 36.91019160691196%;
   }
   .row-fluid .offset4:first-child {
-    margin-left: 34.25414365%;
-    *margin-left: 34.14776067%;
+    margin-left: 34.25414364640884%;
+    *margin-left: 34.14776066768544%;
   }
   .row-fluid .offset3 {
-    margin-left: 28.45303867%;
-    *margin-left: 28.3466557%;
+    margin-left: 28.45303867403315%;
+    *margin-left: 28.346655695309746%;
   }
   .row-fluid .offset3:first-child {
-    margin-left: 25.69060773%;
-    *margin-left: 25.58422476%;
+    margin-left: 25.69060773480663%;
+    *margin-left: 25.584224756083227%;
   }
   .row-fluid .offset2 {
-    margin-left: 19.88950276%;
-    *margin-left: 19.78311978%;
+    margin-left: 19.88950276243094%;
+    *margin-left: 19.783119783707537%;
   }
   .row-fluid .offset2:first-child {
-    margin-left: 17.12707182%;
-    *margin-left: 17.02068884%;
+    margin-left: 17.12707182320442%;
+    *margin-left: 17.02068884448102%;
   }
   .row-fluid .offset1 {
-    margin-left: 11.32596685%;
-    *margin-left: 11.21958387%;
+    margin-left: 11.32596685082873%;
+    *margin-left: 11.219583872105325%;
   }
   .row-fluid .offset1:first-child {
-    margin-left: 8.56353591%;
-    *margin-left: 8.45715293%;
+    margin-left: 8.56353591160221%;
+    *margin-left: 8.457152932878806%;
   }
   input,
   textarea,
@@ -1206,4 +1206,3 @@
     overflow: visible !important;
   }
 }
-/*# sourceMappingURL=responsive.css.map */

--- a/sites/demo/static/demo/css/styles.css
+++ b/sites/demo/static/demo/css/styles.css
@@ -86,12 +86,16 @@ sub {
 }
 img {
   /* Responsive images (ensure images don't scale beyond their parents) */
+
   max-width: 100%;
   /* Part 1: Set a maxium relative to the parent */
+
   width: auto\9;
   /* IE7-8 need help adjusting responsive images */
+
   height: auto;
   /* Part 2: Scale the height according to the width, otherwise you get stretching */
+
   vertical-align: middle;
   border: 0;
   -ms-interpolation-mode: bicubic;
@@ -186,7 +190,7 @@ textarea {
   img {
     max-width: 100% !important;
   }
-  @page {
+  @page  {
     margin: 0.5cm;
   }
   p,
@@ -353,158 +357,158 @@ a:focus {
   -moz-box-sizing: border-box;
   box-sizing: border-box;
   float: left;
-  margin-left: 2.12765957%;
-  *margin-left: 2.07446809%;
+  margin-left: 2.127659574468085%;
+  *margin-left: 2.074468085106383%;
 }
 .row-fluid [class*="span"]:first-child {
   margin-left: 0;
 }
 .row-fluid .controls-row [class*="span"] + [class*="span"] {
-  margin-left: 2.12765957%;
+  margin-left: 2.127659574468085%;
 }
 .row-fluid .span12 {
   width: 100%;
-  *width: 99.94680851%;
+  *width: 99.94680851063829%;
 }
 .row-fluid .span11 {
-  width: 91.4893617%;
-  *width: 91.43617021%;
+  width: 91.48936170212765%;
+  *width: 91.43617021276594%;
 }
 .row-fluid .span10 {
-  width: 82.9787234%;
-  *width: 82.92553191%;
+  width: 82.97872340425532%;
+  *width: 82.92553191489361%;
 }
 .row-fluid .span9 {
-  width: 74.46808511%;
-  *width: 74.41489362%;
+  width: 74.46808510638297%;
+  *width: 74.41489361702126%;
 }
 .row-fluid .span8 {
-  width: 65.95744681%;
-  *width: 65.90425532%;
+  width: 65.95744680851064%;
+  *width: 65.90425531914893%;
 }
 .row-fluid .span7 {
-  width: 57.44680851%;
-  *width: 57.39361702%;
+  width: 57.44680851063829%;
+  *width: 57.39361702127659%;
 }
 .row-fluid .span6 {
-  width: 48.93617021%;
-  *width: 48.88297872%;
+  width: 48.93617021276595%;
+  *width: 48.88297872340425%;
 }
 .row-fluid .span5 {
-  width: 40.42553191%;
-  *width: 40.37234043%;
+  width: 40.42553191489362%;
+  *width: 40.37234042553192%;
 }
 .row-fluid .span4 {
-  width: 31.91489362%;
-  *width: 31.86170213%;
+  width: 31.914893617021278%;
+  *width: 31.861702127659576%;
 }
 .row-fluid .span3 {
-  width: 23.40425532%;
-  *width: 23.35106383%;
+  width: 23.404255319148934%;
+  *width: 23.351063829787233%;
 }
 .row-fluid .span2 {
-  width: 14.89361702%;
-  *width: 14.84042553%;
+  width: 14.893617021276595%;
+  *width: 14.840425531914894%;
 }
 .row-fluid .span1 {
-  width: 6.38297872%;
-  *width: 6.32978723%;
+  width: 6.382978723404255%;
+  *width: 6.329787234042553%;
 }
 .row-fluid .offset12 {
-  margin-left: 104.25531915%;
-  *margin-left: 104.14893617%;
+  margin-left: 104.25531914893617%;
+  *margin-left: 104.14893617021275%;
 }
 .row-fluid .offset12:first-child {
-  margin-left: 102.12765957%;
-  *margin-left: 102.0212766%;
+  margin-left: 102.12765957446808%;
+  *margin-left: 102.02127659574467%;
 }
 .row-fluid .offset11 {
-  margin-left: 95.74468085%;
-  *margin-left: 95.63829787%;
+  margin-left: 95.74468085106382%;
+  *margin-left: 95.6382978723404%;
 }
 .row-fluid .offset11:first-child {
-  margin-left: 93.61702128%;
-  *margin-left: 93.5106383%;
+  margin-left: 93.61702127659574%;
+  *margin-left: 93.51063829787232%;
 }
 .row-fluid .offset10 {
-  margin-left: 87.23404255%;
-  *margin-left: 87.12765957%;
+  margin-left: 87.23404255319149%;
+  *margin-left: 87.12765957446807%;
 }
 .row-fluid .offset10:first-child {
-  margin-left: 85.10638298%;
-  *margin-left: 85%;
+  margin-left: 85.1063829787234%;
+  *margin-left: 84.99999999999999%;
 }
 .row-fluid .offset9 {
-  margin-left: 78.72340426%;
-  *margin-left: 78.61702128%;
+  margin-left: 78.72340425531914%;
+  *margin-left: 78.61702127659572%;
 }
 .row-fluid .offset9:first-child {
-  margin-left: 76.59574468%;
-  *margin-left: 76.4893617%;
+  margin-left: 76.59574468085106%;
+  *margin-left: 76.48936170212764%;
 }
 .row-fluid .offset8 {
-  margin-left: 70.21276596%;
-  *margin-left: 70.10638298%;
+  margin-left: 70.2127659574468%;
+  *margin-left: 70.10638297872339%;
 }
 .row-fluid .offset8:first-child {
-  margin-left: 68.08510638%;
-  *margin-left: 67.9787234%;
+  margin-left: 68.08510638297872%;
+  *margin-left: 67.9787234042553%;
 }
 .row-fluid .offset7 {
-  margin-left: 61.70212766%;
-  *margin-left: 61.59574468%;
+  margin-left: 61.70212765957446%;
+  *margin-left: 61.59574468085106%;
 }
 .row-fluid .offset7:first-child {
-  margin-left: 59.57446809%;
-  *margin-left: 59.46808511%;
+  margin-left: 59.574468085106375%;
+  *margin-left: 59.46808510638297%;
 }
 .row-fluid .offset6 {
-  margin-left: 53.19148936%;
-  *margin-left: 53.08510638%;
+  margin-left: 53.191489361702125%;
+  *margin-left: 53.085106382978715%;
 }
 .row-fluid .offset6:first-child {
-  margin-left: 51.06382979%;
-  *margin-left: 50.95744681%;
+  margin-left: 51.063829787234035%;
+  *margin-left: 50.95744680851063%;
 }
 .row-fluid .offset5 {
-  margin-left: 44.68085106%;
-  *margin-left: 44.57446809%;
+  margin-left: 44.68085106382979%;
+  *margin-left: 44.57446808510638%;
 }
 .row-fluid .offset5:first-child {
-  margin-left: 42.55319149%;
-  *margin-left: 42.44680851%;
+  margin-left: 42.5531914893617%;
+  *margin-left: 42.4468085106383%;
 }
 .row-fluid .offset4 {
-  margin-left: 36.17021277%;
-  *margin-left: 36.06382979%;
+  margin-left: 36.170212765957444%;
+  *margin-left: 36.06382978723405%;
 }
 .row-fluid .offset4:first-child {
-  margin-left: 34.04255319%;
-  *margin-left: 33.93617021%;
+  margin-left: 34.04255319148936%;
+  *margin-left: 33.93617021276596%;
 }
 .row-fluid .offset3 {
-  margin-left: 27.65957447%;
-  *margin-left: 27.55319149%;
+  margin-left: 27.659574468085104%;
+  *margin-left: 27.5531914893617%;
 }
 .row-fluid .offset3:first-child {
-  margin-left: 25.53191489%;
-  *margin-left: 25.42553191%;
+  margin-left: 25.53191489361702%;
+  *margin-left: 25.425531914893618%;
 }
 .row-fluid .offset2 {
-  margin-left: 19.14893617%;
-  *margin-left: 19.04255319%;
+  margin-left: 19.148936170212764%;
+  *margin-left: 19.04255319148936%;
 }
 .row-fluid .offset2:first-child {
-  margin-left: 17.0212766%;
-  *margin-left: 16.91489362%;
+  margin-left: 17.02127659574468%;
+  *margin-left: 16.914893617021278%;
 }
 .row-fluid .offset1 {
-  margin-left: 10.63829787%;
-  *margin-left: 10.53191489%;
+  margin-left: 10.638297872340425%;
+  *margin-left: 10.53191489361702%;
 }
 .row-fluid .offset1:first-child {
-  margin-left: 8.5106383%;
-  *margin-left: 8.40425532%;
+  margin-left: 8.51063829787234%;
+  *margin-left: 8.404255319148938%;
 }
 [class*="span"].hide,
 .row-fluid [class*="span"].hide {
@@ -543,158 +547,158 @@ ul.row-fluid {
   -moz-box-sizing: border-box;
   box-sizing: border-box;
   float: left;
-  margin-left: 3.44827586%;
-  *margin-left: 3.39508437%;
+  margin-left: 3.4482758620689653%;
+  *margin-left: 3.395084372707263%;
 }
 .product-list .row-fluid [class*="span"]:first-child {
   margin-left: 0;
 }
 .product-list .row-fluid .controls-row [class*="span"] + [class*="span"] {
-  margin-left: 3.44827586%;
+  margin-left: 3.4482758620689653%;
 }
 .product-list .row-fluid .span12 {
   width: 100%;
-  *width: 99.94680851%;
+  *width: 99.94680851063829%;
 }
 .product-list .row-fluid .span11 {
-  width: 91.37931034%;
-  *width: 91.32611886%;
+  width: 91.37931034482759%;
+  *width: 91.32611885546588%;
 }
 .product-list .row-fluid .span10 {
-  width: 82.75862069%;
-  *width: 82.7054292%;
+  width: 82.75862068965517%;
+  *width: 82.70542920029347%;
 }
 .product-list .row-fluid .span9 {
-  width: 74.13793103%;
-  *width: 74.08473955%;
+  width: 74.13793103448276%;
+  *width: 74.08473954512105%;
 }
 .product-list .row-fluid .span8 {
-  width: 65.51724138%;
-  *width: 65.46404989%;
+  width: 65.51724137931035%;
+  *width: 65.46404988994864%;
 }
 .product-list .row-fluid .span7 {
-  width: 56.89655172%;
-  *width: 56.84336023%;
+  width: 56.896551724137936%;
+  *width: 56.843360234776235%;
 }
 .product-list .row-fluid .span6 {
-  width: 48.27586207%;
-  *width: 48.22267058%;
+  width: 48.275862068965516%;
+  *width: 48.222670579603815%;
 }
 .product-list .row-fluid .span5 {
-  width: 39.65517241%;
-  *width: 39.60198092%;
+  width: 39.6551724137931%;
+  *width: 39.6019809244314%;
 }
 .product-list .row-fluid .span4 {
-  width: 31.03448276%;
-  *width: 30.98129127%;
+  width: 31.03448275862069%;
+  *width: 30.98129126925899%;
 }
 .product-list .row-fluid .span3 {
-  width: 22.4137931%;
-  *width: 22.36060161%;
+  width: 22.413793103448278%;
+  *width: 22.360601614086576%;
 }
 .product-list .row-fluid .span2 {
-  width: 13.79310345%;
-  *width: 13.73991196%;
+  width: 13.793103448275861%;
+  *width: 13.73991195891416%;
 }
 .product-list .row-fluid .span1 {
-  width: 5.17241379%;
-  *width: 5.1192223%;
+  width: 5.172413793103448%;
+  *width: 5.119222303741746%;
 }
 .product-list .row-fluid .offset12 {
-  margin-left: 106.89655172%;
-  *margin-left: 106.79016875%;
+  margin-left: 106.89655172413794%;
+  *margin-left: 106.79016874541452%;
 }
 .product-list .row-fluid .offset12:first-child {
-  margin-left: 103.44827586%;
-  *margin-left: 103.34189288%;
+  margin-left: 103.44827586206897%;
+  *margin-left: 103.34189288334555%;
 }
 .product-list .row-fluid .offset11 {
-  margin-left: 98.27586207%;
-  *margin-left: 98.16947909%;
+  margin-left: 98.27586206896552%;
+  *margin-left: 98.1694790902421%;
 }
 .product-list .row-fluid .offset11:first-child {
-  margin-left: 94.82758621%;
-  *margin-left: 94.72120323%;
+  margin-left: 94.82758620689656%;
+  *margin-left: 94.72120322817314%;
 }
 .product-list .row-fluid .offset10 {
-  margin-left: 89.65517241%;
-  *margin-left: 89.54878944%;
+  margin-left: 89.65517241379311%;
+  *margin-left: 89.5487894350697%;
 }
 .product-list .row-fluid .offset10:first-child {
-  margin-left: 86.20689655%;
-  *margin-left: 86.10051357%;
+  margin-left: 86.20689655172414%;
+  *margin-left: 86.10051357300073%;
 }
 .product-list .row-fluid .offset9 {
-  margin-left: 81.03448276%;
-  *margin-left: 80.92809978%;
+  margin-left: 81.0344827586207%;
+  *margin-left: 80.92809977989728%;
 }
 .product-list .row-fluid .offset9:first-child {
-  margin-left: 77.5862069%;
-  *margin-left: 77.47982392%;
+  margin-left: 77.58620689655173%;
+  *margin-left: 77.47982391782831%;
 }
 .product-list .row-fluid .offset8 {
-  margin-left: 72.4137931%;
-  *margin-left: 72.30741012%;
+  margin-left: 72.41379310344828%;
+  *margin-left: 72.30741012472487%;
 }
 .product-list .row-fluid .offset8:first-child {
-  margin-left: 68.96551724%;
-  *margin-left: 68.85913426%;
+  margin-left: 68.96551724137932%;
+  *margin-left: 68.8591342626559%;
 }
 .product-list .row-fluid .offset7 {
-  margin-left: 63.79310345%;
-  *margin-left: 63.68672047%;
+  margin-left: 63.793103448275865%;
+  *margin-left: 63.68672046955246%;
 }
 .product-list .row-fluid .offset7:first-child {
-  margin-left: 60.34482759%;
-  *margin-left: 60.23844461%;
+  margin-left: 60.344827586206904%;
+  *margin-left: 60.2384446074835%;
 }
 .product-list .row-fluid .offset6 {
-  margin-left: 55.17241379%;
-  *margin-left: 55.06603081%;
+  margin-left: 55.172413793103445%;
+  *margin-left: 55.06603081438004%;
 }
 .product-list .row-fluid .offset6:first-child {
-  margin-left: 51.72413793%;
-  *margin-left: 51.61775495%;
+  margin-left: 51.724137931034484%;
+  *margin-left: 51.61775495231108%;
 }
 .product-list .row-fluid .offset5 {
-  margin-left: 46.55172414%;
-  *margin-left: 46.44534116%;
+  margin-left: 46.55172413793103%;
+  *margin-left: 46.44534115920763%;
 }
 .product-list .row-fluid .offset5:first-child {
-  margin-left: 43.10344828%;
-  *margin-left: 42.9970653%;
+  margin-left: 43.10344827586207%;
+  *margin-left: 42.99706529713867%;
 }
 .product-list .row-fluid .offset4 {
-  margin-left: 37.93103448%;
-  *margin-left: 37.8246515%;
+  margin-left: 37.93103448275862%;
+  *margin-left: 37.82465150403522%;
 }
 .product-list .row-fluid .offset4:first-child {
-  margin-left: 34.48275862%;
-  *margin-left: 34.37637564%;
+  margin-left: 34.48275862068966%;
+  *margin-left: 34.376375641966256%;
 }
 .product-list .row-fluid .offset3 {
-  margin-left: 29.31034483%;
-  *margin-left: 29.20396185%;
+  margin-left: 29.310344827586206%;
+  *margin-left: 29.203961848862804%;
 }
 .product-list .row-fluid .offset3:first-child {
-  margin-left: 25.86206897%;
-  *margin-left: 25.75568599%;
+  margin-left: 25.862068965517242%;
+  *margin-left: 25.75568598679384%;
 }
 .product-list .row-fluid .offset2 {
-  margin-left: 20.68965517%;
-  *margin-left: 20.58327219%;
+  margin-left: 20.689655172413794%;
+  *margin-left: 20.58327219369039%;
 }
 .product-list .row-fluid .offset2:first-child {
-  margin-left: 17.24137931%;
-  *margin-left: 17.13499633%;
+  margin-left: 17.241379310344826%;
+  *margin-left: 17.134996331621423%;
 }
 .product-list .row-fluid .offset1 {
-  margin-left: 12.06896552%;
-  *margin-left: 11.96258254%;
+  margin-left: 12.068965517241379%;
+  *margin-left: 11.962582538517974%;
 }
 .product-list .row-fluid .offset1:first-child {
-  margin-left: 8.62068966%;
-  *margin-left: 8.51430668%;
+  margin-left: 8.620689655172413%;
+  *margin-left: 8.51430667644901%;
 }
 .product-list .row-fluid [class*="span"].no-margin {
   margin-left: 0;
@@ -812,19 +816,19 @@ h6 small {
   line-height: 1;
 }
 h1 {
-  font-size: 3.42857143em;
+  font-size: 3.4285714285714284em;
   line-height: 58px;
 }
 h2 {
-  font-size: 2.28571429em;
+  font-size: 2.2857142857142856em;
   line-height: 38px;
 }
 h3 {
-  font-size: 1.71428571em;
+  font-size: 1.7142857142857142em;
   line-height: 30px;
 }
 h4 {
-  font-size: 1.14285714em;
+  font-size: 1.1428571428571428em;
   line-height: 20px;
 }
 h5,
@@ -833,13 +837,13 @@ h6 {
   line-height: 20px;
 }
 h1 small {
-  font-size: 0.66666667em;
+  font-size: 0.6666666666666666em;
 }
 h2 small {
   font-size: 0.75em;
 }
 h3 small {
-  font-size: 0.66666667em;
+  font-size: 0.6666666666666666em;
 }
 h4 small {
   font-size: 0.875em;
@@ -874,7 +878,7 @@ h3 {
   clear: both;
 }
 .page-header h1 {
-  font-size: 2.28571429em;
+  font-size: 2.2857142857142856em;
   line-height: 38px;
   text-transform: uppercase;
 }
@@ -929,6 +933,7 @@ ol.inline > li {
   display: inline-block;
   *display: inline;
   /* IE7 inline-block hack */
+
   *zoom: 1;
   padding-left: 5px;
   padding-right: 5px;
@@ -1104,11 +1109,11 @@ input[type="tel"],
 input[type="color"],
 .uneditable-input {
   display: inline-block;
-  height: 1.71428571em;
+  height: 1.7142857142857142em;
   padding: 6px;
-  margin-bottom: 0.85714286em;
-  font-size: 1.14285714em;
-  line-height: 1.71428571em;
+  margin-bottom: 0.8571428571428571em;
+  font-size: 1.1428571428571428em;
+  line-height: 1.7142857142857142em;
   color: #8e8e8e;
   vertical-align: middle;
 }
@@ -1163,6 +1168,7 @@ input[type="color"]:focus,
   outline: 0;
   outline: thin dotted \9;
   /* IE6-9 */
+
   -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(82,168,236,.6);
   -moz-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(82,168,236,.6);
   box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(82,168,236,.6);
@@ -1172,8 +1178,10 @@ input[type="checkbox"] {
   margin: 4px 0 0;
   *margin-top: 0;
   /* IE7 */
+
   margin-top: 1px \9;
   /* IE8-9 */
+
   line-height: normal;
 }
 input[type="file"],
@@ -1189,8 +1197,10 @@ select,
 input[type="file"] {
   height: 40px;
   /* In IE7, the height of the select element cannot be changed by height, only font-size */
+
   *margin-top: 4px;
   /* For IE7, add top margin to align select with labels */
+
   line-height: 40px;
 }
 select {
@@ -1589,6 +1599,7 @@ select:focus:invalid:focus {
   display: inline-block;
   *display: inline;
   /* IE7 inline-block hack */
+
   *zoom: 1;
   vertical-align: middle;
   padding-left: 5px;
@@ -1739,6 +1750,7 @@ input.search-query {
   padding-left: 14px;
   padding-left: 4px \9;
   /* IE7-8 doesn't have border-radius, so don't indent the padding */
+
   margin-bottom: 0;
   -webkit-border-radius: 15px;
   -moz-border-radius: 15px;
@@ -1795,6 +1807,7 @@ input.search-query {
   display: inline-block;
   *display: inline;
   /* IE7 inline-block hack */
+
   *zoom: 1;
   margin-bottom: 0;
   vertical-align: middle;
@@ -2382,6 +2395,7 @@ button.close {
   display: inline-block;
   *display: inline;
   /* IE7 inline-block hack */
+
   *zoom: 1;
   padding: 8px 16px;
   margin-bottom: 0;
@@ -2449,7 +2463,7 @@ fieldset[disabled] .btn {
 }
 .btn-large {
   padding: 20px 30px;
-  font-size: 1.71428571em;
+  font-size: 1.7142857142857142em;
   *line-height: 2em;
 }
 .btn-large [class^="icon-"],
@@ -2612,6 +2626,7 @@ input[type="submit"].btn.btn-mini {
   display: inline-block;
   *display: inline;
   /* IE7 inline-block hack */
+
   *zoom: 1;
   font-size: 0;
   vertical-align: middle;
@@ -2791,6 +2806,7 @@ input[type="submit"].btn.btn-mini {
   display: inline-block;
   *display: inline;
   /* IE7 inline-block hack */
+
   *zoom: 1;
 }
 .btn-group-vertical > .btn {
@@ -3762,6 +3778,7 @@ input[type="submit"].btn.btn-mini {
   display: inline-block;
   *display: inline;
   /* IE7 inline-block hack */
+
   *zoom: 1;
   text-shadow: 0 1px 0 #ffffff;
 }
@@ -3788,6 +3805,7 @@ input[type="submit"].btn.btn-mini {
   display: inline-block;
   *display: inline;
   /* IE7 inline-block hack */
+
   *zoom: 1;
   margin-left: 0;
   margin-bottom: 0;
@@ -3988,6 +4006,7 @@ input[type="submit"].btn.btn-mini {
   border: 1px solid rgba(0, 0, 0, 0.3);
   *border: 1px solid #999;
   /* IE6-7 */
+
   -webkit-border-radius: 6px;
   -moz-border-radius: 6px;
   border-radius: 6px;
@@ -4506,7 +4525,7 @@ you can use the generic selector below, but it's slower:
   margin-right: 5px;
 }
 .header-content i {
-  font-size: 1.71428571em;
+  font-size: 1.7142857142857142em;
   color: #337abf;
   margin-right: 5px;
   vertical-align: top;
@@ -4583,7 +4602,7 @@ you can use the generic selector below, but it's slower:
   clear: both;
 }
 .footer-links h3 {
-  font-size: 1.14285714em;
+  font-size: 1.1428571428571428em;
   color: #ffffff;
   margin-bottom: 20px;
   text-transform: capitalize;
@@ -4610,7 +4629,7 @@ you can use the generic selector below, but it's slower:
   float: right;
 }
 .social-icons {
-  font-size: 2.28571429em;
+  font-size: 2.2857142857142856em;
 }
 .social-icons a:hover {
   text-decoration: none;
@@ -4772,7 +4791,7 @@ you can use the generic selector below, but it's slower:
   margin: 0;
 }
 .checkout-proceed > strong {
-  font-size: 1.14285714em;
+  font-size: 1.1428571428571428em;
   text-transform: uppercase;
   display: block;
   margin: 20px 0;
@@ -4867,14 +4886,14 @@ you can use the generic selector below, but it's slower:
   font-weight: bold;
   text-transform: uppercase;
   color: #10283f;
-  font-size: 1.28571429em;
+  font-size: 1.2857142857142858em;
 }
 .checkoutNav ul li.visited {
   color: #4ca84c;
 }
 .checkoutNav ul li.visited i:first-child + i {
   display: inline-block;
-  font-size: 1.33333333em;
+  font-size: 1.3333333333333333em;
   line-height: 1em;
 }
 .checkoutNav ul li.visited a {
@@ -4882,7 +4901,7 @@ you can use the generic selector below, but it's slower:
 }
 .checkoutNav ul li.active i:first-child {
   display: inline-block;
-  font-size: 1.77777778em;
+  font-size: 1.7777777777777777em;
   line-height: 1em;
   height: 1em;
   overflow: hidden;
@@ -4953,7 +4972,7 @@ you can use the generic selector below, but it's slower:
   margin-bottom: 0;
 }
 .product_pod h3 {
-  font-size: 1.14285714em;
+  font-size: 1.1428571428571428em;
   margin-bottom: 0;
   line-height: 20px;
   color: #8e8e8e;
@@ -5014,7 +5033,7 @@ you can use the generic selector below, but it's slower:
   color: #ffffff;
   text-transform: uppercase;
   margin-bottom: 0;
-  font-size: 2.28571429em;
+  font-size: 2.2857142857142856em;
   margin: 50px 35% 0 30px;
 }
 .category-title p {
@@ -5116,8 +5135,8 @@ you can use the generic selector below, but it's slower:
   float: left;
 }
 .product-highlight .price_color i {
-  font-size: 1.14285714em;
-  line-height: 1.14285714em;
+  font-size: 1.1428571428571428em;
+  line-height: 1.1428571428571428em;
 }
 .product-highlight .free-delivery {
   float: right;
@@ -5128,7 +5147,7 @@ you can use the generic selector below, but it's slower:
   padding: 10px;
 }
 .product-page .free-delivery > span span {
-  font-size: 1.42857143em;
+  font-size: 1.4285714285714286em;
   font-weight: 700;
 }
 .review-title {
@@ -5145,7 +5164,7 @@ you can use the generic selector below, but it's slower:
   clear: both;
 }
 .review-title p {
-  font-size: 1.14285714em;
+  font-size: 1.1428571428571428em;
 }
 .review-title > a {
   float: right;
@@ -5166,8 +5185,8 @@ you can use the generic selector below, but it's slower:
   clear: both;
 }
 .review h3 {
-  font-size: 1.14285714em;
-  line-height: 1.71428571em;
+  font-size: 1.1428571428571428em;
+  line-height: 1.7142857142857142em;
   text-transform: none;
 }
 .review h3 a {
@@ -5205,7 +5224,7 @@ you can use the generic selector below, but it's slower:
 }
 .review_add h3 {
   color: #97a5a3;
-  font-size: 1.14285714em;
+  font-size: 1.1428571428571428em;
 }
 .child-product {
   *zoom: 1;
@@ -5227,7 +5246,7 @@ you can use the generic selector below, but it's slower:
   margin-bottom: 15px;
 }
 .child-product .price_color {
-  font-size: 1.71428571em;
+  font-size: 1.7142857142857142em;
 }
 .child-product .image_container {
   background: #ffffff;
@@ -5446,8 +5465,7 @@ you can use the generic selector below, but it's slower:
   list-style: none;
 }
 /* FlexSlider Necessary Styles
-*********************************/
-.flexslider {
+*********************************/.flexslider {
   margin: 0;
   padding: 0;
 }
@@ -5741,11 +5759,11 @@ html[xmlns] .slides {
   display: block;
 }
 .free-delivery > span span {
-  font-size: 1.33333333em;
+  font-size: 1.3333333333333333em;
   line-height: 1em;
 }
 .free-delivery strong {
-  font-size: 0.70833333em;
+  font-size: 0.7083333333333334em;
   letter-spacing: 0;
 }
 .widget-delivery,
@@ -5801,13 +5819,13 @@ html[xmlns] .slides {
 }
 .widget-image-link h3 small {
   display: block;
-  line-height: 1.14285714em;
+  line-height: 1.1428571428571428em;
 }
 .widget-image-link i {
   position: absolute;
   right: 5px;
   top: 10px;
-  font-size: 1.33333333em;
+  font-size: 1.3333333333333333em;
 }
 .widget-image-link.large h3 {
   background: #10283f;
@@ -5853,4 +5871,3 @@ html[xmlns] .slides {
 .table .align-center {
   text-align: center;
 }
-/*# sourceMappingURL=styles.css.map */

--- a/src/oscar/static/oscar/css/dashboard.css
+++ b/src/oscar/static/oscar/css/dashboard.css
@@ -20,7 +20,9 @@
   width: 100%;
   min-height: 28px;
   /* Make inputs at least the height of their button counterpart */
+
   /* Makes inputs behave like true block-level elements */
+
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   -ms-box-sizing: border-box;
@@ -80,7 +82,7 @@
 /* makes the font 33% larger relative to the icon container */
 .icon-large:before {
   vertical-align: -10%;
-  font-size: 1.33333333em;
+  font-size: 1.3333333333333333em;
 }
 /* makes sure icons active on rollover in links */
 a [class^="icon-"],
@@ -91,16 +93,16 @@ a [class*=" icon-"] {
 [class^="icon-"].icon-fixed-width,
 [class*=" icon-"].icon-fixed-width {
   display: inline-block;
-  width: 1.14285714em;
+  width: 1.1428571428571428em;
   text-align: right;
-  padding-right: 0.28571429em;
+  padding-right: 0.2857142857142857em;
 }
 [class^="icon-"].icon-fixed-width.icon-large,
 [class*=" icon-"].icon-fixed-width.icon-large {
-  width: 1.42857143em;
+  width: 1.4285714285714286em;
 }
 .icons-ul {
-  margin-left: 2.14285714em;
+  margin-left: 2.142857142857143em;
   list-style-type: none;
 }
 .icons-ul > li {
@@ -108,8 +110,8 @@ a [class*=" icon-"] {
 }
 .icons-ul .icon-li {
   position: absolute;
-  left: -2.14285714em;
-  width: 2.14285714em;
+  left: -2.142857142857143em;
+  width: 2.142857142857143em;
   text-align: center;
   line-height: inherit;
 }
@@ -1531,7 +1533,7 @@ a .icon-flip-vertical:before {
  *  Work: Lead Product Designer @ Kyruus - http://kyruus.com
  */
 .lt-ie8 .icon-large {
-  font-size: 1.33333333em;
+  font-size: 1.3333333333333333em;
   margin-top: -4px;
   padding-top: 3px;
   margin-bottom: -4px;
@@ -3029,6 +3031,7 @@ body {
 .container-fluid.dashboard {
   margin: 0 auto;
   /*  max-width: 1170px;*/
+
   position: relative;
   padding: 0 20px;
 }
@@ -3862,4 +3865,3 @@ textarea.plain {
     -webkit-transform: none;
   }
 }
-/*# sourceMappingURL=dashboard.css.map */

--- a/src/oscar/static/oscar/css/responsive.css
+++ b/src/oscar/static/oscar/css/responsive.css
@@ -210,158 +210,158 @@
     -moz-box-sizing: border-box;
     box-sizing: border-box;
     float: left;
-    margin-left: 2.56410256%;
-    *margin-left: 2.51091107%;
+    margin-left: 2.564102564102564%;
+    *margin-left: 2.5109110747408616%;
   }
   .row-fluid [class*="span"]:first-child {
     margin-left: 0;
   }
   .row-fluid .controls-row [class*="span"] + [class*="span"] {
-    margin-left: 2.56410256%;
+    margin-left: 2.564102564102564%;
   }
   .row-fluid .span12 {
     width: 100%;
-    *width: 99.94680851%;
+    *width: 99.94680851063829%;
   }
   .row-fluid .span11 {
-    width: 91.45299145%;
-    *width: 91.39979996%;
+    width: 91.45299145299145%;
+    *width: 91.39979996362975%;
   }
   .row-fluid .span10 {
-    width: 82.90598291%;
-    *width: 82.85279142%;
+    width: 82.90598290598291%;
+    *width: 82.8527914166212%;
   }
   .row-fluid .span9 {
-    width: 74.35897436%;
-    *width: 74.30578287%;
+    width: 74.35897435897436%;
+    *width: 74.30578286961266%;
   }
   .row-fluid .span8 {
-    width: 65.81196581%;
-    *width: 65.75877432%;
+    width: 65.81196581196582%;
+    *width: 65.75877432260411%;
   }
   .row-fluid .span7 {
-    width: 57.26495726%;
-    *width: 57.21176578%;
+    width: 57.26495726495726%;
+    *width: 57.21176577559556%;
   }
   .row-fluid .span6 {
-    width: 48.71794872%;
-    *width: 48.66475723%;
+    width: 48.717948717948715%;
+    *width: 48.664757228587014%;
   }
   .row-fluid .span5 {
-    width: 40.17094017%;
-    *width: 40.11774868%;
+    width: 40.17094017094017%;
+    *width: 40.11774868157847%;
   }
   .row-fluid .span4 {
-    width: 31.62393162%;
-    *width: 31.57074013%;
+    width: 31.623931623931625%;
+    *width: 31.570740134569924%;
   }
   .row-fluid .span3 {
-    width: 23.07692308%;
-    *width: 23.02373159%;
+    width: 23.076923076923077%;
+    *width: 23.023731587561375%;
   }
   .row-fluid .span2 {
-    width: 14.52991453%;
-    *width: 14.47672304%;
+    width: 14.52991452991453%;
+    *width: 14.476723040552828%;
   }
   .row-fluid .span1 {
-    width: 5.98290598%;
-    *width: 5.92971449%;
+    width: 5.982905982905983%;
+    *width: 5.929714493544281%;
   }
   .row-fluid .offset12 {
-    margin-left: 105.12820513%;
-    *margin-left: 105.02182215%;
+    margin-left: 105.12820512820512%;
+    *margin-left: 105.02182214948171%;
   }
   .row-fluid .offset12:first-child {
-    margin-left: 102.56410256%;
-    *margin-left: 102.45771959%;
+    margin-left: 102.56410256410257%;
+    *margin-left: 102.45771958537915%;
   }
   .row-fluid .offset11 {
-    margin-left: 96.58119658%;
-    *margin-left: 96.4748136%;
+    margin-left: 96.58119658119658%;
+    *margin-left: 96.47481360247316%;
   }
   .row-fluid .offset11:first-child {
-    margin-left: 94.01709402%;
-    *margin-left: 93.91071104%;
+    margin-left: 94.01709401709402%;
+    *margin-left: 93.91071103837061%;
   }
   .row-fluid .offset10 {
-    margin-left: 88.03418803%;
-    *margin-left: 87.92780506%;
+    margin-left: 88.03418803418803%;
+    *margin-left: 87.92780505546462%;
   }
   .row-fluid .offset10:first-child {
-    margin-left: 85.47008547%;
-    *margin-left: 85.36370249%;
+    margin-left: 85.47008547008548%;
+    *margin-left: 85.36370249136206%;
   }
   .row-fluid .offset9 {
-    margin-left: 79.48717949%;
-    *margin-left: 79.38079651%;
+    margin-left: 79.48717948717949%;
+    *margin-left: 79.38079650845607%;
   }
   .row-fluid .offset9:first-child {
-    margin-left: 76.92307692%;
-    *margin-left: 76.81669394%;
+    margin-left: 76.92307692307693%;
+    *margin-left: 76.81669394435352%;
   }
   .row-fluid .offset8 {
-    margin-left: 70.94017094%;
-    *margin-left: 70.83378796%;
+    margin-left: 70.94017094017094%;
+    *margin-left: 70.83378796144753%;
   }
   .row-fluid .offset8:first-child {
-    margin-left: 68.37606838%;
-    *margin-left: 68.2696854%;
+    margin-left: 68.37606837606839%;
+    *margin-left: 68.26968539734497%;
   }
   .row-fluid .offset7 {
-    margin-left: 62.39316239%;
-    *margin-left: 62.28677941%;
+    margin-left: 62.393162393162385%;
+    *margin-left: 62.28677941443899%;
   }
   .row-fluid .offset7:first-child {
-    margin-left: 59.82905983%;
-    *margin-left: 59.72267685%;
+    margin-left: 59.82905982905982%;
+    *margin-left: 59.72267685033642%;
   }
   .row-fluid .offset6 {
-    margin-left: 53.84615385%;
-    *margin-left: 53.73977087%;
+    margin-left: 53.84615384615384%;
+    *margin-left: 53.739770867430444%;
   }
   .row-fluid .offset6:first-child {
-    margin-left: 51.28205128%;
-    *margin-left: 51.1756683%;
+    margin-left: 51.28205128205128%;
+    *margin-left: 51.175668303327875%;
   }
   .row-fluid .offset5 {
-    margin-left: 45.2991453%;
-    *margin-left: 45.19276232%;
+    margin-left: 45.299145299145295%;
+    *margin-left: 45.1927623204219%;
   }
   .row-fluid .offset5:first-child {
-    margin-left: 42.73504274%;
-    *margin-left: 42.62865976%;
+    margin-left: 42.73504273504273%;
+    *margin-left: 42.62865975631933%;
   }
   .row-fluid .offset4 {
-    margin-left: 36.75213675%;
-    *margin-left: 36.64575377%;
+    margin-left: 36.75213675213675%;
+    *margin-left: 36.645753773413354%;
   }
   .row-fluid .offset4:first-child {
-    margin-left: 34.18803419%;
-    *margin-left: 34.08165121%;
+    margin-left: 34.18803418803419%;
+    *margin-left: 34.081651209310785%;
   }
   .row-fluid .offset3 {
-    margin-left: 28.20512821%;
-    *margin-left: 28.09874523%;
+    margin-left: 28.205128205128204%;
+    *margin-left: 28.0987452264048%;
   }
   .row-fluid .offset3:first-child {
-    margin-left: 25.64102564%;
-    *margin-left: 25.53464266%;
+    margin-left: 25.641025641025642%;
+    *margin-left: 25.53464266230224%;
   }
   .row-fluid .offset2 {
-    margin-left: 19.65811966%;
-    *margin-left: 19.55173668%;
+    margin-left: 19.65811965811966%;
+    *margin-left: 19.551736679396257%;
   }
   .row-fluid .offset2:first-child {
-    margin-left: 17.09401709%;
-    *margin-left: 16.98763412%;
+    margin-left: 17.094017094017094%;
+    *margin-left: 16.98763411529369%;
   }
   .row-fluid .offset1 {
-    margin-left: 11.11111111%;
-    *margin-left: 11.00472813%;
+    margin-left: 11.11111111111111%;
+    *margin-left: 11.004728132387708%;
   }
   .row-fluid .offset1:first-child {
-    margin-left: 8.54700855%;
-    *margin-left: 8.44062557%;
+    margin-left: 8.547008547008547%;
+    *margin-left: 8.440625568285142%;
   }
   input,
   textarea,
@@ -559,158 +559,158 @@
     -moz-box-sizing: border-box;
     box-sizing: border-box;
     float: left;
-    margin-left: 2.76243094%;
-    *margin-left: 2.70923945%;
+    margin-left: 2.7624309392265194%;
+    *margin-left: 2.709239449864817%;
   }
   .row-fluid [class*="span"]:first-child {
     margin-left: 0;
   }
   .row-fluid .controls-row [class*="span"] + [class*="span"] {
-    margin-left: 2.76243094%;
+    margin-left: 2.7624309392265194%;
   }
   .row-fluid .span12 {
     width: 100%;
-    *width: 99.94680851%;
+    *width: 99.94680851063829%;
   }
   .row-fluid .span11 {
-    width: 91.43646409%;
-    *width: 91.3832726%;
+    width: 91.43646408839778%;
+    *width: 91.38327259903608%;
   }
   .row-fluid .span10 {
-    width: 82.87292818%;
-    *width: 82.81973669%;
+    width: 82.87292817679558%;
+    *width: 82.81973668743387%;
   }
   .row-fluid .span9 {
-    width: 74.30939227%;
-    *width: 74.25620078%;
+    width: 74.30939226519337%;
+    *width: 74.25620077583166%;
   }
   .row-fluid .span8 {
-    width: 65.74585635%;
-    *width: 65.69266486%;
+    width: 65.74585635359117%;
+    *width: 65.69266486422946%;
   }
   .row-fluid .span7 {
-    width: 57.18232044%;
-    *width: 57.12912895%;
+    width: 57.18232044198895%;
+    *width: 57.12912895262725%;
   }
   .row-fluid .span6 {
-    width: 48.61878453%;
-    *width: 48.56559304%;
+    width: 48.61878453038674%;
+    *width: 48.56559304102504%;
   }
   .row-fluid .span5 {
-    width: 40.05524862%;
-    *width: 40.00205713%;
+    width: 40.05524861878453%;
+    *width: 40.00205712942283%;
   }
   .row-fluid .span4 {
-    width: 31.49171271%;
-    *width: 31.43852122%;
+    width: 31.491712707182323%;
+    *width: 31.43852121782062%;
   }
   .row-fluid .span3 {
-    width: 22.9281768%;
-    *width: 22.87498531%;
+    width: 22.92817679558011%;
+    *width: 22.87498530621841%;
   }
   .row-fluid .span2 {
-    width: 14.36464088%;
-    *width: 14.31144939%;
+    width: 14.3646408839779%;
+    *width: 14.311449394616199%;
   }
   .row-fluid .span1 {
-    width: 5.80110497%;
-    *width: 5.74791348%;
+    width: 5.801104972375691%;
+    *width: 5.747913483013988%;
   }
   .row-fluid .offset12 {
-    margin-left: 105.52486188%;
-    *margin-left: 105.4184789%;
+    margin-left: 105.52486187845304%;
+    *margin-left: 105.41847889972962%;
   }
   .row-fluid .offset12:first-child {
-    margin-left: 102.76243094%;
-    *margin-left: 102.65604796%;
+    margin-left: 102.76243093922652%;
+    *margin-left: 102.6560479605031%;
   }
   .row-fluid .offset11 {
-    margin-left: 96.96132597%;
-    *margin-left: 96.85494299%;
+    margin-left: 96.96132596685082%;
+    *margin-left: 96.8549429881274%;
   }
   .row-fluid .offset11:first-child {
-    margin-left: 94.19889503%;
-    *margin-left: 94.09251205%;
+    margin-left: 94.1988950276243%;
+    *margin-left: 94.09251204890089%;
   }
   .row-fluid .offset10 {
-    margin-left: 88.39779006%;
-    *margin-left: 88.29140708%;
+    margin-left: 88.39779005524862%;
+    *margin-left: 88.2914070765252%;
   }
   .row-fluid .offset10:first-child {
-    margin-left: 85.63535912%;
-    *margin-left: 85.52897614%;
+    margin-left: 85.6353591160221%;
+    *margin-left: 85.52897613729868%;
   }
   .row-fluid .offset9 {
-    margin-left: 79.83425414%;
-    *margin-left: 79.72787116%;
+    margin-left: 79.8342541436464%;
+    *margin-left: 79.72787116492299%;
   }
   .row-fluid .offset9:first-child {
-    margin-left: 77.0718232%;
-    *margin-left: 76.96544023%;
+    margin-left: 77.07182320441989%;
+    *margin-left: 76.96544022569647%;
   }
   .row-fluid .offset8 {
-    margin-left: 71.27071823%;
-    *margin-left: 71.16433525%;
+    margin-left: 71.2707182320442%;
+    *margin-left: 71.16433525332079%;
   }
   .row-fluid .offset8:first-child {
-    margin-left: 68.50828729%;
-    *margin-left: 68.40190431%;
+    margin-left: 68.50828729281768%;
+    *margin-left: 68.40190431409427%;
   }
   .row-fluid .offset7 {
-    margin-left: 62.70718232%;
-    *margin-left: 62.60079934%;
+    margin-left: 62.70718232044199%;
+    *margin-left: 62.600799341718584%;
   }
   .row-fluid .offset7:first-child {
-    margin-left: 59.94475138%;
-    *margin-left: 59.8383684%;
+    margin-left: 59.94475138121547%;
+    *margin-left: 59.838368402492065%;
   }
   .row-fluid .offset6 {
-    margin-left: 54.14364641%;
-    *margin-left: 54.03726343%;
+    margin-left: 54.14364640883978%;
+    *margin-left: 54.037263430116376%;
   }
   .row-fluid .offset6:first-child {
-    margin-left: 51.38121547%;
-    *margin-left: 51.27483249%;
+    margin-left: 51.38121546961326%;
+    *margin-left: 51.27483249088986%;
   }
   .row-fluid .offset5 {
-    margin-left: 45.5801105%;
-    *margin-left: 45.47372752%;
+    margin-left: 45.58011049723757%;
+    *margin-left: 45.47372751851417%;
   }
   .row-fluid .offset5:first-child {
-    margin-left: 42.81767956%;
-    *margin-left: 42.71129658%;
+    margin-left: 42.81767955801105%;
+    *margin-left: 42.71129657928765%;
   }
   .row-fluid .offset4 {
-    margin-left: 37.01657459%;
-    *margin-left: 36.91019161%;
+    margin-left: 37.01657458563536%;
+    *margin-left: 36.91019160691196%;
   }
   .row-fluid .offset4:first-child {
-    margin-left: 34.25414365%;
-    *margin-left: 34.14776067%;
+    margin-left: 34.25414364640884%;
+    *margin-left: 34.14776066768544%;
   }
   .row-fluid .offset3 {
-    margin-left: 28.45303867%;
-    *margin-left: 28.3466557%;
+    margin-left: 28.45303867403315%;
+    *margin-left: 28.346655695309746%;
   }
   .row-fluid .offset3:first-child {
-    margin-left: 25.69060773%;
-    *margin-left: 25.58422476%;
+    margin-left: 25.69060773480663%;
+    *margin-left: 25.584224756083227%;
   }
   .row-fluid .offset2 {
-    margin-left: 19.88950276%;
-    *margin-left: 19.78311978%;
+    margin-left: 19.88950276243094%;
+    *margin-left: 19.783119783707537%;
   }
   .row-fluid .offset2:first-child {
-    margin-left: 17.12707182%;
-    *margin-left: 17.02068884%;
+    margin-left: 17.12707182320442%;
+    *margin-left: 17.02068884448102%;
   }
   .row-fluid .offset1 {
-    margin-left: 11.32596685%;
-    *margin-left: 11.21958387%;
+    margin-left: 11.32596685082873%;
+    *margin-left: 11.219583872105325%;
   }
   .row-fluid .offset1:first-child {
-    margin-left: 8.56353591%;
-    *margin-left: 8.45715293%;
+    margin-left: 8.56353591160221%;
+    *margin-left: 8.457152932878806%;
   }
   input,
   textarea,
@@ -1181,4 +1181,3 @@
     -webkit-transform: none;
   }
 }
-/*# sourceMappingURL=responsive.css.map */

--- a/src/oscar/static/oscar/css/styles.css
+++ b/src/oscar/static/oscar/css/styles.css
@@ -883,7 +883,7 @@ html {
 body {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   font-size: 14px;
-  line-height: 1.42857143;
+  line-height: 1.428571429;
   color: #333333;
   background-color: #ffffff;
 }
@@ -930,7 +930,7 @@ img {
 }
 .img-thumbnail {
   padding: 4px;
-  line-height: 1.42857143;
+  line-height: 1.428571429;
   background-color: #ffffff;
   border: 1px solid #dddddd;
   border-radius: 4px;
@@ -1235,7 +1235,7 @@ dl {
 }
 dt,
 dd {
-  line-height: 1.42857143;
+  line-height: 1.428571429;
 }
 dt {
   font-weight: bold;
@@ -1282,7 +1282,7 @@ blockquote small,
 blockquote .small {
   display: block;
   font-size: 80%;
-  line-height: 1.42857143;
+  line-height: 1.428571429;
   color: #777777;
 }
 blockquote footer:before,
@@ -1321,7 +1321,7 @@ blockquote:after {
 address {
   margin-bottom: 20px;
   font-style: normal;
-  line-height: 1.42857143;
+  line-height: 1.428571429;
 }
 code,
 kbd,
@@ -1354,7 +1354,7 @@ pre {
   padding: 9.5px;
   margin: 0 0 10px;
   font-size: 13px;
-  line-height: 1.42857143;
+  line-height: 1.428571429;
   word-break: break-all;
   word-wrap: break-word;
   color: #333333;
@@ -1418,73 +1418,73 @@ pre code {
   width: 100%;
 }
 .col-xs-11 {
-  width: 91.66666667%;
+  width: 91.66666666666666%;
 }
 .col-xs-10 {
-  width: 83.33333333%;
+  width: 83.33333333333334%;
 }
 .col-xs-9 {
   width: 75%;
 }
 .col-xs-8 {
-  width: 66.66666667%;
+  width: 66.66666666666666%;
 }
 .col-xs-7 {
-  width: 58.33333333%;
+  width: 58.333333333333336%;
 }
 .col-xs-6 {
   width: 50%;
 }
 .col-xs-5 {
-  width: 41.66666667%;
+  width: 41.66666666666667%;
 }
 .col-xs-4 {
-  width: 33.33333333%;
+  width: 33.33333333333333%;
 }
 .col-xs-3 {
   width: 25%;
 }
 .col-xs-2 {
-  width: 16.66666667%;
+  width: 16.666666666666664%;
 }
 .col-xs-1 {
-  width: 8.33333333%;
+  width: 8.333333333333332%;
 }
 .col-xs-pull-12 {
   right: 100%;
 }
 .col-xs-pull-11 {
-  right: 91.66666667%;
+  right: 91.66666666666666%;
 }
 .col-xs-pull-10 {
-  right: 83.33333333%;
+  right: 83.33333333333334%;
 }
 .col-xs-pull-9 {
   right: 75%;
 }
 .col-xs-pull-8 {
-  right: 66.66666667%;
+  right: 66.66666666666666%;
 }
 .col-xs-pull-7 {
-  right: 58.33333333%;
+  right: 58.333333333333336%;
 }
 .col-xs-pull-6 {
   right: 50%;
 }
 .col-xs-pull-5 {
-  right: 41.66666667%;
+  right: 41.66666666666667%;
 }
 .col-xs-pull-4 {
-  right: 33.33333333%;
+  right: 33.33333333333333%;
 }
 .col-xs-pull-3 {
   right: 25%;
 }
 .col-xs-pull-2 {
-  right: 16.66666667%;
+  right: 16.666666666666664%;
 }
 .col-xs-pull-1 {
-  right: 8.33333333%;
+  right: 8.333333333333332%;
 }
 .col-xs-pull-0 {
   right: auto;
@@ -1493,37 +1493,37 @@ pre code {
   left: 100%;
 }
 .col-xs-push-11 {
-  left: 91.66666667%;
+  left: 91.66666666666666%;
 }
 .col-xs-push-10 {
-  left: 83.33333333%;
+  left: 83.33333333333334%;
 }
 .col-xs-push-9 {
   left: 75%;
 }
 .col-xs-push-8 {
-  left: 66.66666667%;
+  left: 66.66666666666666%;
 }
 .col-xs-push-7 {
-  left: 58.33333333%;
+  left: 58.333333333333336%;
 }
 .col-xs-push-6 {
   left: 50%;
 }
 .col-xs-push-5 {
-  left: 41.66666667%;
+  left: 41.66666666666667%;
 }
 .col-xs-push-4 {
-  left: 33.33333333%;
+  left: 33.33333333333333%;
 }
 .col-xs-push-3 {
   left: 25%;
 }
 .col-xs-push-2 {
-  left: 16.66666667%;
+  left: 16.666666666666664%;
 }
 .col-xs-push-1 {
-  left: 8.33333333%;
+  left: 8.333333333333332%;
 }
 .col-xs-push-0 {
   left: auto;
@@ -1532,37 +1532,37 @@ pre code {
   margin-left: 100%;
 }
 .col-xs-offset-11 {
-  margin-left: 91.66666667%;
+  margin-left: 91.66666666666666%;
 }
 .col-xs-offset-10 {
-  margin-left: 83.33333333%;
+  margin-left: 83.33333333333334%;
 }
 .col-xs-offset-9 {
   margin-left: 75%;
 }
 .col-xs-offset-8 {
-  margin-left: 66.66666667%;
+  margin-left: 66.66666666666666%;
 }
 .col-xs-offset-7 {
-  margin-left: 58.33333333%;
+  margin-left: 58.333333333333336%;
 }
 .col-xs-offset-6 {
   margin-left: 50%;
 }
 .col-xs-offset-5 {
-  margin-left: 41.66666667%;
+  margin-left: 41.66666666666667%;
 }
 .col-xs-offset-4 {
-  margin-left: 33.33333333%;
+  margin-left: 33.33333333333333%;
 }
 .col-xs-offset-3 {
   margin-left: 25%;
 }
 .col-xs-offset-2 {
-  margin-left: 16.66666667%;
+  margin-left: 16.666666666666664%;
 }
 .col-xs-offset-1 {
-  margin-left: 8.33333333%;
+  margin-left: 8.333333333333332%;
 }
 .col-xs-offset-0 {
   margin-left: 0%;
@@ -1575,73 +1575,73 @@ pre code {
     width: 100%;
   }
   .col-sm-11 {
-    width: 91.66666667%;
+    width: 91.66666666666666%;
   }
   .col-sm-10 {
-    width: 83.33333333%;
+    width: 83.33333333333334%;
   }
   .col-sm-9 {
     width: 75%;
   }
   .col-sm-8 {
-    width: 66.66666667%;
+    width: 66.66666666666666%;
   }
   .col-sm-7 {
-    width: 58.33333333%;
+    width: 58.333333333333336%;
   }
   .col-sm-6 {
     width: 50%;
   }
   .col-sm-5 {
-    width: 41.66666667%;
+    width: 41.66666666666667%;
   }
   .col-sm-4 {
-    width: 33.33333333%;
+    width: 33.33333333333333%;
   }
   .col-sm-3 {
     width: 25%;
   }
   .col-sm-2 {
-    width: 16.66666667%;
+    width: 16.666666666666664%;
   }
   .col-sm-1 {
-    width: 8.33333333%;
+    width: 8.333333333333332%;
   }
   .col-sm-pull-12 {
     right: 100%;
   }
   .col-sm-pull-11 {
-    right: 91.66666667%;
+    right: 91.66666666666666%;
   }
   .col-sm-pull-10 {
-    right: 83.33333333%;
+    right: 83.33333333333334%;
   }
   .col-sm-pull-9 {
     right: 75%;
   }
   .col-sm-pull-8 {
-    right: 66.66666667%;
+    right: 66.66666666666666%;
   }
   .col-sm-pull-7 {
-    right: 58.33333333%;
+    right: 58.333333333333336%;
   }
   .col-sm-pull-6 {
     right: 50%;
   }
   .col-sm-pull-5 {
-    right: 41.66666667%;
+    right: 41.66666666666667%;
   }
   .col-sm-pull-4 {
-    right: 33.33333333%;
+    right: 33.33333333333333%;
   }
   .col-sm-pull-3 {
     right: 25%;
   }
   .col-sm-pull-2 {
-    right: 16.66666667%;
+    right: 16.666666666666664%;
   }
   .col-sm-pull-1 {
-    right: 8.33333333%;
+    right: 8.333333333333332%;
   }
   .col-sm-pull-0 {
     right: auto;
@@ -1650,37 +1650,37 @@ pre code {
     left: 100%;
   }
   .col-sm-push-11 {
-    left: 91.66666667%;
+    left: 91.66666666666666%;
   }
   .col-sm-push-10 {
-    left: 83.33333333%;
+    left: 83.33333333333334%;
   }
   .col-sm-push-9 {
     left: 75%;
   }
   .col-sm-push-8 {
-    left: 66.66666667%;
+    left: 66.66666666666666%;
   }
   .col-sm-push-7 {
-    left: 58.33333333%;
+    left: 58.333333333333336%;
   }
   .col-sm-push-6 {
     left: 50%;
   }
   .col-sm-push-5 {
-    left: 41.66666667%;
+    left: 41.66666666666667%;
   }
   .col-sm-push-4 {
-    left: 33.33333333%;
+    left: 33.33333333333333%;
   }
   .col-sm-push-3 {
     left: 25%;
   }
   .col-sm-push-2 {
-    left: 16.66666667%;
+    left: 16.666666666666664%;
   }
   .col-sm-push-1 {
-    left: 8.33333333%;
+    left: 8.333333333333332%;
   }
   .col-sm-push-0 {
     left: auto;
@@ -1689,37 +1689,37 @@ pre code {
     margin-left: 100%;
   }
   .col-sm-offset-11 {
-    margin-left: 91.66666667%;
+    margin-left: 91.66666666666666%;
   }
   .col-sm-offset-10 {
-    margin-left: 83.33333333%;
+    margin-left: 83.33333333333334%;
   }
   .col-sm-offset-9 {
     margin-left: 75%;
   }
   .col-sm-offset-8 {
-    margin-left: 66.66666667%;
+    margin-left: 66.66666666666666%;
   }
   .col-sm-offset-7 {
-    margin-left: 58.33333333%;
+    margin-left: 58.333333333333336%;
   }
   .col-sm-offset-6 {
     margin-left: 50%;
   }
   .col-sm-offset-5 {
-    margin-left: 41.66666667%;
+    margin-left: 41.66666666666667%;
   }
   .col-sm-offset-4 {
-    margin-left: 33.33333333%;
+    margin-left: 33.33333333333333%;
   }
   .col-sm-offset-3 {
     margin-left: 25%;
   }
   .col-sm-offset-2 {
-    margin-left: 16.66666667%;
+    margin-left: 16.666666666666664%;
   }
   .col-sm-offset-1 {
-    margin-left: 8.33333333%;
+    margin-left: 8.333333333333332%;
   }
   .col-sm-offset-0 {
     margin-left: 0%;
@@ -1733,73 +1733,73 @@ pre code {
     width: 100%;
   }
   .col-md-11 {
-    width: 91.66666667%;
+    width: 91.66666666666666%;
   }
   .col-md-10 {
-    width: 83.33333333%;
+    width: 83.33333333333334%;
   }
   .col-md-9 {
     width: 75%;
   }
   .col-md-8 {
-    width: 66.66666667%;
+    width: 66.66666666666666%;
   }
   .col-md-7 {
-    width: 58.33333333%;
+    width: 58.333333333333336%;
   }
   .col-md-6 {
     width: 50%;
   }
   .col-md-5 {
-    width: 41.66666667%;
+    width: 41.66666666666667%;
   }
   .col-md-4 {
-    width: 33.33333333%;
+    width: 33.33333333333333%;
   }
   .col-md-3 {
     width: 25%;
   }
   .col-md-2 {
-    width: 16.66666667%;
+    width: 16.666666666666664%;
   }
   .col-md-1 {
-    width: 8.33333333%;
+    width: 8.333333333333332%;
   }
   .col-md-pull-12 {
     right: 100%;
   }
   .col-md-pull-11 {
-    right: 91.66666667%;
+    right: 91.66666666666666%;
   }
   .col-md-pull-10 {
-    right: 83.33333333%;
+    right: 83.33333333333334%;
   }
   .col-md-pull-9 {
     right: 75%;
   }
   .col-md-pull-8 {
-    right: 66.66666667%;
+    right: 66.66666666666666%;
   }
   .col-md-pull-7 {
-    right: 58.33333333%;
+    right: 58.333333333333336%;
   }
   .col-md-pull-6 {
     right: 50%;
   }
   .col-md-pull-5 {
-    right: 41.66666667%;
+    right: 41.66666666666667%;
   }
   .col-md-pull-4 {
-    right: 33.33333333%;
+    right: 33.33333333333333%;
   }
   .col-md-pull-3 {
     right: 25%;
   }
   .col-md-pull-2 {
-    right: 16.66666667%;
+    right: 16.666666666666664%;
   }
   .col-md-pull-1 {
-    right: 8.33333333%;
+    right: 8.333333333333332%;
   }
   .col-md-pull-0 {
     right: auto;
@@ -1808,37 +1808,37 @@ pre code {
     left: 100%;
   }
   .col-md-push-11 {
-    left: 91.66666667%;
+    left: 91.66666666666666%;
   }
   .col-md-push-10 {
-    left: 83.33333333%;
+    left: 83.33333333333334%;
   }
   .col-md-push-9 {
     left: 75%;
   }
   .col-md-push-8 {
-    left: 66.66666667%;
+    left: 66.66666666666666%;
   }
   .col-md-push-7 {
-    left: 58.33333333%;
+    left: 58.333333333333336%;
   }
   .col-md-push-6 {
     left: 50%;
   }
   .col-md-push-5 {
-    left: 41.66666667%;
+    left: 41.66666666666667%;
   }
   .col-md-push-4 {
-    left: 33.33333333%;
+    left: 33.33333333333333%;
   }
   .col-md-push-3 {
     left: 25%;
   }
   .col-md-push-2 {
-    left: 16.66666667%;
+    left: 16.666666666666664%;
   }
   .col-md-push-1 {
-    left: 8.33333333%;
+    left: 8.333333333333332%;
   }
   .col-md-push-0 {
     left: auto;
@@ -1847,37 +1847,37 @@ pre code {
     margin-left: 100%;
   }
   .col-md-offset-11 {
-    margin-left: 91.66666667%;
+    margin-left: 91.66666666666666%;
   }
   .col-md-offset-10 {
-    margin-left: 83.33333333%;
+    margin-left: 83.33333333333334%;
   }
   .col-md-offset-9 {
     margin-left: 75%;
   }
   .col-md-offset-8 {
-    margin-left: 66.66666667%;
+    margin-left: 66.66666666666666%;
   }
   .col-md-offset-7 {
-    margin-left: 58.33333333%;
+    margin-left: 58.333333333333336%;
   }
   .col-md-offset-6 {
     margin-left: 50%;
   }
   .col-md-offset-5 {
-    margin-left: 41.66666667%;
+    margin-left: 41.66666666666667%;
   }
   .col-md-offset-4 {
-    margin-left: 33.33333333%;
+    margin-left: 33.33333333333333%;
   }
   .col-md-offset-3 {
     margin-left: 25%;
   }
   .col-md-offset-2 {
-    margin-left: 16.66666667%;
+    margin-left: 16.666666666666664%;
   }
   .col-md-offset-1 {
-    margin-left: 8.33333333%;
+    margin-left: 8.333333333333332%;
   }
   .col-md-offset-0 {
     margin-left: 0%;
@@ -1891,73 +1891,73 @@ pre code {
     width: 100%;
   }
   .col-lg-11 {
-    width: 91.66666667%;
+    width: 91.66666666666666%;
   }
   .col-lg-10 {
-    width: 83.33333333%;
+    width: 83.33333333333334%;
   }
   .col-lg-9 {
     width: 75%;
   }
   .col-lg-8 {
-    width: 66.66666667%;
+    width: 66.66666666666666%;
   }
   .col-lg-7 {
-    width: 58.33333333%;
+    width: 58.333333333333336%;
   }
   .col-lg-6 {
     width: 50%;
   }
   .col-lg-5 {
-    width: 41.66666667%;
+    width: 41.66666666666667%;
   }
   .col-lg-4 {
-    width: 33.33333333%;
+    width: 33.33333333333333%;
   }
   .col-lg-3 {
     width: 25%;
   }
   .col-lg-2 {
-    width: 16.66666667%;
+    width: 16.666666666666664%;
   }
   .col-lg-1 {
-    width: 8.33333333%;
+    width: 8.333333333333332%;
   }
   .col-lg-pull-12 {
     right: 100%;
   }
   .col-lg-pull-11 {
-    right: 91.66666667%;
+    right: 91.66666666666666%;
   }
   .col-lg-pull-10 {
-    right: 83.33333333%;
+    right: 83.33333333333334%;
   }
   .col-lg-pull-9 {
     right: 75%;
   }
   .col-lg-pull-8 {
-    right: 66.66666667%;
+    right: 66.66666666666666%;
   }
   .col-lg-pull-7 {
-    right: 58.33333333%;
+    right: 58.333333333333336%;
   }
   .col-lg-pull-6 {
     right: 50%;
   }
   .col-lg-pull-5 {
-    right: 41.66666667%;
+    right: 41.66666666666667%;
   }
   .col-lg-pull-4 {
-    right: 33.33333333%;
+    right: 33.33333333333333%;
   }
   .col-lg-pull-3 {
     right: 25%;
   }
   .col-lg-pull-2 {
-    right: 16.66666667%;
+    right: 16.666666666666664%;
   }
   .col-lg-pull-1 {
-    right: 8.33333333%;
+    right: 8.333333333333332%;
   }
   .col-lg-pull-0 {
     right: auto;
@@ -1966,37 +1966,37 @@ pre code {
     left: 100%;
   }
   .col-lg-push-11 {
-    left: 91.66666667%;
+    left: 91.66666666666666%;
   }
   .col-lg-push-10 {
-    left: 83.33333333%;
+    left: 83.33333333333334%;
   }
   .col-lg-push-9 {
     left: 75%;
   }
   .col-lg-push-8 {
-    left: 66.66666667%;
+    left: 66.66666666666666%;
   }
   .col-lg-push-7 {
-    left: 58.33333333%;
+    left: 58.333333333333336%;
   }
   .col-lg-push-6 {
     left: 50%;
   }
   .col-lg-push-5 {
-    left: 41.66666667%;
+    left: 41.66666666666667%;
   }
   .col-lg-push-4 {
-    left: 33.33333333%;
+    left: 33.33333333333333%;
   }
   .col-lg-push-3 {
     left: 25%;
   }
   .col-lg-push-2 {
-    left: 16.66666667%;
+    left: 16.666666666666664%;
   }
   .col-lg-push-1 {
-    left: 8.33333333%;
+    left: 8.333333333333332%;
   }
   .col-lg-push-0 {
     left: auto;
@@ -2005,37 +2005,37 @@ pre code {
     margin-left: 100%;
   }
   .col-lg-offset-11 {
-    margin-left: 91.66666667%;
+    margin-left: 91.66666666666666%;
   }
   .col-lg-offset-10 {
-    margin-left: 83.33333333%;
+    margin-left: 83.33333333333334%;
   }
   .col-lg-offset-9 {
     margin-left: 75%;
   }
   .col-lg-offset-8 {
-    margin-left: 66.66666667%;
+    margin-left: 66.66666666666666%;
   }
   .col-lg-offset-7 {
-    margin-left: 58.33333333%;
+    margin-left: 58.333333333333336%;
   }
   .col-lg-offset-6 {
     margin-left: 50%;
   }
   .col-lg-offset-5 {
-    margin-left: 41.66666667%;
+    margin-left: 41.66666666666667%;
   }
   .col-lg-offset-4 {
-    margin-left: 33.33333333%;
+    margin-left: 33.33333333333333%;
   }
   .col-lg-offset-3 {
     margin-left: 25%;
   }
   .col-lg-offset-2 {
-    margin-left: 16.66666667%;
+    margin-left: 16.666666666666664%;
   }
   .col-lg-offset-1 {
-    margin-left: 8.33333333%;
+    margin-left: 8.333333333333332%;
   }
   .col-lg-offset-0 {
     margin-left: 0%;
@@ -2059,7 +2059,7 @@ th {
 .table > tbody > tr > td,
 .table > tfoot > tr > td {
   padding: 8px;
-  line-height: 1.42857143;
+  line-height: 1.428571429;
   vertical-align: top;
   border-top: 1px solid #dddddd;
 }
@@ -2331,7 +2331,7 @@ output {
   display: block;
   padding-top: 7px;
   font-size: 14px;
-  line-height: 1.42857143;
+  line-height: 1.428571429;
   color: #555555;
 }
 .form-control {
@@ -2340,7 +2340,7 @@ output {
   height: 34px;
   padding: 6px 12px;
   font-size: 14px;
-  line-height: 1.42857143;
+  line-height: 1.428571429;
   color: #555555;
   background-color: #ffffff;
   background-image: none;
@@ -2386,7 +2386,7 @@ input[type="time"],
 input[type="datetime-local"],
 input[type="month"] {
   line-height: 34px;
-  line-height: 1.42857143 \0;
+  line-height: 1.428571429 \0;
 }
 input[type="date"].input-sm,
 input[type="time"].input-sm,
@@ -2716,7 +2716,7 @@ select[multiple].input-lg {
   white-space: nowrap;
   padding: 6px 12px;
   font-size: 14px;
-  line-height: 1.42857143;
+  line-height: 1.428571429;
   border-radius: 4px;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -3145,7 +3145,7 @@ tbody.collapse.in {
   padding: 3px 20px;
   clear: both;
   font-weight: normal;
-  line-height: 1.42857143;
+  line-height: 1.428571429;
   color: #333333;
   white-space: nowrap;
 }
@@ -3194,7 +3194,7 @@ tbody.collapse.in {
   display: block;
   padding: 3px 20px;
   font-size: 12px;
-  line-height: 1.42857143;
+  line-height: 1.428571429;
   color: #777777;
   white-space: nowrap;
 }
@@ -3610,7 +3610,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 }
 .nav-tabs > li > a {
   margin-right: 2px;
-  line-height: 1.42857143;
+  line-height: 1.428571429;
   border: 1px solid transparent;
   border-radius: 4px 4px 0 0;
 }
@@ -4302,7 +4302,7 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
   position: relative;
   float: left;
   padding: 6px 12px;
-  line-height: 1.42857143;
+  line-height: 1.428571429;
   text-decoration: none;
   color: #428bca;
   background-color: #ffffff;
@@ -4567,7 +4567,7 @@ a.list-group-item.active > .badge,
   display: block;
   padding: 4px;
   margin-bottom: 20px;
-  line-height: 1.42857143;
+  line-height: 1.428571429;
   background-color: #ffffff;
   border: 1px solid #dddddd;
   border-radius: 4px;
@@ -5416,7 +5416,7 @@ button.close {
 /* makes the font 33% larger relative to the icon container */
 .icon-large:before {
   vertical-align: -10%;
-  font-size: 1.33333333em;
+  font-size: 1.3333333333333333em;
 }
 /* makes sure icons active on rollover in links */
 a [class^="icon-"],
@@ -5427,16 +5427,16 @@ a [class*=" icon-"] {
 [class^="icon-"].icon-fixed-width,
 [class*=" icon-"].icon-fixed-width {
   display: inline-block;
-  width: 1.14285714em;
+  width: 1.1428571428571428em;
   text-align: right;
-  padding-right: 0.28571429em;
+  padding-right: 0.2857142857142857em;
 }
 [class^="icon-"].icon-fixed-width.icon-large,
 [class*=" icon-"].icon-fixed-width.icon-large {
-  width: 1.42857143em;
+  width: 1.4285714285714286em;
 }
 .icons-ul {
-  margin-left: 2.14285714em;
+  margin-left: 2.142857142857143em;
   list-style-type: none;
 }
 .icons-ul > li {
@@ -5444,8 +5444,8 @@ a [class*=" icon-"] {
 }
 .icons-ul .icon-li {
   position: absolute;
-  left: -2.14285714em;
-  width: 2.14285714em;
+  left: -2.142857142857143em;
+  width: 2.142857142857143em;
   text-align: center;
   line-height: inherit;
 }
@@ -6867,7 +6867,7 @@ a .icon-flip-vertical:before {
  *  Work: Lead Product Designer @ Kyruus - http://kyruus.com
  */
 .lt-ie8 .icon-large {
-  font-size: 1.33333333em;
+  font-size: 1.3333333333333333em;
   margin-top: -4px;
   padding-top: 3px;
   margin-bottom: -4px;
@@ -8111,14 +8111,14 @@ a .icon-flip-vertical:before {
 .modal-header {
   padding: 15px;
   border-bottom: 1px solid #e5e5e5;
-  min-height: 16.42857143px;
+  min-height: 16.428571429px;
 }
 .modal-header .close {
   margin-top: -2px;
 }
 .modal-title {
   margin: 0;
-  line-height: 1.42857143;
+  line-height: 1.428571429;
 }
 .modal-body {
   position: relative;
@@ -8652,7 +8652,7 @@ ol {
 }
 h1,
 .h1 {
-  font-size: 30.1px;
+  font-size: 30.099999999999998px;
   line-height: 1.3;
 }
 h2,
@@ -8667,13 +8667,13 @@ h3,
 }
 h4,
 .h4 {
-  font-size: 16.1px;
+  font-size: 16.099999999999998px;
   line-height: 1.4;
 }
 h5,
 .h5 {
   font-size: 14px;
-  line-height: 1.42857143;
+  line-height: 1.428571429;
 }
 .h1,
 .h2,
@@ -8693,8 +8693,8 @@ h5,
 .sub-header h2,
 .sub-header h3,
 .sub-header h4 {
-  font-size: 22.4px;
-  line-height: 2.14285714;
+  font-size: 22.400000000000002px;
+  line-height: 2.1428571435;
   font-weight: normal;
   color: #333333;
 }
@@ -8743,8 +8743,10 @@ form.flat {
   color: #b94a48;
   margin-top: 6px;
 }
-.control-label.required span {
+.control-label.required:after {
   color: #FF0000;
+  content: "*";
+  display: inline-block;
 }
 /* weird alternative to btn-block for specific use on the product page, where btn-block would cause a vertical misalignment when product size options are shown */
 .btn-add-to-basket {
@@ -8868,7 +8870,7 @@ ul.row {
   margin-top: 10px;
   margin-bottom: 10px;
   font-size: 14px;
-  line-height: 1.42857143;
+  line-height: 1.428571429;
   margin-bottom: 0;
 }
 .product_pod h3 small,
@@ -8889,7 +8891,7 @@ ul.row {
   margin-top: 10px;
   margin-bottom: 10px;
   font-size: 18px;
-  font-size: 16.1px;
+  font-size: 16.099999999999998px;
   line-height: 1.4;
   color: #5cb85c;
 }
@@ -9018,7 +9020,7 @@ a:hover .thumbnail {
 .review_all li ol,
 .review_read li ol,
 .side_categories li ol {
-  padding-left: 1.78571429em;
+  padding-left: 1.7857142857142858em;
 }
 .add-to-basket {
   width: 220px;
@@ -9142,7 +9144,7 @@ a:hover .thumbnail {
   margin-top: 10px;
   margin-bottom: 10px;
   font-size: 14px;
-  line-height: 1.42857143;
+  line-height: 1.428571429;
 }
 .sidebar .promotion_single h3 small,
 .sidebar .promotion_single h3 .small {
@@ -9160,7 +9162,13 @@ a:hover .thumbnail {
 }
 input[type="text"][id*="quantity"],
 input[type="number"][id*="quantity"] {
-  width: 55px;
+  max-width: 55px;
+}
+.checkout-quantity .input-group {
+  max-width: 130px;
+}
+.checkout-quantity .input-group input[type="number"][id*="quantity"] {
+  max-width: none;
 }
 .checkout-quantity input {
   margin-right: 2px;
@@ -9194,7 +9202,7 @@ input[type="number"][id*="quantity"] {
   margin-top: 10px;
   margin-bottom: 10px;
   font-size: 18px;
-  font-size: 16.1px;
+  font-size: 16.099999999999998px;
   line-height: 1.4;
   color: #5cb85c;
   font-weight: bold;
@@ -9267,15 +9275,15 @@ input[type="number"][id*="quantity"] {
 #update_user_address #id_line2,
 #new_shipping_address #id_line3,
 #update_user_address #id_line3 {
-  width: 300px;
+  max-width: 300px;
 }
 #new_shipping_address #id_postcode,
 #update_user_address #id_postcode {
-  width: 100px;
+  max-width: 100px;
 }
 #new_shipping_address #id_notes,
 #update_user_address #id_notes {
-  width: 400px;
+  max-width: 600px;
   height: 100px;
 }
 .nav-checkout {
@@ -9702,4 +9710,3 @@ input[type="number"][id*="quantity"] {
     display: none !important;
   }
 }
-/*# sourceMappingURL=styles.css.map */

--- a/src/oscar/static/oscar/less/page/checkout.less
+++ b/src/oscar/static/oscar/less/page/checkout.less
@@ -1,10 +1,18 @@
 // OSCAR CHECKOUT UNIQUE STYLES
 // -----------
 
-//Set Width of all quantity fields
+//Set max width of all quantity fields
 input[type="text"][id*="quantity"], input[type="number"][id*="quantity"] {
-    width: 55px;
+    max-width: 55px;
 }
+
+.checkout-quantity .input-group {
+  max-width: 130px;
+  input[type="number"][id*="quantity"] {
+    max-width: none;
+  }
+}
+
 // Quantity on the basket
 .checkout-quantity {
     input {
@@ -44,9 +52,9 @@ input[type="text"][id*="quantity"], input[type="number"][id*="quantity"] {
 
 // Descriptions next to shipping prices - basket totals table
 #basket_totals {
-	th small {
-		font-weight: normal;
-	}
+    th small {
+        font-weight: normal;
+    }
 }
 
 // Table background for totals
@@ -94,13 +102,13 @@ input[type="text"][id*="quantity"], input[type="number"][id*="quantity"] {
         width: auto;
     }
     #id_line1, #id_line2, #id_line3 {
-        width: 300px;
+        max-width: 300px;
     }
     #id_postcode {
-        width: 100px;
+        max-width: 100px;
     }
     #id_notes {
-        width: 400px;
+        max-width: 600px;
         height: 100px;
     }
 }

--- a/src/oscar/static/oscar/less/page/forms.less
+++ b/src/oscar/static/oscar/less/page/forms.less
@@ -28,8 +28,10 @@ form {
     margin-top: 6px;
 }
 
-.control-label.required span {
+.control-label.required:after {
     color: #FF0000;
+    content:"*";
+    display: inline-block;
 }
 
 /* weird alternative to btn-block for specific use on the product page, where btn-block would cause a vertical misalignment when product size options are shown */

--- a/src/oscar/templates/README.rst
+++ b/src/oscar/templates/README.rst
@@ -9,14 +9,13 @@ Forms should be marked-up as::
     <form method="post" action="." class="form-horizontal">
         {% csrf_token %}
         {% include 'partials/form_fields.html' %}
-        <div class="form-group form-actions">
+        <div class="form-group col-sm-offset-4 col-sm-8">
             <button class="btn btn-lg btn-primary" type="submit" data-loading-text="{% trans 'Saving...' %}">Save</button>
             or <a href="{{ some_url }}">cancel</a>
         </div>
     </form>
 
-The ``.form-group`` class aligns the buttons with the fields. The ``.forms-actions``
-class adds a gray background.
+The ``.col-sm-offset-4`` class aligns the buttons with the fields.
 
 Alternatively, use::
     

--- a/src/oscar/templates/oscar/basket/partials/basket_content.html
+++ b/src/oscar/templates/oscar/basket/partials/basket_content.html
@@ -35,7 +35,7 @@
     {% endblock %}
 
     {% block basket_form_main %}
-        <form action="." method="post" class="basket_summary form-inline" id="basket_formset">
+        <form action="." method="post" class="basket_summary" id="basket_formset">
             {% csrf_token %}
             {{ formset.management_form }}
 
@@ -59,12 +59,15 @@
                                 <p class="availability {{ session.availability.code }}">{{ session.availability.message }}</p>
                             </div>
                             <div class="col-sm-3">
-                                <div class="checkout-quantity form-group {% if form.errors %}error{% endif %}">
-                                    <p>
+                                <div class="checkout-quantity">
+                                    <div class="input-group  {% if form.errors %}error{% endif %}">
                                         {% render_field form.quantity class+="form-control" %}
+                                    <span class="input-group-btn">
                                         <button class="btn btn-default" type="submit" data-loading-text="{% trans 'Updating...' %}">{% trans "Update" %}</button>
-                                    </p>
-                                    <p>
+                                    </span>
+                                    </div>
+                                </div>
+                                    <div>
                                         <a href="#" data-id="{{ forloop.counter0 }}" data-behaviours="remove" class="inline">{% trans "Remove" %}</a>
                                         {% if request.user.is_authenticated %}
                                             | <a href="#" data-id="{{ forloop.counter0 }}" data-behaviours="save" class="inline">{% trans "Save for later" %}</a>
@@ -79,8 +82,8 @@
                                             {% endfor %}
 
                                         {% endfor %}
-                                    </p>
-                                </div>
+                                    </div>
+
                             </div>
                             <div class="col-sm-1">
                                 <p class="price_color align-right">
@@ -141,7 +144,7 @@
 
 
     {% block formactions %}
-        <div class="form-group form-actions clearfix">
+        <div class="form-group clearfix">
             <div class="row">
                 <div class="col-sm-4 col-sm-offset-8">
                     <a href="{% url 'checkout:index' %}" class="btn btn-lg btn-primary btn-block">{% trans "Proceed to checkout" %}</a>

--- a/src/oscar/templates/oscar/checkout/gateway.html
+++ b/src/oscar/templates/oscar/checkout/gateway.html
@@ -53,7 +53,7 @@
             </div>
         </div>
 
-        <div class="form-group form-actions">
+        <div class="form-group">
             <div class="row">
                 <div class="col-sm-3">
                     <button type="submit" class="btn btn-lg btn-block btn-primary" data-loading-text="{% trans 'Continuing...' %}">{% trans "Continue" %}</button>

--- a/src/oscar/templates/oscar/checkout/preview.html
+++ b/src/oscar/templates/oscar/checkout/preview.html
@@ -28,7 +28,7 @@
             {% block hiddenforms %}{% endblock %}
         </div>
 
-        <div class="form-group form-actions clearfix">
+        <div class="form-group clearfix">
             <div class="row">
                 <div class="col-sm-3 col-sm-offset-9">
                      <button id='place-order' type="submit" class="btn btn-primary btn-lg btn-block" data-loading-text="{% trans 'Submitting...' %}">{% trans "Place order" %}</button>

--- a/src/oscar/templates/oscar/checkout/shipping_address.html
+++ b/src/oscar/templates/oscar/checkout/shipping_address.html
@@ -70,16 +70,19 @@
     {% endif %}
 
     {% block new_address_form %}
-        <form action="{% url 'checkout:shipping-address' %}" method="post" id="new_shipping_address" class="form form-horizontal">
-            <div class="well">
+        <div class="well">
+            <form action="{% url 'checkout:shipping-address' %}" method="post" id="new_shipping_address" class="form form-horizontal">
                 {% csrf_token %}
                 {% include "partials/form_fields.html" with form=form style='horizontal' %}
-                <div class="controls">
-                    <button type="submit" class="btn btn-lg btn-primary" data-loading-text="{% trans 'Continuing...' %}">{% trans "Continue" %}</button>
-                    {% trans "or" %} <a href="{% url 'basket:summary' %}">{% trans "return to basket" %}</a>
+                <div class="form-group">
+                    <div class="col-sm-offset-4 col-sm-8">
+                        <button type="submit" class="btn btn-lg btn-primary" data-loading-text="{% trans 'Continuing...' %}">{% trans "Continue" %}</button>
+                        {% trans "or" %} <a href="{% url 'basket:summary' %}">{% trans "return to basket" %}</a>
+
+                    </div>
                 </div>
-            </div>
-        </form>
+            </form>
+        </div>
     {% endblock %}
 {% endblock shipping_address %}
 

--- a/src/oscar/templates/oscar/checkout/thank_you.html
+++ b/src/oscar/templates/oscar/checkout/thank_you.html
@@ -308,7 +308,7 @@
 
 
     {% block order_actions %}
-        <div class="form-group form-actions">
+        <div class="form-group">
             <div class="row">
                 <div class="col-sm-4">
                     <p><a onclick="window.print()" href="#" class="btn btn-primary btn-block btn-lg">{% trans "Print this page" %}</a></p>

--- a/src/oscar/templates/oscar/checkout/user_address_form.html
+++ b/src/oscar/templates/oscar/checkout/user_address_form.html
@@ -17,12 +17,16 @@
 {% block checkout_title %}{% trans "Edit address" %}{% endblock %}
 
 {% block shipping_address %}
-    <form id="update_user_address" action="." method="post" class="form form-horizontal">
-        <div class="well">
+    <div class="well">
+        <form id="update_user_address" action="." method="post" class="form form-horizontal">
             {% csrf_token %}
-            {% include "partials/form_fields.html" with form=form %}
-            <button type="submit" class="btn btn-lg btn-primary" data-loading-text="{% trans 'Saving...' %}">{% trans "Save" %}</button>
-            {% trans "or" %} <a href="{% url 'checkout:shipping-address' %}">{% trans "cancel" %}</a>.
-        </div>
-    </form>
+            {% include "partials/form_fields.html" with form=form style='horizontal' %}
+            <div class="form-group">
+                <div class="col-sm-offset-4 col-sm-8">
+                    <button type="submit" class="btn btn-lg btn-primary" data-loading-text="{% trans 'Saving...' %}">{% trans "Save" %}</button>
+                    {% trans "or" %} <a href="{% url 'checkout:shipping-address' %}">{% trans "cancel" %}</a>.
+                </div>
+            </div>
+        </form>
+    </div>
 {% endblock shipping_address %}

--- a/src/oscar/templates/oscar/customer/address/address_form.html
+++ b/src/oscar/templates/oscar/customer/address/address_form.html
@@ -4,9 +4,9 @@
 {% load i18n %}
 
 {% block extra_breadcrumbs %}
-	<li>
-		<a href="{% url 'customer:address-list' %}">{% trans 'Address book' %}</a>
-	</li>
+    <li>
+        <a href="{% url 'customer:address-list' %}">{% trans 'Address book' %}</a>
+    </li>
 {% endblock %}
 
 {% block tabcontent %}

--- a/src/oscar/templates/oscar/customer/order/order_list.html
+++ b/src/oscar/templates/oscar/customer/order/order_list.html
@@ -22,9 +22,11 @@
             <h2>{% trans "Filter" %}</h2>
             <form action="." method="get" class="form-horizontal">
                 {% include "partials/form_fields.html" with form=form style='horizontal' %}
-                <div class="controls">
-                    <button type="submit" class="btn btn-primary" data-loading-text="{% trans 'Filtering...' %}">{% trans 'Filter results' %}</button>
-                    <a href="{% url 'customer:order-list' %}" class="btn btn-default">{% trans 'Reset' %}</a>
+                <div class="form-group">
+                    <div class="col-sm-offset-4 col-sm-8">
+                        <button type="submit" class="btn btn-primary" data-loading-text="{% trans 'Filtering...' %}">{% trans 'Filter results' %}</button>
+                        <a href="{% url 'customer:order-list' %}" class="btn btn-default">{% trans 'Reset' %}</a>
+                    </div>
                 </div>
             </form>
         </div>

--- a/src/oscar/templates/oscar/customer/profile/profile_delete.html
+++ b/src/oscar/templates/oscar/customer/profile/profile_delete.html
@@ -13,7 +13,7 @@
                 undone.
             {% endblocktrans %}
         </div>
-        <div class="form-group form-actions">
+        <div class="form-group">
             <button class="btn btn-lg btn-danger" type="submit" data-loading-text="{% trans 'Deleting...' %}">{% trans "Delete" %}</button>
             {% trans "or" %} <a href="{% url "customer:profile-view" %}">{% trans "cancel" %}</a>.
         </div>

--- a/src/oscar/templates/oscar/customer/wishlists/wishlists_delete.html
+++ b/src/oscar/templates/oscar/customer/wishlists/wishlists_delete.html
@@ -28,7 +28,7 @@
             {% endblocktrans %}
         </p>
 
-        <div class="form-group form-actions">
+        <div class="form-group">
             <button type="submit" class="btn btn-danger btn-lg" data-loading-text="{% trans 'Deleting...' %}">{% trans 'Delete' %}</button> {% trans 'or' %} <a href="{% url 'customer:wishlists-list' %}">{% trans 'cancel' %}</a>
         </div>
     </form>

--- a/src/oscar/templates/oscar/customer/wishlists/wishlists_delete_product.html
+++ b/src/oscar/templates/oscar/customer/wishlists/wishlists_delete_product.html
@@ -28,7 +28,7 @@
             {% endblocktrans %}
         </p>
 
-        <div class="form-group form-actions">
+        <div class="form-group">
             <button type="submit" class="btn btn-lg btn-danger" data-loading-text="{% trans 'Removing...' %}">{% trans 'Remove' %}</button> {% trans 'or' %} <a href="{{ wishlist.get_absolute_url }}">{% trans 'cancel' %}</a>
         </div>
     </form>

--- a/src/oscar/templates/oscar/customer/wishlists/wishlists_detail.html
+++ b/src/oscar/templates/oscar/customer/wishlists/wishlists_detail.html
@@ -1,6 +1,7 @@
 {% extends "customer/baseaccountpage.html" %}
 {% load thumbnail %}
 {% load i18n %}
+{% load widget_tweaks %}
 
 {% block breadcrumbs %}
     <ul class="breadcrumb">
@@ -55,7 +56,7 @@
                                 </td>
                                 <td>
                                     {% for field in subform %}
-                                        {{ field }}
+                                        {% render_field field class+="form-control" %}
                                         {% for error in field.errors %}
                                             <ul class="error-block">
                                                 <li>{{ error }}</li>

--- a/src/oscar/templates/oscar/customer/wishlists/wishlists_form.html
+++ b/src/oscar/templates/oscar/customer/wishlists/wishlists_form.html
@@ -36,7 +36,7 @@
                 {% endblocktrans %}
             </p>
         {% endif %}
-        <div class="form-group form-actions">
+        <div class="form-group">
             <button class="btn btn-lg btn-primary" type="submit" data-loading-text="{% trans 'Saving...' %}">{% trans "Save" %}</button>
             {% trans "or" %} <a href="#" onclick="history.go(-1);return false" >{% trans "cancel" %}</a>.
         </div>

--- a/src/oscar/templates/oscar/partials/form.html
+++ b/src/oscar/templates/oscar/partials/form.html
@@ -6,8 +6,10 @@
 
     {% if not method == "get" %}{% csrf_token %}{% endif %}
     {% include 'partials/form_fields.html' %}
-    <div class="form-group form-actions">
-        <button class="btn btn-lg btn-primary" type="submit" data-loading-text="{% trans 'Saving...' %}">{% trans "Save" %}</button>
-        {% trans "or" %} <a href="#" onclick="window.history.go(-1);return false" >{% trans "cancel" %}</a>.
+    <div class="form-group">
+        <div class="{% if style == 'horizontal' %}col-sm-offset-4 col-sm-8{% endif %}">
+            <button class="btn btn-lg btn-primary" type="submit" data-loading-text="{% trans 'Saving...' %}">{% trans "Save" %}</button>
+            {% trans "or" %} <a href="#" onclick="window.history.go(-1);return false" >{% trans "cancel" %}</a>.
+        </div>
     </div>
 </form>

--- a/src/oscar/templates/oscar/partials/form_field.html
+++ b/src/oscar/templates/oscar/partials/form_field.html
@@ -11,23 +11,22 @@
     {% annotate_form_field field %}
 
     {% block control_group %}
-        <div class="form-group {% if field.errors %}error{% endif %}">
+        <div class="form-group {% if field.errors %}has-error{% endif %}">
 
             {% block label %}
                 {% if not nolabel and field.widget_type != 'CheckboxInput' %}
                     <label for="{{ field.auto_id }}" class="{% if style|default:"stacked" != 'stacked' %}col-sm-4{% endif%} control-label{% if field.field.required %} required{% endif %}">
                         {{ field.label|safe }}
-                        {% if field.field.required %} <span>*</span>{% endif %}
                     </label>
                 {% endif %}
             {% endblock %}
 
             {% block controls %}
-                <div class="{% if style|default:"stacked" != 'stacked' %}col-sm-8{% endif %}">
+                <div class="{% if style|default:"stacked" != 'stacked' %}col-sm-7{% endif %}">
                     {% block widget %}
                         {% if field.widget_type == 'CheckboxInput' %}
                             <label for="{{ field.auto_id }}" class="checkbox {% if field.field.required %}required{% endif %}">
-                                {{ field.label|safe }}{% if field.field.required %} <span>*</span>{% endif %}
+                                {{ field.label|safe }}
                                 {% render_field field class+="form-control" %}
                             </label>
                         {% else %}

--- a/src/oscar/templates/oscar/partials/form_fields.html
+++ b/src/oscar/templates/oscar/partials/form_fields.html
@@ -8,8 +8,8 @@
 
 {% if form.non_field_errors %}
     {% for error in form.non_field_errors %}
-        <div class="alert alert-danger form-group error">
-            <span class="help-block"><i class="icon-exclamation-sign"></i> {{ error }}</span>
+        <div class="alert alert-danger">
+            <i class="icon-exclamation-sign"></i> {{ error }}
         </div>
     {% endfor %}
 {% endif %}


### PR DESCRIPTION
These are small improvements in the Bootstrap3 forms for the frontend website

Here the changes:
* fix `make css` paths
* fix error styles on form fields (focus and label should be red)
* align form buttons with fields
* remove `help-block` class inside alert box to avoid alert
  misalignment and text not readable
* avoid class `form-actions`: this class is removed from boostrap 3 and
  creates button misalignments
* use class `input-group` in the basket quantity form. Class
  `form-inline` applies only to forms within viewports that are
  at least 768px wide.
* move `well` divs outside forms
* remove mixed tab/space indentation in address_form.html
* proper style quantity field in whislist detail
* style label `required` using only css
* use `max-width` instead of `width` for fields
* update README
* compile .less files into .css files
 
A form for testing most of these changes could be the shipping Address form in the checkout process.

