### PR TITLE
Fix false-negative for UPCs when UPC matches a variant.

### DIFF
--- a/oscar/apps/dashboard/catalogue/views.py
+++ b/oscar/apps/dashboard/catalogue/views.py
@@ -115,9 +115,14 @@ class ProductListView(SingleTableMixin, generic.TemplateView):
         data = self.form.cleaned_data
 
         if data.get('upc'):
-            # Filter the queryset by upc
-            matches_upc = Product.objects.filter(upc__icontains=data['upc'])
-            queryset = queryset.filter( Q(id=matches_upc.values('id')) | Q(id=matches_upc.values('parent_id')) )
+            # If there's an exact UPC match, it returns just the matched
+            # product. Otherwise does a broader icontains search.
+            qs_match = queryset.filter(Q(upc=data['upc']) | Q(parent__upc=data['upc']))
+
+            if qs_match.exists():
+                queryset = qs_match
+            else:
+                queryset = queryset.filter(Q(upc__icontains=data['upc']) | Q(parent__upc__icontains=data['upc']))
 
         if data.get('title'):
             queryset = queryset.filter(title__icontains=data['title'])

--- a/oscar/apps/dashboard/catalogue/views.py
+++ b/oscar/apps/dashboard/catalogue/views.py
@@ -115,13 +115,9 @@ class ProductListView(SingleTableMixin, generic.TemplateView):
         data = self.form.cleaned_data
 
         if data.get('upc'):
-            # If there's an exact UPC match, it returns just the matched
-            # product. Otherwise does a broader icontains search.
-            qs_match = queryset.filter(upc=data['upc'])
-            if qs_match.exists():
-                queryset = qs_match
-            else:
-                queryset = queryset.filter(upc__icontains=data['upc'])
+            # Filter the queryset by upc
+            matches_upc = Product.objects.filter(upc__icontains=data['upc'])
+            queryset = queryset.filter( Q(id=matches_upc.values('id')) | Q(id=matches_upc.values('parent_id')) )
 
         if data.get('title'):
             queryset = queryset.filter(title__icontains=data['title'])

--- a/oscar/apps/dashboard/catalogue/views.py
+++ b/oscar/apps/dashboard/catalogue/views.py
@@ -115,14 +115,17 @@ class ProductListView(SingleTableMixin, generic.TemplateView):
         data = self.form.cleaned_data
 
         if data.get('upc'):
-            # If there's an exact UPC match, it returns just the matched
-            # product. Otherwise does a broader icontains search.
-            qs_match = queryset.filter(Q(upc=data['upc']) | Q(parent__upc=data['upc']))
+            # Filter the queryset by upc
+            # If there's an exact match, return it, otherwise return results
+            # that contain the UPC
+            matches_upc = Product.objects.filter(upc=data['upc'])
+            qs_match = queryset.filter(Q(id=matches_upc.values('id')) | Q(id=matches_upc.values('parent_id')))
 
             if qs_match.exists():
                 queryset = qs_match
             else:
-                queryset = queryset.filter(Q(upc__icontains=data['upc']) | Q(parent__upc__icontains=data['upc']))
+                matches_upc = Product.objects.filter(upc__icontains=data['upc'])
+                queryset = queryset.filter(Q(id=matches_upc.values('id')) | Q(id=matches_upc.values('parent_id')))
 
         if data.get('title'):
             queryset = queryset.filter(title__icontains=data['title'])


### PR DESCRIPTION
Fixes https://github.com/django-oscar/django-oscar/issues/1684

I removed the `exists()` logic. I can update the pull request with that logic in place if you think it's really necessary.

