### PR TITLE
Run `pip wheel -r` over all requirement files in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,12 +35,13 @@ env:
         - DJANGO=Django==1.8.1
 
 before_install:
-    - pip install codecov
-
-install:
     # Before installation, we'll run ``pip wheel``, this will build wheels for
     # anything that doesn't already have one on PyPI.
-    - pip wheel -r requirements.txt
+    - ls requirements*.txt | xargs -n 1 pip wheel --allow-external django-oscar --process-dependency-links -r 
+    - pip install codecov
+
+
+install:
     # Actually install our dependencies now, this will pull from the directory
     # that the first command placed the Wheels into.
     - pip install -e . -r requirements.txt $DJANGO 

--- a/requirements_demo.txt
+++ b/requirements_demo.txt
@@ -4,7 +4,7 @@ django-oscar-paypal==0.9.1
 django-oscar-datacash==0.8.3
 
 # We need PostGIS as the stores extension uses GeoDjango.
-psycopg2==2.5.1
+psycopg2==2.6
 
 # To use Solr, we need pysolr
 pysolr==3.2

--- a/requirements_migrations.txt
+++ b/requirements_migrations.txt
@@ -1,3 +1,3 @@
 # Those dependencies are needed for the test_migrations.sh script
 PyMySQL==0.6.2
-psycopg2==2.4.5
+psycopg2==2.6


### PR DESCRIPTION
Since both the demo and the migrations test use psycopg2 we might as
well build these as wheels. Should probably speed up travis runs.