### PR TITLE
enable multi_option choice for attributes

### DIFF
--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -792,6 +792,7 @@ class AbstractProductAttribute(models.Model):
     RICHTEXT = "richtext"
     DATE = "date"
     OPTION = "option"
+    MULTI_OPTION = "multi_option"
     ENTITY = "entity"
     FILE = "file"
     IMAGE = "image"
@@ -803,6 +804,7 @@ class AbstractProductAttribute(models.Model):
         (RICHTEXT, _("Rich Text")),
         (DATE, _("Date")),
         (OPTION, _("Option")),
+        (MULTI_OPTION, _("Multi-option")),
         (ENTITY, _("Entity")),
         (FILE, _("File")),
         (IMAGE, _("Image")),


### PR DESCRIPTION
See my comment here:
https://github.com/django-oscar/django-oscar/issues/1739#issuecomment-105931475

This is a minimal change allowing us to hack in our own support for multi options while PRs #879 and #1740  are considered
