### PR TITLE
Fix #1689

### DIFF
--- a/src/oscar/apps/catalogue/migrations/0003_data_migration_slugs.py
+++ b/src/oscar/apps/catalogue/migrations/0003_data_migration_slugs.py
@@ -2,17 +2,18 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
+from oscar.core.loading import get_model
 
 
 def remove_ancestor_slugs(apps, schema_editor):
-    Category = apps.get_model('catalogue', 'Category')
+    Category = get_model('catalogue', 'Category')
     for category in Category.objects.all():
         category.slug = category.slug.split(Category._slug_separator)[-1]
         category.save()
 
 
 def add_ancestor_slugs(apps, schema_editor):
-    Category = apps.get_model('catalogue', 'Category')
+    Category = get_model('catalogue', 'Category')
     for category in Category.objects.all():
         category.slug = category.full_slug
         category.save()


### PR DESCRIPTION
Use Oscar's core method `get_model` to get Category model in data migrations.

**Explanation:**
Documented way to data migration in Django 1.7+ is using `apps.get_model` in forward/backward migrations. But this is not the same method as `get_model` from `django.apps.apps`. In migrations operations used ModelState instances which actually is:

> Represents a Django Model. We don't use the actual Model class
> as it's not designed to have its options changed - instead, we
> mutate this one and then render it into a Model as required.

It's from [here](https://github.com/django/django/blob/1.7.7/django/db/migrations/state.py#L140-L142).

So, `apps.get_model` return *fake* model, which actually is deconstructed model class instance (ModelBase) with no properties, no class methods, only with model fields.

Side effect of using Oscar's `get_model` is requirement to Category model's properties `full_slug` and `_slug_separator` will not be changed/renamed in future.