### PR TITLE
Fall back to Django 1.7 behavior for currency_filter. Fixes an Attrib…

### DIFF
--- a/src/oscar/templatetags/currency_filters.py
+++ b/src/oscar/templatetags/currency_filters.py
@@ -22,6 +22,6 @@ def currency(value, currency=None):
     kwargs = {
         'currency': currency if currency else settings.OSCAR_DEFAULT_CURRENCY,
         'format': getattr(settings, 'OSCAR_CURRENCY_FORMAT', None),
-        'locale': to_locale(get_language()),
+        'locale': to_locale(get_language() or settings.LANGUAGE_CODE),
     }
     return format_currency(value, **kwargs)

--- a/tests/integration/templatetags/test_currency_filters.py
+++ b/tests/integration/templatetags/test_currency_filters.py
@@ -35,8 +35,8 @@ class TestCurrencyFilter(TestCase):
             'price': ''
         }))
 
-    @translation.override(None, deactivate=True)
     def test_handles_no_translation(self):
-        self.template.render(template.Context({
-            'price': D('10.23'),
-        }))
+        with translation.override(None, deactivate=True):
+            self.template.render(template.Context({
+                'price': D('10.23'),
+            }))

--- a/tests/integration/templatetags/test_currency_filters.py
+++ b/tests/integration/templatetags/test_currency_filters.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from decimal import Decimal as D
 
+from django.utils import translation
 from django.test import TestCase
 from django import template
 
@@ -32,4 +33,10 @@ class TestCurrencyFilter(TestCase):
     def test_handles_string_price_gracefully(self):
         self.template.render(template.Context({
             'price': ''
+        }))
+
+    @translation.override(None, deactivate=True)
+    def test_handles_no_translation(self):
+        self.template.render(template.Context({
+            'price': D('10.23'),
         }))

--- a/tests/integration/templatetags/test_currency_filters.py
+++ b/tests/integration/templatetags/test_currency_filters.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from decimal import Decimal as D
 
-from django.utils import translation
-from django.test import TestCase
 from django import template
+from django.test import TestCase
+from django.utils import translation
 
 
 def render(template_string, ctx):


### PR DESCRIPTION
Closes https://github.com/django-oscar/django-oscar/issues/1803

`currency_filter.currency` now falls back to `settings.LANGUAGE_CODE`.

Added a test.