### PR TITLE
Fix email template extending the wrong base template

### DIFF
--- a/src/oscar/templates/oscar/customer/emails/commtype_password_changed_body.txt
+++ b/src/oscar/templates/oscar/customer/emails/commtype_password_changed_body.txt
@@ -1,4 +1,4 @@
-{% extends "customer/emails/base.html" %}
+{% extends "customer/emails/base.txt" %}
 {% load i18n %}
 
 {% block body %}{% autoescape off %}{% blocktrans with name=site.name %}


### PR DESCRIPTION
The plain text template was extending the HTML base instead of the text one.