### PR TITLE
Allow product_class to be blank.

### DIFF
--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -287,7 +287,7 @@ class AbstractProduct(models.Model):
     #: "Kind" of product, e.g. T-Shirt, Book, etc.
     #: None for child products, they inherit their parent's product class
     product_class = models.ForeignKey(
-        'catalogue.ProductClass', null=True, on_delete=models.PROTECT,
+        'catalogue.ProductClass', null=True, blank=True, on_delete=models.PROTECT,
         verbose_name=_('Product type'), related_name="products",
         help_text=_("Choose what type of product this is"))
     attributes = models.ManyToManyField(


### PR DESCRIPTION
Fixes https://github.com/django-oscar/django-oscar/issues/1748

`Product._clean_standalone` and `Product._clean_parent` already check to make sure `product_class` is not `None`, so there's really no other changes to be made.