### PR TITLE
Move `ProductAttributesContainer` to `oscar.apps.catalogue.attributes`.

### DIFF
--- a/docs/source/releases/v1.2.rst
+++ b/docs/source/releases/v1.2.rst
@@ -29,7 +29,10 @@ Oscar 1.2 is compatible with...
 
 What's new in Oscar 1.2?
 ------------------------
-
+ 
+* The `ProductAttributesContainer` is moved to `oscar.apps.catalogue.attributes`.
+  Various performance optimizations where done and it is now also possible to 
+  override the class.
 
 .. _incompatible_in_1.2:
 

--- a/src/oscar/apps/catalogue/attributes.py
+++ b/src/oscar/apps/catalogue/attributes.py
@@ -21,7 +21,7 @@ class ProductAttributesContainer(object):
         self._initialised = False
 
     def __getattr__(self, name):
-        if not name.startswith('_') and not self.initialised:
+        if not name.startswith('_') and not self._initialised:
             self._load_values()
             return getattr(self, name)
         raise AttributeError(
@@ -75,7 +75,11 @@ class ProductAttributesContainer(object):
 
         # We don't filter on the attributes here since we assume all objects
         # are still available in the orm cache.
-        value_objects = {v.attribute_id: v for v in self.get_values()}
+        if self._product_pk:
+            value_objects = {v.attribute_id: v for v in self.get_values()}
+        else:
+            value_objects = {}
+
         for attribute in dirty_attributes:
             new_value = getattr(self, attribute.code)
             value_obj = value_objects.get(attribute.pk)

--- a/src/oscar/apps/catalogue/attributes.py
+++ b/src/oscar/apps/catalogue/attributes.py
@@ -1,0 +1,99 @@
+from django.core.exceptions import ValidationError
+from django.utils.translation import ugettext as _
+
+
+class ProductAttributesContainer(object):
+    """
+    Stolen liberally from django-eav, but simplified to be product-specific
+
+    To set attributes on a product, use the `attr` attribute:
+
+        product.attr.weight = 125
+    """
+
+    def __setstate__(self, state):
+        self.__dict__ = state
+        self.initialised = False
+
+    def __init__(self, product):
+        self.product = product
+        self.initialised = False
+
+    def __getattr__(self, name):
+        if not name.startswith('_') and not self.initialised:
+            self._load_values()
+            return getattr(self, name)
+        raise AttributeError(
+            _("%(obj)s has no attribute named '%(attr)s'") % {
+                'obj': self.product.get_product_class(), 'attr': name})
+
+    def validate_attributes(self):
+        for attribute in self.get_all_attributes():
+            value = getattr(self, attribute.code, None)
+            if value is None:
+                if attribute.required:
+                    raise ValidationError(
+                        _("%(attr)s attribute cannot be blank") %
+                        {'attr': attribute.code})
+            else:
+                try:
+                    attribute.validate_value(value)
+                except ValidationError as e:
+                    raise ValidationError(
+                        _("%(attr)s attribute %(err)s") %
+                        {'attr': attribute.code, 'err': e})
+
+    def get_values(self):
+        return self.product.attribute_values.all()
+
+    def get_value_by_attribute(self, attribute):
+        return self.get_values().get(attribute=attribute)
+
+    def get_all_attributes(self):
+        return self.product.get_product_class().attributes.all()
+
+    def get_attribute_by_code(self, code):
+        return self.get_all_attributes().get(code=code)
+
+    def __iter__(self):
+        return iter(self.get_values())
+
+    def refresh_from_db(self):
+        self._load_values()
+
+    def save(self):
+        if not hasattr(self, '_initial_state'):
+            self._initial_state = {}
+
+        dirty_attributes = [
+            attr for attr in self.get_all_attributes()
+            if getattr(self, attr.code) != self._initial_state.get(attr.code)
+        ]
+        if not dirty_attributes:
+            return
+
+        # We don't filter on the attributes here since we assume all objects
+        # are still available in the orm cache.
+        value_objects = {v.attribute_id: v for v in self.get_values()}
+        for attribute in dirty_attributes:
+            new_value = getattr(self, attribute.code)
+            value_obj = value_objects.get(attribute.pk)
+
+            # Manually set the reverse relation instead of letting
+            # Django fetch it again.
+            if value_obj:
+                value_obj.attribute = attribute
+            attribute.save_value(self.product, new_value, value_obj)
+
+    def _load_values(self):
+        values = {v.attribute_id: v for v in self.get_values()}
+        attrs = self.product.get_product_class().attributes.all()
+
+        self._initial_state = {}
+        for attr in attrs:
+            value = values.get(attr.pk)
+            value = value.value if value else None
+            setattr(self, attr.code, value)
+            self._initial_state[attr.code] = value
+
+        self.initialised = True

--- a/tests/integration/catalogue/models_tests.py
+++ b/tests/integration/catalogue/models_tests.py
@@ -1,0 +1,52 @@
+from django.test import TestCase
+
+from oscar.apps.catalogue import models
+
+
+class ProductAttributesTest(TestCase):
+    def setUp(self):
+        self.product_class = models.ProductClass.objects.create(name='Test')
+        models.ProductAttribute.objects.create(
+            product_class=self.product_class, name='text', code='text',
+            type=models.ProductAttribute.TEXT)
+        models.ProductAttribute.objects.create(
+            product_class=self.product_class, name='integer', code='integer',
+            type=models.ProductAttribute.INTEGER)
+
+
+    def test_non_set_attrs_are_none(self):
+        product = models.Product(product_class=self.product_class)
+        assert product.attr.text is None
+        assert product.attr.integer is None
+
+    def test_save_attributes(self):
+        product = models.Product(product_class=self.product_class)
+        product.attr.text = 'foobar'
+        product.attr.integer = 1
+
+        with self.assertNumQueries(5):
+            product.save()
+
+    def test_load_attributes(self):
+        product = models.Product.objects.create(
+            product_class=self.product_class)
+        with self.assertNumQueries(2):
+            product.attr._load_values()
+
+    def test_orm_cache(self):
+        product = models.Product.objects.create(
+            product_class=self.product_class)
+
+        product = (
+            models.Product.objects
+            .prefetch_related(
+                'product_class__attributes',
+                'attribute_values')
+            .first())
+
+        with self.assertNumQueries(0):
+            product.attr._load_values()
+
+        product.attr.text = 'foobar'
+        with self.assertNumQueries(1):
+            product.attr.save()

--- a/tests/integration/catalogue/models_tests.py
+++ b/tests/integration/catalogue/models_tests.py
@@ -24,7 +24,7 @@ class ProductAttributesTest(TestCase):
         product.attr.text = 'foobar'
         product.attr.integer = 1
 
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(4):
             product.save()
 
     def test_load_attributes(self):


### PR DESCRIPTION
Refactor the attribute container to reduce the number of queries
done in the save() call.
