### PR TITLE
Use fetch_for_line where appropriate

### DIFF
--- a/src/oscar/apps/basket/abstract_models.py
+++ b/src/oscar/apps/basket/abstract_models.py
@@ -730,8 +730,8 @@ class AbstractLine(models.Model):
         """
         if not hasattr(self, '_info'):
             # Cache the PurchaseInfo instance.
-            self._info = self.basket.strategy.fetch_for_product(
-                self.product, self.stockrecord)
+            self._info = self.basket.strategy.fetch_for_line(
+                self, self.stockrecord)
         return self._info
 
     @property

--- a/src/oscar/apps/checkout/session.py
+++ b/src/oscar/apps/checkout/session.py
@@ -120,7 +120,7 @@ class CheckoutSessionMixin(object):
         messages = []
         strategy = request.strategy
         for line in request.basket.all_lines():
-            result = strategy.fetch_for_product(line.product)
+            result = strategy.fetch_for_line(line)
             is_permitted, reason = result.availability.is_purchase_permitted(
                 line.quantity)
             if not is_permitted:


### PR DESCRIPTION
I'm working on a project where pricing depends on Line attributes. Therefore we need to calculate prices in our Strategy's `fetch_for_line`. While working through this I found that `fetch_for_line` is not called in some places where it seems like it should be. So far I've found two places that have access to a Line, but are calling `fetch_for_product(line.product)` instead of `fetch_for_line(line)`.

- `oscar.apps.basket.AbstractLine.purchase_info` - The symptom here was that prices in the basket were not displaying properly, since they were ultimately using `fetch_for_product`

- `oscar.apps.checkout.session.CheckoutSessionMixin.check_basket_is_valid` - The symptom here was that setting the availability policy in `fetch_for_line` was having no effect (specifically, making it Unavailable did not prevent checkout).