### PR TITLE
Hook for changing tax rate during runtime

### DIFF
--- a/src/oscar/apps/partner/strategy.py
+++ b/src/oscar/apps/partner/strategy.py
@@ -260,7 +260,9 @@ class FixedRateTax(object):
     def pricing_policy(self, product, stockrecord):
         if not stockrecord:
             return prices.Unavailable()
-        tax = (stockrecord.price_excl_tax * self.rate).quantize(self.exponent)
+        rate = self.get_rate(product, stockrecord)
+        exponent = self.get_exponent(stockrecord)
+        tax = (stockrecord.price_excl_tax * rate).quantize(exponent)
         return prices.TaxInclusiveFixedPrice(
             currency=stockrecord.price_currency,
             excl_tax=stockrecord.price_excl_tax,
@@ -273,12 +275,20 @@ class FixedRateTax(object):
 
         # We take price from first record
         stockrecord = stockrecords[0]
-        tax = (stockrecord.price_excl_tax * self.rate).quantize(self.exponent)
+        rate = self.get_rate(product, stockrecord)
+        exponent = self.get_exponent(stockrecord)
+        tax = (stockrecord.price_excl_tax * rate).quantize(exponent)
 
         return prices.FixedPrice(
             currency=stockrecord.price_currency,
             excl_tax=stockrecord.price_excl_tax,
             tax=tax)
+
+    def get_rate(self, product, stockrecord):
+        return self.rate
+
+    def get_exponent(self, stockrecord):
+        return self.exponent
 
 
 class DeferredTax(object):


### PR DESCRIPTION
Added hook to FixedRateTax class for getting tax rate with possibility to change it at runtime without need to restart server or select by product class.

To the hook method ```get_rate``` are passed parameters product and stockrecord. Product is passed because in some countries (e.g. Czech Republic) is possible to have 2 vat rates (basic and reduced) and in my opinion is best place to this information ```ProductClass``` model which is reachable from product instance. StockRecord instance is passed for info about currency. Actually I am not able to imagine case when stock record is needed but if some exists it is ready.

With this I added hook method for exponent too. There is passed ```StockRecord``` instance because exponent is in most cases dependent on currency.