### PR TITLE
PartnerUserUpdateView: Insert partner into context for template rendering to work

### DIFF
--- a/src/oscar/apps/dashboard/partners/views.py
+++ b/src/oscar/apps/dashboard/partners/views.py
@@ -277,6 +277,7 @@ class PartnerUserUpdateView(generic.UpdateView):
     form_class = ExistingUserForm
 
     def get_object(self, queryset=None):
+        self.partner = get_object_or_404(Partner, pk=self.kwargs['partner_pk'])
         return get_object_or_404(User,
                                  pk=self.kwargs['user_pk'],
                                  partners__pk=self.kwargs['partner_pk'])
@@ -284,6 +285,7 @@ class PartnerUserUpdateView(generic.UpdateView):
     def get_context_data(self, **kwargs):
         ctx = super(PartnerUserUpdateView, self).get_context_data(**kwargs)
         name = self.object.get_full_name() or self.object.email
+        ctx['partner'] = self.partner
         ctx['title'] = _("Edit user '%s'") % name
         return ctx
 


### PR DESCRIPTION
PartnerUserUpdateView fails by throwing NoReverseMatch, because the tempalte
partner_user_form.html expects a partner object in the context. Fix by
inserting partner into the context