### PR TITLE
Unify to (basket, user=None, request=None) argument order in Applicator

### DIFF
--- a/docs/source/releases/v1.1.rst
+++ b/docs/source/releases/v1.1.rst
@@ -71,7 +71,12 @@ Misc
   (`#1565`_). This means that sites that rely on zero-weight baskets having no
   change will need to introduce a new weight band that covers this edge case.
 
+* The methods :method:`~oscar.apps.offer.utils.Applicator.apply` and
+  :method:`~oscar.apps.offer.utils.Applicatior.get_offers` changed their
+  arguments to `(basket, user=None, request=None)`. (`#1677`_)
+
 .. _`#1565`: https://github.com/django-oscar/django-oscar/pull/1565
+.. _`#1677`: https://github.com/django-oscar/django-oscar/pull/1677
 
 Migrations
 ~~~~~~~~~~

--- a/src/oscar/apps/basket/middleware.py
+++ b/src/oscar/apps/basket/middleware.py
@@ -192,7 +192,7 @@ class BasketMiddleware(object):
 
     def apply_offers_to_basket(self, request, basket):
         if not basket.is_empty:
-            Applicator().apply(request, basket)
+            Applicator().apply(basket, request.user, request)
 
     def get_basket_hash(self, basket_id):
         return Signer().sign(basket_id)

--- a/src/oscar/apps/basket/views.py
+++ b/src/oscar/apps/basket/views.py
@@ -76,7 +76,7 @@ def apply_messages(request, offers_before):
     """
     # Re-apply offers to see if any new ones are now available
     request.basket.reset_offer_applications()
-    Applicator().apply(request, request.basket)
+    Applicator().apply(request.basket, request.user, request)
     offers_after = request.basket.applied_offers()
 
     for level, msg in get_messages(
@@ -124,7 +124,8 @@ class BasketView(ModelFormSetView):
         return warnings
 
     def get_upsell_messages(self, basket):
-        offers = Applicator().get_offers(self.request, basket)
+        offers = Applicator().get_offers(basket, self.request.user,
+                                         self.request)
         applied_offers = list(basket.offer_applications.offers.values())
         msgs = []
         for offer in offers:
@@ -232,7 +233,8 @@ class BasketView(ModelFormSetView):
             self.request.basket = get_model('basket', 'Basket').objects.get(
                 id=self.request.basket.id)
             self.request.basket.strategy = self.request.strategy
-            Applicator().apply(self.request, self.request.basket)
+            Applicator().apply(self.request.basket, self.request.user,
+                               self.request)
             offers_after = self.request.basket.applied_offers()
 
             for level, msg in get_messages(
@@ -379,7 +381,8 @@ class VoucherAddView(FormView):
             sender=self, basket=self.request.basket, voucher=voucher)
 
         # Recalculate discounts to see if the voucher gives any
-        Applicator().apply(self.request, self.request.basket)
+        Applicator().apply(self.request.basket, self.request.user,
+                           self.request)
         discounts_after = self.request.basket.offer_applications
 
         # Look for discounts from this new voucher

--- a/src/oscar/apps/offer/utils.py
+++ b/src/oscar/apps/offer/utils.py
@@ -18,14 +18,14 @@ class OfferApplicationError(Exception):
 
 class Applicator(object):
 
-    def apply(self, request, basket):
+    def apply(self, basket, user=None, request=None):
         """
         Apply all relevant offers to the given basket.
 
         The request is passed too as sometimes the available offers
         are dependent on the user (eg session-based offers).
         """
-        offers = self.get_offers(request, basket)
+        offers = self.get_offers(basket, user, request)
         self.apply_offers(basket, offers)
 
     def apply_offers(self, basket, offers):
@@ -48,7 +48,7 @@ class Applicator(object):
         # rendered in templates
         basket.offer_applications = applications
 
-    def get_offers(self, request, basket):
+    def get_offers(self, basket, user=None, request=None):
         """
         Return all offers to apply to the basket.
 
@@ -57,8 +57,8 @@ class Applicator(object):
         based on the session or the user type.
         """
         site_offers = self.get_site_offers()
-        basket_offers = self.get_basket_offers(basket, request.user)
-        user_offers = self.get_user_offers(request.user)
+        basket_offers = self.get_basket_offers(basket, user)
+        user_offers = self.get_user_offers(user)
         session_offers = self.get_session_offers(request)
 
         return list(sorted(chain(
@@ -92,7 +92,7 @@ class Applicator(object):
         code
         """
         offers = []
-        if not basket.id:
+        if not basket.id or not user:
             return offers
 
         for voucher in basket.vouchers.all():

--- a/tests/integration/offer/applicator_tests.py
+++ b/tests/integration/offer/applicator_tests.py
@@ -50,6 +50,6 @@ class TestOfferApplicator(TestCase):
                 name="offer2", condition=self.condition, benefit=self.benefit,
                 priority=-1)])
 
-        offers = self.applicator.get_offers(Mock(), self.basket)
+        offers = self.applicator.get_offers(self.basket)
         priorities = [offer.priority for offer in offers]
         self.assertEqual(sorted(priorities, reverse=True), priorities)

--- a/tests/integration/offer/post_order_action_tests.py
+++ b/tests/integration/offer/post_order_action_tests.py
@@ -1,8 +1,6 @@
 from decimal import Decimal as D
 
 from django.test import TestCase
-from django.test.client import RequestFactory
-import mock
 
 from oscar.apps.offer import models, utils, custom
 from oscar.test import factories
@@ -41,19 +39,13 @@ def create_offer():
         offer_type=models.ConditionalOffer.SITE)
 
 
-def apply_offers(basket):
-    req = RequestFactory().get('/')
-    req.user = mock.Mock()
-    utils.Applicator().apply(req, basket)
-
-
 class TestAnOfferWithAPostOrderAction(TestCase):
 
     def setUp(self):
         self.basket = factories.create_basket(empty=True)
         add_product(self.basket, D('12.00'), 1)
         create_offer()
-        apply_offers(self.basket)
+        utils.Applicator().apply(self.basket)
 
     def test_applies_correctly_to_basket_which_meets_condition(self):
         self.assertEqual(1, len(self.basket.offer_applications))

--- a/tests/integration/offer/shipping_benefit_tests.py
+++ b/tests/integration/offer/shipping_benefit_tests.py
@@ -1,8 +1,6 @@
 from decimal import Decimal as D
 
 from django.test import TestCase
-from django.test.client import RequestFactory
-import mock
 
 from oscar.apps.offer import models, utils
 from oscar.apps.shipping.repository import Repository
@@ -27,12 +25,6 @@ def create_offer():
         offer_type=models.ConditionalOffer.SITE)
 
 
-def apply_offers(basket):
-    req = RequestFactory().get('/')
-    req.user = mock.Mock()
-    utils.Applicator().apply(req, basket)
-
-
 class StubRepository(Repository):
     """
     Stubbed shipped repository which overrides the get_shipping_methods method
@@ -50,17 +42,17 @@ class TestAnOfferWithAShippingBenefit(TestCase):
 
     def test_applies_correctly_to_basket_which_matches_condition(self):
         add_product(self.basket, D('12.00'))
-        apply_offers(self.basket)
+        utils.Applicator().apply(self.basket)
         self.assertEqual(1, len(self.basket.offer_applications))
 
     def test_applies_correctly_to_basket_which_exceeds_condition(self):
         add_product(self.basket, D('12.00'), 2)
-        apply_offers(self.basket)
+        utils.Applicator().apply(self.basket)
         self.assertEqual(1, len(self.basket.offer_applications))
 
     def test_wraps_shipping_method_from_repository(self):
         add_product(self.basket, D('12.00'), 1)
-        apply_offers(self.basket)
+        utils.Applicator().apply(self.basket)
         methods = StubRepository().get_shipping_methods(self.basket)
         method = methods[0]
 
@@ -69,7 +61,7 @@ class TestAnOfferWithAShippingBenefit(TestCase):
 
     def test_has_discount_recorded_correctly_when_order_is_placed(self):
         add_product(self.basket, D('12.00'), 1)
-        apply_offers(self.basket)
+        utils.Applicator().apply(self.basket)
         methods = StubRepository().get_shipping_methods(self.basket)
         method = methods[0]
         order = factories.create_order(basket=self.basket,


### PR DESCRIPTION
This order offers the simplest API for common needs - as evidenced by the
fact that the apply_offers crook could be removed from two test files,
saving on imports as well.