### PR TITLE
Unavailable product bug fixes

### DIFF
--- a/src/oscar/apps/basket/abstract_models.py
+++ b/src/oscar/apps/basket/abstract_models.py
@@ -352,6 +352,12 @@ class AbstractBasket(models.Model):
             except ObjectDoesNotExist:
                 # Handle situation where the product may have been deleted
                 pass
+            except TypeError:
+                # Handle Unavailable products with no known price
+                info = self.strategy.fetch_for_product(line.product)
+                if info.availability.is_available_to_buy:
+                    raise
+                pass
         return total
 
     # ==========

--- a/src/oscar/apps/basket/abstract_models.py
+++ b/src/oscar/apps/basket/abstract_models.py
@@ -11,6 +11,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from oscar.apps.basket.managers import OpenBasketManager, SavedBasketManager
 from oscar.apps.offer import results
+from oscar.apps.partner import availability
 from oscar.core.compat import AUTH_USER_MODEL
 from oscar.core.utils import get_default_currency
 from oscar.templatetags.currency_filters import currency
@@ -811,7 +812,7 @@ class AbstractLine(models.Model):
 
         This could be things like the price has changed
         """
-        if not self.stockrecord:
+        if isinstance(self.purchase_info.availability, availability.Unavailable):
             msg = u"'%(product)s' is no longer available"
             return _(msg) % {'product': self.product.get_title()}
 

--- a/tests/integration/basket/model_tests.py
+++ b/tests/integration/basket/model_tests.py
@@ -114,6 +114,7 @@ class TestANonEmptyBasket(TestCase):
 
         try:
             self.basket.strategy = UnavailableProductStrategy()
+            self.assertEqual(self.basket.all_lines()[1].get_warning(), u"'D\xf9\uff4d\u03fb\u03d2 title' is no longer available")
             self.assertEqual(self.basket.total_excl_tax, 100)
         finally:
             self.basket.strategy = strategy.Default()

--- a/tests/integration/basket/model_tests.py
+++ b/tests/integration/basket/model_tests.py
@@ -3,7 +3,7 @@ from decimal import Decimal as D
 from django.test import TestCase
 
 from oscar.apps.basket.models import Basket
-from oscar.apps.partner import strategy
+from oscar.apps.partner import strategy, availability, prices
 from oscar.test import factories
 from oscar.apps.catalogue.models import Option
 
@@ -84,6 +84,39 @@ class TestANonEmptyBasket(TestCase):
             product, record))
         self.assertEqual(1, self.basket.line_quantity(
             product, record, options))
+
+    def test_total_sums_product_totals(self):
+        product = factories.create_product()
+        factories.create_stockrecord(
+            product, price_excl_tax=D('5.00'))
+        self.basket.add(product, 1)
+        self.assertEqual(self.basket.total_excl_tax, 105)
+
+    def test_total_excludes_unavailable_products_with_unknown_price(self):
+        new_product = factories.create_product()
+        factories.create_stockrecord(
+            new_product, price_excl_tax=D('5.00'))
+        self.basket.add(new_product, 1)
+
+        class UnavailableProductStrategy(strategy.Default):
+            """ A test strategy that makes a specific product unavailable """
+
+            def availability_policy(self, product, stockrecord):
+                if product == new_product:
+                    return availability.Unavailable()
+                return super(UnavailableProductStrategy, self).availability_policy(product, stockrecord)
+
+            def pricing_policy(self, product, stockrecord):
+                if product == new_product:
+                    return prices.Unavailable()
+                return super(UnavailableProductStrategy, self).pricing_policy(product, stockrecord)
+
+
+        try:
+            self.basket.strategy = UnavailableProductStrategy()
+            self.assertEqual(self.basket.total_excl_tax, 100)
+        finally:
+            self.basket.strategy = strategy.Default()
 
 
 class TestMergingTwoBaskets(TestCase):


### PR DESCRIPTION
This fixes a couple of bugs relating to an edge case in unavailable products. If a product uses prices.Unavailable as its price strategy (i.e., the pricing information is not known), open baskets will fail to calculate their price and result in an internal server error.

In addition, custom availability strategies may cause a product to be unavailable even though it has a stock record. This patch removes the duplication of the `StockRequired`'s check for availability from line items when generating warning messages.