### PR TITLE
Restrict non-staff user's access to stock records of linked partners only

### DIFF
--- a/src/oscar/apps/dashboard/catalogue/forms.py
+++ b/src/oscar/apps/dashboard/catalogue/forms.py
@@ -63,6 +63,10 @@ class StockRecordForm(forms.ModelForm):
         self.user = user
         super(StockRecordForm, self).__init__(*args, **kwargs)
 
+        # Restrict accessible partners for non-staff users
+        if not self.user.is_staff:
+            self.fields['partner'].queryset = self.user.partners.all()
+
         # If not tracking stock, we hide the fields
         if not product_class.track_stock:
             del self.fields['num_in_stock']

--- a/src/oscar/apps/dashboard/catalogue/forms.py
+++ b/src/oscar/apps/dashboard/catalogue/forms.py
@@ -90,6 +90,15 @@ class StockRecordFormSet(BaseStockRecordFormSet):
         self.user = user
         self.require_user_stockrecord = not user.is_staff
         self.product_class = product_class
+
+        if not user.is_staff and \
+           'instance' in kwargs and \
+           'queryset' not in kwargs:
+            kwargs.update({
+                'queryset': StockRecord.objects.filter(product=kwargs['instance'],
+                                                       partner__in=user.partners.all())
+            })
+
         super(StockRecordFormSet, self).__init__(*args, **kwargs)
         self.set_initial_data()
 


### PR DESCRIPTION
Currently a non-staff user has access to all the stock records, if there is at least one stock record from their linked partner for the product. This is wrong in a market place scenario. Access should be restricted to the stock records of the linked partner only. With this fix, non-staff user can create/delete/update stock records for their linked partners only.