### PR TITLE
Clarify location of Haystack Connections

### DIFF
--- a/docs/source/internals/getting_started.rst
+++ b/docs/source/internals/getting_started.rst
@@ -192,8 +192,8 @@ you will also need to include Django's i18n URLs:
         url(r'', include(application.urls)),
     ]
 
-Search backend
-==============
+Django Settings: Search backend
+===============================
 If you're happy with basic search for now, you can just use Haystack's simple
 backend:
 


### PR DESCRIPTION
The current version didn't specify where the Haystack Connections went; first time through, I assumed we were still in URLs.
