### PR TITLE
Non-staff user has access to stock records of linked partner only

### DIFF
--- a/src/oscar/apps/dashboard/catalogue/forms.py
+++ b/src/oscar/apps/dashboard/catalogue/forms.py
@@ -90,6 +90,15 @@ class StockRecordFormSet(BaseStockRecordFormSet):
         self.user = user
         self.require_user_stockrecord = not user.is_staff
         self.product_class = product_class
+
+        if not user.is_staff and \
+           'instance' in kwargs and \
+           'queryset' not in kwargs:
+            kwargs.update({
+                'queryset': StockRecord.objects.filter(product=kwargs['instance'],
+                                                       partner__in=user.partners.all())
+            })
+
         super(StockRecordFormSet, self).__init__(*args, **kwargs)
         self.set_initial_data()
 

--- a/src/oscar/apps/dashboard/catalogue/forms.py
+++ b/src/oscar/apps/dashboard/catalogue/forms.py
@@ -62,6 +62,7 @@ class StockRecordForm(forms.ModelForm):
         # anyway in case one wishes to customise the partner queryset
         self.user = user
         super(StockRecordForm, self).__init__(*args, **kwargs)
+        self.fields['partner'].queryset = self.user.partners.all()
 
         # If not tracking stock, we hide the fields
         if not product_class.track_stock:


### PR DESCRIPTION
Currently a non-staff user has access to all the stock records, if there is at least one stock record from their linked partner for the product. This is wrong in a market place scenario. Access should be restricted to the stock records of the linked partner only. With this fix, non-staff user can create/delete/update stock records for their linked partners only.