### PR TITLE
Fix `AttributeError` or `ship_to_new_address` method

### DIFF
--- a/src/oscar/apps/checkout/utils.py
+++ b/src/oscar/apps/checkout/utils.py
@@ -91,12 +91,6 @@ class CheckoutSessionData(object):
         Use a manually entered address as the shipping address
         """
         self._unset('shipping', 'new_address_fields')
-        phone_number = address_fields.get('phone_number')
-        if phone_number:
-            # Phone number is stored as a PhoneNumber instance. As we store
-            # strings in the session, we need to serialize it.
-            address_fields = address_fields.copy()
-            address_fields['phone_number'] = phone_number.as_international
         self._set('shipping', 'new_address_fields', address_fields)
 
     def new_shipping_address_fields(self):


### PR DESCRIPTION
##### Getting an `AttributeError` on `ship_to_new_address`:

 `phone_number.as_international` is throwing an `AttributeError` since `phone_number` is now a `str` and not a `PhoneNumber` instance.