### PR TITLE
basket: Do None check of unit_price_excl_tax before multiplication

### DIFF
--- a/src/oscar/apps/basket/abstract_models.py
+++ b/src/oscar/apps/basket/abstract_models.py
@@ -759,7 +759,9 @@ class AbstractLine(models.Model):
 
     @property
     def line_price_excl_tax(self):
-        return self.quantity * self.unit_price_excl_tax
+        if self.unit_price_excl_tax:
+            return self.quantity * self.unit_price_excl_tax
+        return 0
 
     @property
     def line_price_excl_tax_incl_discounts(self):


### PR DESCRIPTION
If price of a product, which is already in a basket becomes unavailable, Line.line_price_excl_tax property throws a TypeError while multiplying quantity with unit_price_excl_tax, since unit_price_excl_tax is None. Do a None check before multiplication to avoid this.
