### PR TITLE
Fix CSS classes for ProductSelect widgets

### DIFF
--- a/src/oscar/apps/dashboard/catalogue/forms.py
+++ b/src/oscar/apps/dashboard/catalogue/forms.py
@@ -410,6 +410,10 @@ class ProductRecommendationForm(forms.ModelForm):
             'recommendation': ProductSelect,
         }
 
+    def __init__(self, *args, **kwargs):
+        super(ProductRecommendationForm, self).__init__(*args, **kwargs)
+        self.fields['recommendation'].widget.attrs['class'] = "select2"
+
 
 BaseProductRecommendationFormSet = inlineformset_factory(
     Product, ProductRecommendation, form=ProductRecommendationForm,

--- a/src/oscar/apps/dashboard/catalogue/widgets.py
+++ b/src/oscar/apps/dashboard/catalogue/widgets.py
@@ -14,4 +14,3 @@ class ProductSelectMultiple(MultipleRemoteSelect):
     # AjaxSelect(data_url=...) for overridability and backwards compatibility
     lookup_url = reverse_lazy('dashboard:catalogue-product-lookup')
     is_multiple = True
-    css = 'select2 input-xxlarge'

--- a/src/oscar/apps/dashboard/promotions/forms.py
+++ b/src/oscar/apps/dashboard/promotions/forms.py
@@ -38,6 +38,10 @@ class SingleProductForm(forms.ModelForm):
         fields = ['name', 'product', 'description']
         widgets = {'product': ProductSelect}
 
+    def __init__(self, *args, **kwargs):
+        super(SingleProductForm, self).__init__(*args, **kwargs)
+        self.fields['product'].widget.attrs['class'] = "select2 input-xlarge"
+
 
 class HandPickedProductListForm(forms.ModelForm):
     class Meta:
@@ -52,6 +56,10 @@ class OrderedProductForm(forms.ModelForm):
         widgets = {
             'product': ProductSelect,
         }
+
+    def __init__(self, *args, **kwargs):
+        super(OrderedProductForm, self).__init__(*args, **kwargs)
+        self.fields['product'].widget.attrs['class'] = "select2 input-xlarge"
 
 
 OrderedProductFormSet = inlineformset_factory(

--- a/src/oscar/forms/widgets.py
+++ b/src/oscar/forms/widgets.py
@@ -295,7 +295,6 @@ class RemoteSelect(forms.Widget):
     constructing
     """
     is_multiple = False
-    css = 'select2 input-xlarge'
     lookup_url = None
 
     def __init__(self, *args, **kwargs):
@@ -319,7 +318,6 @@ class RemoteSelect(forms.Widget):
     def render(self, name, value, attrs=None, choices=()):
         attrs = self.build_attrs(attrs, **{
             'type': 'hidden',
-            'class': self.css,
             'name': name,
             'data-ajax-url': self.lookup_url,
             'data-multiple': 'multiple' if self.is_multiple else '',
@@ -331,7 +329,6 @@ class RemoteSelect(forms.Widget):
 
 class MultipleRemoteSelect(RemoteSelect):
     is_multiple = True
-    css = 'select2 input-xxlarge'
 
     def format_value(self, value):
         if value:


### PR DESCRIPTION
ProductSelect widgets in the Dashboard require at least the CSS class `select2`. Django widget tweaks was overriding CSS classes set in the RemoteSelect and MultipleRemoteSelect widgets.

Fixes #1772