### PR TITLE
Use hidden inputs for results forms, instead of hiding visible inputs.

### DIFF
--- a/src/oscar/templates/oscar/catalogue/browse.html
+++ b/src/oscar/templates/oscar/catalogue/browse.html
@@ -58,13 +58,11 @@
 {% block content %}
 
     <form method="get" class="form-horizontal">
-        {# Render other search params in a hidden block #}
-        <div style="display:none">
-            {% for value in selected_facets %}
-                <input name="selected_facets" value="{{ value }}" />
-            {% endfor %}
-            {{ form.q }}
-        </div>
+        {# Render other search params as hidden inputs #}
+        {% for value in selected_facets %}
+            <input type="hidden" name="selected_facets" value="{{ value }}" />
+        {% endfor %}
+        <input type="hidden" name="q" value="{{ search_form.q.value }}" />
 
         {% if paginator.count %}
             {% if paginator.num_pages > 1 %}

--- a/src/oscar/templates/oscar/search/results.html
+++ b/src/oscar/templates/oscar/search/results.html
@@ -42,13 +42,12 @@
 
 {% block content %}
     <form method="get" action="." class="form-horizontal">
-        {# Render other search params in a hidden block #}
-        <div style="display:none">
-            {% for value in selected_facets %}
-                <input name="selected_facets" value="{{ value }}" />
-            {% endfor %}
-            {{ search_form.q }}
-        </div>
+        {# Render other search params as hidden inputs #}
+        {% for value in selected_facets %}
+            <input type="hidden" name="selected_facets" value="{{ value }}" />
+        {% endfor %}
+        <input type="hidden" name="q" value="{{ search_form.q.value }}" />
+
         {% if paginator.count %}
             {% if paginator.num_pages > 1 %}
                 {% blocktrans with start=page.start_index end=page.end_index num_results=paginator.count %}
@@ -58,7 +57,7 @@
                 {% blocktrans count num_results=paginator.count %}
                     Found <strong>1</strong> result.
                 {% plural %}
-                    Found <strong>{{ num_results }}</strong> results. 
+                    Found <strong>{{ num_results }}</strong> results.
                 {% endblocktrans %}
             {% endif %}
             <div class="pull-right">


### PR DESCRIPTION
Hi,

A small fix to the way hidden parameters are rendered in the search/category results forms. It uses hidden inputs instead of wrapping normal inputs in a hidden div.

There is also currently an ID conflict between the main search form `q` field and the hidden one used in the results forms which interferes with JS manipulations. Rendering the latter manually ensures that only the main search form input has the ID.
