### PR TITLE
Fix missing page_url promotions form field

### DIFF
--- a/src/oscar/apps/dashboard/promotions/forms.py
+++ b/src/oscar/apps/dashboard/promotions/forms.py
@@ -75,7 +75,7 @@ class PagePromotionForm(forms.ModelForm):
 
     class Meta:
         model = PagePromotion
-        fields = ['position']
+        fields = ['position', 'page_url']
 
     def clean_page_url(self):
         page_url = self.cleaned_data.get('page_url')

--- a/tests/unit/dashboard/promotions_form_tests.py
+++ b/tests/unit/dashboard/promotions_form_tests.py
@@ -1,0 +1,19 @@
+from django.test import TestCase
+
+from oscar.apps.dashboard.promotions import forms
+from oscar.core.loading import get_classes
+
+RawHTML, PagePromotion = get_classes('promotions.models', ['RawHTML', 'PagePromotion'])
+
+
+class TestPagePromotionForm(TestCase):
+
+    def test_page_promotion_has_fields(self):
+        promotion = RawHTML()
+        promotion.save()
+        instance = PagePromotion(content_object=promotion)
+        data = {'position': 'page', 'page_url': '/'}
+        form = forms.PagePromotionForm(data=data, instance=instance)
+        self.assertTrue(form.is_valid())
+        page_promotion = form.save()
+        self.assertEqual(page_promotion.page_url, '/')


### PR DESCRIPTION
fixes https://github.com/django-oscar/django-oscar/issues/1815

The issue is that in this commit: https://github.com/django-oscar/django-oscar/commit/55fb961011736d75f7a1c4225e8948e096d7c9da fields for forms were moved from excludes to the meta.fields. It looks like the page_url field was missed.