### PR TITLE
Fix validation message in basket

### DIFF
--- a/src/oscar/apps/partner/availability.py
+++ b/src/oscar/apps/partner/availability.py
@@ -83,7 +83,7 @@ class StockRequired(Base):
         self.num_available = num_available
 
     def is_purchase_permitted(self, quantity):
-        if self.num_available == 0:
+        if self.num_available <= 0:
             return False, _("no stock available")
         if quantity > self.num_available:
             msg = _("a maximum of %(max)d can be bought") % {

--- a/tests/unit/partner/availability_tests.py
+++ b/tests/unit/partner/availability_tests.py
@@ -51,14 +51,22 @@ class TestStockRequiredWrapperForRecordWithStock(TestCase):
             self.assertTrue(is_permitted)
 
     def test_forbids_purchases_over_stock_level(self):
-        is_permitted, __ = self.availability.is_purchase_permitted(7)
+        is_permitted, msg = self.availability.is_purchase_permitted(7)
         self.assertFalse(is_permitted)
+        self.assertEqual(msg, "a maximum of 5 can be bought")
 
     def test_returns_correct_code(self):
         self.assertEqual('instock', self.availability.code)
 
     def test_returns_correct_message(self):
         self.assertEqual('In stock (5 available)', self.availability.message)
+
+    def test_returns_correct_message_when_allocation_higher_than_stock(self):
+        # this is the value passed when stock lower than allocation by 1
+        self.availability.num_available = -1
+        is_permitted, msg = self.availability.is_purchase_permitted(1)
+        self.assertFalse(is_permitted)
+        self.assertEqual(msg, "no stock available")
 
 
 class TestStockRequiredWrapperForRecordWithoutStock(TestCase):


### PR DESCRIPTION
Fixes stockrecord availability validation message in the case when stock is lower than allocation. Previously the message that appeared contained negative numbers. For example: "a maximum of -1 can be bought". Now it will display: "no stock available"

Fixes #1765 