### PR TITLE
Fix validate_payment_event for payment events with no lines specified

### DIFF
--- a/src/oscar/apps/order/processing.py
+++ b/src/oscar/apps/order/processing.py
@@ -90,16 +90,17 @@ class EventHandler(object):
         if errors:
             raise exceptions.InvalidShippingEvent(", ".join(errors))
 
-    def validate_payment_event(self, order, event_type, amount, lines,
-                               line_quantities, **kwargs):
-        errors = []
-        for line, qty in zip(lines, line_quantities):
-            if not line.is_payment_event_permitted(event_type, qty):
-                msg = _("The selected quantity for line #%(line_id)s is too"
-                        " large") % {'line_id': line.id}
-                errors.append(msg)
-        if errors:
-            raise exceptions.InvalidPaymentEvent(", ".join(errors))
+    def validate_payment_event(self, order, event_type, amount, lines=None,
+                               line_quantities=None, **kwargs):
+        if lines and line_quantities:
+            errors = []
+            for line, qty in zip(lines, line_quantities):
+                if not line.is_payment_event_permitted(event_type, qty):
+                    msg = _("The selected quantity for line #%(line_id)s is too"
+                            " large") % {'line_id': line.id}
+                    errors.append(msg)
+            if errors:
+                raise exceptions.InvalidPaymentEvent(", ".join(errors))
 
     # Query methods
     # -------------

--- a/tests/unit/order/processing_tests.py
+++ b/tests/unit/order/processing_tests.py
@@ -2,6 +2,7 @@ from decimal import Decimal as D
 
 from django.test import TestCase
 import mock
+import six
 
 from oscar.apps.order import processing
 from oscar.apps.order import exceptions
@@ -40,7 +41,7 @@ class TestValidatePaymentEvent(TestCase):
 
         error = "The selected quantity for line #6 is too large"
 
-        with self.assertRaisesRegexp(exceptions.InvalidPaymentEvent, error):
+        with six.assertRaisesRegex(self, exceptions.InvalidPaymentEvent, error):
             self.event_handler.validate_payment_event(order, 'payment',
                                                       D('10.00'), lines,
                                                       line_quantities)

--- a/tests/unit/order/processing_tests.py
+++ b/tests/unit/order/processing_tests.py
@@ -1,0 +1,55 @@
+from decimal import Decimal as D
+
+from django.test import TestCase
+import mock
+
+from oscar.apps.order import processing
+from oscar.apps.order import exceptions
+from oscar.apps.order.models import Line
+from oscar.test.factories import create_order
+
+
+class TestValidatePaymentEvent(TestCase):
+
+    def setUp(self):
+        self.event_handler = processing.EventHandler()
+
+    def test_valid_lines(self):
+        order = mock.Mock()
+        lines = [mock.Mock() for r in range(3)]
+        line_quantities = [line.quantity for line in lines]
+        self.event_handler.validate_payment_event(order, 'pre-auth',
+                                                  D('10.00'), lines,
+                                                  line_quantities)
+        # Has each line has been checked
+        for line in lines:
+            line.is_payment_event_permitted.assert_called_with('pre-auth',
+                                                               line.quantity)
+
+    def test_invalid_lines(self):
+        order = mock.Mock()
+        invalid_line = mock.Mock()
+        invalid_line.is_payment_event_permitted.return_value = False
+        invalid_line.id = 6
+        lines = [
+            mock.Mock(),
+            invalid_line,
+            mock.Mock(),
+        ]
+        line_quantities = [line.quantity for line in lines]
+
+        error = "The selected quantity for line #6 is too large"
+
+        with self.assertRaisesRegexp(exceptions.InvalidPaymentEvent, error):
+            self.event_handler.validate_payment_event(order, 'payment',
+                                                      D('10.00'), lines,
+                                                      line_quantities)
+
+    def test_no_lines(self):
+        order = mock.Mock()
+        lines = None
+        line_quantities = None
+        out = self.event_handler.validate_payment_event(order, 'payment',
+                                                  D('10.00'), lines,
+                                                  line_quantities)
+        self.assertIsNone(out)


### PR DESCRIPTION
Currently  `order.processing.EventHandler.handle_payment_event` defaults `lines` and `line_quantities` to `None`, however, calling it with these defaults will result in an exception being raised in `validate_payment_event` because it expects iterables.

This commit also adds tests to cover `validate_payment_event`.