### PR TITLE
Remove meta keywords tag and keywords block.

### DIFF
--- a/src/oscar/templates/oscar/base.html
+++ b/src/oscar/templates/oscar/base.html
@@ -11,7 +11,6 @@
         <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
         <meta name="created" content="{% now "jS M Y h:i" %}" />
         <meta name="description" content="{% block description %}{% endblock %}" />
-        <meta name="keywords" content="{% block keywords %}{% endblock %}" />
         <meta name="viewport" content="{% block viewport %}width=device-width{% endblock %}" />
         <meta name="robots" content="NOARCHIVE,NOCACHE" />
 


### PR DESCRIPTION
Closes https://github.com/django-oscar/django-oscar/issues/1799

We might want to document this as a backward incompatible change. Anyone that is using the base template and uses the keywords block is going to have the keywords automatically stripped out. (This is probably a *good* thing for them, but it might be worth noting.)