### PR TITLE
Add --initial-only option in oscar_populate_countries.

### DIFF
--- a/src/oscar/management/commands/oscar_populate_countries.py
+++ b/src/oscar/management/commands/oscar_populate_countries.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from optparse import make_option
+import sys
 
 from django.core.management.base import BaseCommand, CommandError
 from oscar.core.loading import get_model
@@ -19,6 +20,12 @@ class Command(BaseCommand):
             dest='is_shipping',
             default=True,
             help="Don't mark countries for shipping"),
+        make_option(
+            '--initial-only',
+            action='store_true',
+            dest='is_initial_only',
+            default=False,
+            help="Exit quietly without doing anything if countries were already populated."),
     )
 
     def handle(self, *args, **options):
@@ -30,9 +37,14 @@ class Command(BaseCommand):
                 "'pip install pycountry'")
 
         if Country.objects.exists():
-            raise CommandError(
-                "You already have countries in your database. This command "
-                "currently does not support updating existing countries.")
+            if options.get('is_initial_only', False):
+                # exit quietly, as the initial load already seems to have happened.
+                self.stdout.write("Countries already populated; nothing to be done.")
+                sys.exit(0)
+            else:
+                raise CommandError(
+                    "You already have countries in your database. This command "
+                    "currently does not support updating existing countries.")
 
         countries = [
             Country(


### PR DESCRIPTION
This change adds support for a new command-line option to `oscar_populate_countries` which will suppress an error message / nonzero exit state when the countries have already been populated.   This is useful for idempotent automation tasks which use the same code for first-time installation and successive updates.  Without using the option, the behavior of the command is unchanged.