### PR TITLE
Update all ModelForm’s to specify Meta.fields

### DIFF
--- a/docs/source/releases/v1.1.rst
+++ b/docs/source/releases/v1.1.rst
@@ -31,6 +31,7 @@ What's new in Oscar 1.1?
 * The icon and caption of `django-tables2` tables can be set directly on the `Table` object, if it
   derives from :class:`~oscar.apps.dashboard.tables.DashboardTable`. The caption can be localized
   in singular and plural. (`#1482`_)
+* All modelforms now specify the `fields` meta attribute instead of the `excludes` list.
 
 .. _`#1576`: https://github.com/django-oscar/django-oscar/pull/1576
 .. _`#1482`: https://github.com/django-oscar/django-oscar/pull/1482

--- a/src/oscar/apps/address/forms.py
+++ b/src/oscar/apps/address/forms.py
@@ -24,8 +24,12 @@ class UserAddressForm(PhoneNumberMixin, AbstractAddressForm):
 
     class Meta:
         model = UserAddress
-        exclude = ('user', 'num_orders', 'hash', 'search_text',
-                   'is_default_for_billing', 'is_default_for_shipping')
+        fields = [
+            'title', 'first_name', 'last_name',
+            'line1', 'line2', 'line3', 'line4',
+            'state', 'postcode', 'country',
+            'phone_number', 'notes',
+        ]
 
     def __init__(self, user, *args, **kwargs):
         super(UserAddressForm, self).__init__(*args, **kwargs)

--- a/src/oscar/apps/basket/forms.py
+++ b/src/oscar/apps/basket/forms.py
@@ -41,8 +41,7 @@ class BasketLineForm(forms.ModelForm):
 
     class Meta:
         model = Line
-        exclude = ('basket', 'product', 'stockrecord', 'line_reference',
-                   'price_excl_tax', 'price_incl_tax', 'price_currency')
+        fields = ['quantity']
 
 
 class BaseBasketLineFormSet(BaseModelFormSet):

--- a/src/oscar/apps/checkout/forms.py
+++ b/src/oscar/apps/checkout/forms.py
@@ -33,7 +33,12 @@ class ShippingAddressForm(PhoneNumberMixin, AbstractAddressForm):
 
     class Meta:
         model = get_model('order', 'shippingaddress')
-        exclude = ('user', 'search_text')
+        fields = [
+            'title', 'first_name', 'last_name',
+            'line1', 'line2', 'line3', 'line4',
+            'state', 'postcode', 'country',
+            'phone_number', 'notes',
+        ]
 
 
 class GatewayForm(AuthenticationForm):

--- a/src/oscar/apps/customer/forms.py
+++ b/src/oscar/apps/customer/forms.py
@@ -413,6 +413,4 @@ class ProductAlertForm(forms.ModelForm):
 
     class Meta:
         model = ProductAlert
-        exclude = ('user', 'key',
-                   'status', 'date_confirmed', 'date_cancelled', 'date_closed',
-                   'product')
+        fields = ['email']

--- a/src/oscar/apps/dashboard/catalogue/forms.py
+++ b/src/oscar/apps/dashboard/catalogue/forms.py
@@ -113,7 +113,11 @@ class StockRecordForm(forms.ModelForm):
 
     class Meta:
         model = StockRecord
-        exclude = ('product', 'num_allocated')
+        fields = [
+            'partner', 'partner_sku',
+            'price_currency', 'price_excl_tax', 'price_retail', 'cost_price',
+            'num_in_stock', 'low_stock_threshold',
+        ]
 
 
 BaseStockRecordFormSet = inlineformset_factory(
@@ -406,7 +410,7 @@ class ProductImageForm(forms.ModelForm):
 
     class Meta:
         model = ProductImage
-        exclude = ('display_order',)
+        fields = ['product', 'original', 'caption']
         # use ImageInput widget to create HTML displaying the
         # actual uploaded image and providing the upload dialog
         # when clicking on the actual image.

--- a/src/oscar/apps/dashboard/offers/forms.py
+++ b/src/oscar/apps/dashboard/offers/forms.py
@@ -74,7 +74,7 @@ class ConditionForm(forms.ModelForm):
 
     class Meta:
         model = Condition
-        exclude = ('proxy_class',)
+        fields = ['range', 'type', 'value']
 
     def clean(self):
         data = super(ConditionForm, self).clean()
@@ -127,7 +127,7 @@ class BenefitForm(forms.ModelForm):
 
     class Meta:
         model = Benefit
-        exclude = ('proxy_class',)
+        fields = ['range', 'type', 'value', 'max_affected_items']
 
     def clean(self):
         data = super(BenefitForm, self).clean()

--- a/src/oscar/apps/dashboard/orders/forms.py
+++ b/src/oscar/apps/dashboard/orders/forms.py
@@ -120,7 +120,7 @@ class OrderNoteForm(forms.ModelForm):
 
     class Meta:
         model = OrderNote
-        exclude = ('order', 'user', 'note_type')
+        fields = ['message']
 
     def __init__(self, order, user, *args, **kwargs):
         super(OrderNoteForm, self).__init__(*args, **kwargs)
@@ -132,7 +132,12 @@ class ShippingAddressForm(PhoneNumberMixin, AbstractAddressForm):
 
     class Meta:
         model = ShippingAddress
-        exclude = ('search_text',)
+        fields = [
+            'title', 'first_name', 'last_name',
+            'line1', 'line2', 'line3', 'line4',
+            'state', 'postcode', 'country',
+            'phone_number', 'notes',
+        ]
 
 
 class OrderStatusForm(forms.Form):

--- a/src/oscar/apps/dashboard/promotions/forms.py
+++ b/src/oscar/apps/dashboard/promotions/forms.py
@@ -25,7 +25,7 @@ class PromotionTypeSelectForm(forms.Form):
 class RawHTMLForm(forms.ModelForm):
     class Meta:
         model = RawHTML
-        exclude = ('display_type',)
+        fields = ['name', 'body']
 
     def __init__(self, *args, **kwargs):
         super(RawHTMLForm, self).__init__(*args, **kwargs)
@@ -42,7 +42,7 @@ class SingleProductForm(forms.ModelForm):
 class HandPickedProductListForm(forms.ModelForm):
     class Meta:
         model = HandPickedProductList
-        exclude = ('products',)
+        fields = ['name', 'description', 'link_url', 'link_text']
 
 
 class OrderedProductForm(forms.ModelForm):
@@ -67,7 +67,7 @@ class PagePromotionForm(forms.ModelForm):
 
     class Meta:
         model = PagePromotion
-        exclude = ('display_order', 'clicks', 'content_type', 'object_id')
+        fields = ['position']
 
     def clean_page_url(self):
         page_url = self.cleaned_data.get('page_url')

--- a/src/oscar/apps/dashboard/ranges/forms.py
+++ b/src/oscar/apps/dashboard/ranges/forms.py
@@ -14,8 +14,10 @@ class RangeForm(forms.ModelForm):
 
     class Meta:
         model = Range
-        exclude = ('included_products', 'slug', 'excluded_products', 'classes',
-                   'proxy_class')
+        fields = [
+            'name', 'description', 'is_public',
+            'includes_all_products','included_categories'
+        ]
 
 
 class RangeProductForm(forms.Form):

--- a/src/oscar/apps/dashboard/users/forms.py
+++ b/src/oscar/apps/dashboard/users/forms.py
@@ -28,8 +28,9 @@ class ProductAlertUpdateForm(forms.ModelForm):
 
     class Meta:
         model = ProductAlert
-        exclude = ('product', 'user', 'email', 'key',
-                   'date_confirmed', 'date_cancelled', 'date_closed')
+        fields = [
+            'status',
+        ]
 
 
 class ProductAlertSearchForm(forms.Form):

--- a/src/oscar/apps/payment/forms.py
+++ b/src/oscar/apps/payment/forms.py
@@ -273,4 +273,8 @@ class BillingAddressForm(PhoneNumberMixin, AbstractAddressForm):
 
     class Meta:
         model = BillingAddress
-        exclude = ('search_text',)
+        fields = [
+            'title', 'first_name', 'last_name',
+            'line1', 'line2', 'line3', 'line4',
+            'state', 'postcode', 'country',
+        ]

--- a/tests/unit/core/phonenumber_tests.py
+++ b/tests/unit/core/phonenumber_tests.py
@@ -19,6 +19,7 @@ class PhoneNumberForm(forms.ModelForm):
 
     class Meta:
         model = MandatoryPhoneNumber
+        fields = ['phone_number']
 
 
 valid_number = '+4917696842671'


### PR DESCRIPTION
Specifying `excludes` is deprecated in Django 1.7 and not supported in
Django 1.8.