### PR TITLE
Add a multi_option value type. This will create a new table for the m…

### DIFF
--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -984,7 +984,7 @@ class AbstractProductAttributeValue(models.Model):
     value_richtext = models.TextField(_('Richtext'), blank=True, null=True)
     value_date = models.DateField(_('Date'), blank=True, null=True)
     value_multi_option = models.ManyToManyField(
-        'catalogue.AttributeOption', blank=True, null=True,
+        'catalogue.AttributeOption', blank=True,
         related_name='multi_valued_attribute_values',
         verbose_name=_("Value multi option"))
     value_option = models.ForeignKey(

--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -836,6 +836,10 @@ class AbstractProductAttribute(models.Model):
         return self.type == self.OPTION
 
     @property
+    def is_multi_option(self):
+        return self.type == self.MULTI_OPTION
+
+    @property
     def is_file(self):
         return self.type in [self.FILE, self.IMAGE]
 
@@ -866,6 +870,20 @@ class AbstractProductAttribute(models.Model):
                 value_obj.delete()
             else:
                 # New uploaded file
+                value_obj.value = value
+                value_obj.save()
+        elif self.is_multi_option:
+            # ManyToMany fields are handled separately
+            if value is None:
+                value_obj.delete()
+                return
+            try:
+                count = value.count()
+            except (AttributeError, TypeError):
+                count = len(value)
+            if count == 0:
+                value_obj.delete()
+            else:
                 value_obj.value = value
                 value_obj.save()
         else:


### PR DESCRIPTION
Fixes https://github.com/django-oscar/django-oscar/issues/1739

I took inspiration from https://github.com/django-oscar/django-oscar/pull/879 but tried to implement it in such a way that it would be backwards compatible.

It's not a particularly elegant solution. There's now both a `ForeignKey` and `ManyToManyField` to `catalogue.AttributeOption`, but `ProductAttributeValue` isn't a particularly elegant model to begin with.

I initially thought I would add a `ManyToManyField` and then make the option field actually use it, but doing so would make backwards compatibility really difficult.
## To do

I am willing to do these, but I would appreciate some input before proceeding.
- Update the initial migration.
- Documentation. 
- Tests

Thanks,

John
