### PR TITLE
Forbid hyphens from AbstractProdutAttribute.code

### DIFF
--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -806,9 +806,9 @@ class AbstractProductAttribute(models.Model):
     code = models.SlugField(
         _('Code'), max_length=128,
         validators=[RegexValidator(
-            regex=r'^[a-zA-Z\-_][0-9a-zA-Z\-_]*$',
+            regex=r'^[a-zA-Z_][0-9a-zA-Z_]*$',
             message=_("Code can only contain the letters a-z, A-Z, digits, "
-                      "minus and underscores, and can't start with a digit"))])
+                      "and underscores, and can't start with a digit"))])
 
     # Attribute types
     TEXT = "text"


### PR DESCRIPTION
Fixes https://github.com/django-oscar/django-oscar/issues/1713

Validates that `AbstractProdutAttribute.code` is a valid Python identifier.

The only caveat is that if you supply a name with spaces, Django's `prepopulated_fields` setting will generate a code with hyphens, which will then have to be manually fixed.