### PR TITLE
Fix call to calculate_excl_discount

### DIFF
--- a/src/oscar/apps/basket/views.py
+++ b/src/oscar/apps/basket/views.py
@@ -159,7 +159,7 @@ class BasketView(ModelFormSetView):
         shipping_charge = method.calculate(self.request.basket)
         context['shipping_charge'] = shipping_charge
         if method.is_discounted:
-            excl_discount = method.calculate_excl_discount(shipping_charge)
+            excl_discount = method.calculate_excl_discount(self.request.basket)
             context['shipping_charge_excl_discount'] = excl_discount
 
         context['order_total'] = OrderTotalCalculator().calculate(


### PR DESCRIPTION
Fixes #1719.

`calculate_excl_discount` was being passed a shipping charge, when it wants a basket.