### PR TITLE
Allow robots to index the ecommerce pages again.

### DIFF
--- a/src/oscar/templates/oscar/base.html
+++ b/src/oscar/templates/oscar/base.html
@@ -13,7 +13,7 @@
         <meta name="description" content="{% block description %}{% endblock %}" />
         <meta name="keywords" content="{% block keywords %}{% endblock %}" />
         <meta name="viewport" content="{% block viewport %}width=device-width{% endblock %}" />
-        <meta name="robots" content="NONE,NOARCHIVE" />
+        <meta name="robots" content="NOARCHIVE,NOCACHE" />
 
         <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
         <!--[if lt IE 9]>


### PR DESCRIPTION
All e-commerce pages would be removed from search results if someone uses oscar default base.html. 

I noticed this while upgrading a project to 1.0.x.
Could this be backported to the 1.0 branch?

**Changes**:
* Remove ``none``: it's equivalent to ``noindex, nofollow``
* Use ``nocache`` (Bing) and ``noarchive`` (Google, Yahoo): we don't want search engines to cache copy of web pages and products prices in search results.

**References**:
https://developers.google.com/webmasters/control-crawl-index/docs/robots_meta_tag
https://developer.mozilla.org/it/docs/Web/HTML/Element/meta
