### PR TITLE
Fix race condition when tracking num_basket_additions on a voucher

### DIFF
--- a/src/oscar/apps/voucher/receivers.py
+++ b/src/oscar/apps/voucher/receivers.py
@@ -1,14 +1,19 @@
+from django.db.models import F
 from oscar.apps.basket import signals
 
 
 def track_voucher_addition(basket, voucher, **kwargs):
     voucher.num_basket_additions += 1
-    voucher.save()
+    voucher.__class__._default_manager.filter(pk=voucher.pk).update(
+        num_basket_additions=F('num_basket_additions') + 1,
+    )
 
 
 def track_voucher_removal(basket, voucher, **kwargs):
     voucher.num_basket_additions -= 1
-    voucher.save()
+    voucher.__class__._default_manager.filter(pk=voucher.pk).update(
+        num_basket_additions=F('num_basket_additions') - 1,
+    )
 
 
 signals.voucher_addition.connect(track_voucher_addition)


### PR DESCRIPTION
### What is the problem / feature ?

The current implementation that maintains the counts for `Voucher.num_basket_addition` is subject to race conditions.  If two users apply the same voucher at approximately the same time, one of the additions can easily be lost.  The same applies to voucher removal.

### How did it get fixed / implemented ?

Instead of using `voucher.save()` change to use an `.update()` statement using an `F()` statement.

https://docs.djangoproject.com/en/1.7/ref/models/queries/#avoiding-race-conditions-using-f

This delegates the increment/decrement of this count to the database which allows for this operation to be safe from multiple concurrent updates.

### How can someone test / see it ?

I don't know how to write a test case that exposes this bug without some nasty mocking, `time.sleep()` and threading.  Ick.

*Here is a cute animal picture for your troubles...*

![cat-wearing-a-pointy-hat](https://cloud.githubusercontent.com/assets/824194/6943853/d6343ec8-d84d-11e4-9bdc-c624edb5658e.jpg)




