### PR TITLE
Move Basket.vouchers to Voucher.baskets with migration.

### DIFF
--- a/src/oscar/apps/basket/abstract_models.py
+++ b/src/oscar/apps/basket/abstract_models.py
@@ -42,12 +42,6 @@ class AbstractBasket(models.Model):
     status = models.CharField(
         _("Status"), max_length=128, default=OPEN, choices=STATUS_CHOICES)
 
-    # A basket can have many vouchers attached to it.  However, it is common
-    # for sites to only allow one voucher per basket - this will need to be
-    # enforced in the project's codebase.
-    vouchers = models.ManyToManyField(
-        'voucher.Voucher', verbose_name=_("Vouchers"), blank=True)
-
     date_created = models.DateTimeField(_("Date created"), auto_now_add=True)
     date_merged = models.DateTimeField(_("Date merged"), null=True, blank=True)
     date_submitted = models.DateTimeField(_("Date submitted"), null=True,

--- a/src/oscar/apps/basket/migrations/0006_move_basket_vouchers.py
+++ b/src/oscar/apps/basket/migrations/0006_move_basket_vouchers.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('basket', '0005_auto_20150604_1450'),
+    ]
+
+    state_operations = [
+        migrations.RemoveField(
+            model_name='basket',
+            name='vouchers'
+        ),
+    ]
+
+    database_operations = [
+        migrations.AlterField(
+            model_name='basket',
+            name='vouchers',
+            field=models.ManyToManyField(to='voucher.Voucher', db_table=b'voucher_voucher_baskets', verbose_name='Vouchers', blank=True),
+        ),
+    ]
+    
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=database_operations,
+            state_operations=state_operations)
+    ]

--- a/src/oscar/apps/voucher/abstract_models.py
+++ b/src/oscar/apps/voucher/abstract_models.py
@@ -52,6 +52,12 @@ class AbstractVoucher(models.Model):
 
     date_created = models.DateField(auto_now_add=True)
 
+    # A basket can have many vouchers attached to it.  However, it is common
+    # for sites to only allow one voucher per basket - this will need to be
+    # enforced in the project's codebase.
+    baskets = models.ManyToManyField(
+        'basket.Basket', verbose_name=_("Baskets"), blank=True, related_name='vouchers')
+
     class Meta:
         abstract = True
         app_label = 'voucher'

--- a/src/oscar/apps/voucher/migrations/0002_voucher_baskets.py
+++ b/src/oscar/apps/voucher/migrations/0002_voucher_baskets.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('basket', '0006_move_basket_vouchers'),
+        ('voucher', '0001_initial'),
+    ]
+
+    state_operations = [
+        migrations.AddField(
+            model_name='voucher',
+            name='baskets',
+            field=models.ManyToManyField(related_name='vouchers', verbose_name='Baskets', to='basket.Basket', blank=True),
+        ),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(state_operations=state_operations)
+    ]


### PR DESCRIPTION
Should close https://github.com/django-oscar/django-oscar/issues/1808

This moves the `vouchers` `ManyToManyField` definition to the `Voucher` model as a `baskets` `ManyToManyField` with a `vouchers` `related_name` for backwards compatibility.

I've included a migration that will remove the old field and add the new field without removing the data. 

I'm not 100% sure how migrations interact with app forking. Probably something that needs to be addressed before this is accepted.
