### PR TITLE
Allow for children to be explicitly included in ranges. (Allows for rang...

### DIFF
--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -824,9 +824,6 @@ class AbstractRange(models.Model):
         Default display_order for a new product in the range is 0; this puts
         the product at the top of the list.
         """
-        if product.is_child:
-            raise ValueError(
-                "Ranges can only contain parent and stand-alone products.")
 
         initial_order = display_order or 0
         RangeProduct = get_model('offer', 'RangeProduct')

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -851,9 +851,6 @@ class AbstractRange(models.Model):
         """
         Check whether the passed product is part of this range.
         """
-        # Child products are never part of the range, but the parent may be.
-        if product.is_child:
-            product = product.parent
 
         # Delegate to a proxy class if one is provided
         if self.proxy:
@@ -867,6 +864,9 @@ class AbstractRange(models.Model):
         if product.product_class_id in self._class_ids():
             return True
         included_product_ids = self._included_product_ids()
+        # If the product's parent is in the range, the child is automatically included as well
+        if product.is_child and product.parent.id in included_product_ids:
+            return True
         if product.id in included_product_ids:
             return True
         test_categories = self.included_categories.all()

--- a/tests/integration/offer/range_tests.py
+++ b/tests/integration/offer/range_tests.py
@@ -28,6 +28,26 @@ class TestWholeSiteRange(TestCase):
         self.assertFalse(self.range.contains_product(self.prod))
 
 
+class TestChildRange(TestCase):
+
+    def setUp(self):
+        self.range = models.Range.objects.create(
+            name='Child-specific range', includes_all_products=False)
+        self.parent = create_product(structure='parent')
+        self.child1 = create_product(structure='child', parent=self.parent)
+        self.child2 = create_product(structure='child', parent=self.parent)
+        self.range.add_product(self.child1)
+
+    def test_includes_child(self):
+        self.assertTrue(self.range.contains_product(self.child1))
+
+    def test_does_not_include_parent(self):
+        self.assertFalse(self.range.contains_product(self.parent))
+
+    def test_does_not_include_sibling(self):
+        self.assertFalse(self.range.contains_product(self.child2))
+
+
 class TestPartialRange(TestCase):
 
     def setUp(self):

--- a/tests/integration/offer/range_tests.py
+++ b/tests/integration/offer/range_tests.py
@@ -50,9 +50,6 @@ class TestPartialRange(TestCase):
         self.assertTrue(self.range.contains_product(self.parent))
         self.assertTrue(self.range.contains_product(self.child))
 
-    def test_cant_add_child_product(self):
-        self.assertRaises(ValueError, self.range.add_product, self.child)
-
     def test_included_class_with_exception(self):
         self.range.classes.add(self.parent.get_product_class())
         self.range.excluded_products.add(self.parent)


### PR DESCRIPTION
Fix for https://github.com/django-oscar/django-oscar/issues/1698

There should be just one backwards incompatible changes: this changes the parameter that is passed to `load_proxy(self.proxy_class)().contains_product(product)` so any custom `Condition` that overrides `contains_product` will have to make sure it can handle accepting a child product. This should probably be documented.