### PR TITLE
Fix inconsistent Order.shipping_status

### DIFF
--- a/src/oscar/apps/order/abstract_models.py
+++ b/src/oscar/apps/order/abstract_models.py
@@ -1,4 +1,4 @@
-from itertools import chain
+from collections import OrderedDict
 from decimal import Decimal as D
 import hashlib
 
@@ -223,24 +223,28 @@ class AbstractOrder(models.Model):
 
     @property
     def shipping_status(self):
-        events = self.shipping_events.all()
+        """Return the last complete shipping event for this order."""
+
+        # As safeguard against identical timestamps, also sort by the primary
+        # key. It's not recommended to rely on this behaviour, but in practice
+        # reasonably safe if PKs are not manually set.
+        events = self.shipping_events.order_by('-date_created', '-pk').all()
         if not len(events):
             return ''
 
         # Collect all events by event-type
-        map = {}
+        event_map = OrderedDict()
         for event in events:
             event_name = event.event_type.name
-            if event_name not in map:
-                map[event_name] = []
-            map[event_name] = list(chain(map[event_name],
-                                         event.line_quantities.all()))
+            if event_name not in event_map:
+                event_map[event_name] = []
+            event_map[event_name].extend(list(event.line_quantities.all()))
 
         # Determine last complete event
         status = _("In progress")
-        for event_name, event_line_quantities in map.items():
+        for event_name, event_line_quantities in event_map.items():
             if self._is_event_complete(event_line_quantities):
-                status = event_name
+                return event_name
         return status
 
     @property
@@ -258,14 +262,14 @@ class AbstractOrder(models.Model):
 
     def _is_event_complete(self, event_quantities):
         # Form map of line to quantity
-        map = {}
+        event_map = {}
         for event_quantity in event_quantities:
             line_id = event_quantity.line_id
-            map.setdefault(line_id, 0)
-            map[line_id] += event_quantity.quantity
+            event_map.setdefault(line_id, 0)
+            event_map[line_id] += event_quantity.quantity
 
         for line in self.lines.all():
-            if map[line.id] != line.quantity:
+            if event_map.get(line.pk, 0) != line.quantity:
                 return False
         return True
 

--- a/src/oscar/test/newfactories.py
+++ b/src/oscar/test/newfactories.py
@@ -11,13 +11,16 @@ module to factories.py and drop the old ones.
 """
 import datetime
 from decimal import Decimal as D
+from decimal import ROUND_HALF_UP
 
-from django.utils.timezone import now
 import factory
+from django.conf import settings
+from django.utils.timezone import now
 
 from oscar.core.loading import get_model, get_class
 from oscar.core.compat import get_user_model
 from oscar.core.phonenumber import PhoneNumber
+from oscar.core.utils import slugify
 
 __all__ = ["UserFactory", "CountryFactory", "UserAddressFactory",
            "BasketFactory", "VoucherFactory", "ProductFactory",
@@ -50,6 +53,8 @@ class CountryFactory(factory.DjangoModelFactory):
 
     class Meta:
         model = get_model('address', 'Country')
+        django_get_or_create = ('iso_3166_1_a2',)
+
 
 
 class UserAddressFactory(factory.DjangoModelFactory):
@@ -187,3 +192,137 @@ class RangeFactory(factory.DjangoModelFactory):
 
     class Meta:
         model = get_model('offer', 'Range')
+
+
+class ShippingAddressFactory(factory.DjangoModelFactory):
+    first_name = 'John'
+    last_name = 'Doe'
+    line1 = 'Streetname'
+    line2 = '1a'
+    line4 = 'City'
+    postcode = '1000 AA'
+    phone_number = '06-12345678'
+    country = factory.SubFactory(CountryFactory)
+
+    class Meta:
+        model = get_model('order', 'ShippingAddress')
+
+
+class BillingAddressFactory(factory.DjangoModelFactory):
+    country = factory.SubFactory(CountryFactory)
+
+    first_name = 'John'
+    last_name = 'Doe'
+    line1 = 'Streetname'
+    line2 = '1a'
+    line4 = 'City'
+    postcode = '1000AA'
+
+    class Meta:
+        model = get_model('order', 'BillingAddress')
+
+
+class OrderFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = get_model('order', 'Order')
+        exclude = ('basket',)
+
+    status = settings.OSCAR_INITIAL_ORDER_STATUS
+    site_id = settings.SITE_ID
+    number = factory.LazyAttribute(lambda o: '%d' % (100000 + o.basket.pk))
+    basket = factory.SubFactory(BasketFactory)
+
+    shipping_code = 'delivery'
+    shipping_incl_tax = D('4.95')
+    shipping_excl_tax = factory.LazyAttribute(
+        lambda o: tax_subtract(o.shipping_incl_tax))
+
+    total_incl_tax = factory.LazyAttribute(lambda o: o.basket.total_incl_tax)
+    total_excl_tax = factory.LazyAttribute(lambda o: o.basket.total_excl_tax)
+
+    guest_email = factory.LazyAttribute(
+        lambda o: (
+            '%s.%s@example.com' % (
+                o.billing_address.first_name[0],
+                o.billing_address.last_name
+            )).lower())
+
+    shipping_address = factory.SubFactory(ShippingAddressFactory)
+    billing_address = factory.SubFactory(BillingAddressFactory)
+
+    @classmethod
+    def _create(cls, target_class, *args, **kwargs):
+        date_placed = kwargs.pop('date_placed', None)
+        instance = super(OrderFactory, cls)._create(
+            target_class, *args, **kwargs)
+
+        if date_placed:
+            instance.date_placed = date_placed
+        return instance
+
+
+class OrderLineFactory(factory.DjangoModelFactory):
+    order = factory.SubFactory(OrderFactory)
+    product = factory.SubFactory(ProductFactory)
+    partner_sku = factory.LazyAttribute(lambda l: l.product.upc)
+    stockrecord = factory.LazyAttribute(
+        lambda l: l.product.stockrecords.first())
+    quantity = 1
+
+    line_price_incl_tax = factory.LazyAttribute(
+        lambda obj: tax_add(obj.stockrecord.price_excl_tax) * obj.quantity)
+    line_price_excl_tax = factory.LazyAttribute(
+        lambda obj: obj.stockrecord.price_excl_tax * obj.quantity)
+
+    line_price_before_discounts_incl_tax = (
+        factory.SelfAttribute('.line_price_incl_tax'))
+    line_price_before_discounts_excl_tax = (
+        factory.SelfAttribute('.line_price_excl_tax'))
+
+    unit_price_incl_tax = factory.LazyAttribute(
+        lambda obj: tax_add(obj.stockrecord.price_excl_tax))
+    unit_cost_price = factory.LazyAttribute(
+        lambda obj: obj.stockrecord.cost_price)
+    unit_price_excl_tax = factory.LazyAttribute(
+        lambda obj: obj.stockrecord.price_excl_tax)
+    unit_retail_price = factory.LazyAttribute(
+        lambda obj: obj.stockrecord.price_retail)
+
+    class Meta:
+        model = get_model('order', 'Line')
+
+
+class ShippingEventTypeFactory(factory.DjangoModelFactory):
+    name = 'Test event'
+    code =  factory.LazyAttribute(lambda o: slugify(o.name).replace('-', '_'))
+
+    class Meta:
+        model = get_model('order', 'ShippingEventType')
+        django_get_or_create = ('code', )
+
+
+class ShippingEventFactory(factory.DjangoModelFactory):
+
+    order = factory.SubFactory(OrderFactory)
+    event_type = factory.SubFactory(ShippingEventTypeFactory)
+
+    class Meta:
+        model = get_model('order', 'ShippingEvent')
+
+
+def tax_subtract(price, tax_percentage=21):
+    """Subtract the given `tax_percentage` from the given `price`."""
+    if price is None:
+        return None
+
+    result = price / ((100 + tax_percentage) / D(100))
+    return result.quantize(D('0.01'), ROUND_HALF_UP)
+
+
+def tax_add(price, tax_percentage=21):
+    """Add the given `tax_percentage` to the given `price`."""
+    if price is None:
+        return None
+
+    result = price * ((100 + tax_percentage) / D(100))
+    return result.quantize(D('0.01'), ROUND_HALF_UP)


### PR DESCRIPTION
Refactor the shipping_status method to return a consistent last 
complete status. Since dictionaries have no guaranteed order, and also
since the shipping status queryset isn’t ordered the method didn’t
always return the actual last complete status.

Note that this should also be backported for a 1.0.2 release.