### PR TITLE
Replace assert statements with appropriate assert* method.

### DIFF
--- a/tests/functional/dashboard/catalogue_tests.py
+++ b/tests/functional/dashboard/catalogue_tests.py
@@ -77,7 +77,7 @@ class TestAStaffUser(WebTestCase):
         )
         form = page.forms[0]
         form['productcategory_set-0-category'] = category.id
-        assert form['title'].value != new_title
+        self.assertNotEqual(form['title'].value, new_title)
         form['title'] = new_title
         form.submit()
 
@@ -151,8 +151,8 @@ class TestAStaffUser(WebTestCase):
         page = self.get(reverse('dashboard:catalogue-product-list'))
         products_on_page = [row.record for row
                             in page.context['products'].page.object_list]
-        assert product1 in products_on_page
-        assert product2 in products_on_page
+        self.assertIn(product1, products_on_page)
+        self.assertIn(product2, products_on_page)
 
     def test_can_create_a_child_product(self):
         parent_product = create_product(structure='parent')
@@ -191,8 +191,8 @@ class TestANonStaffUser(TestAStaffUser):
         page = self.get(reverse('dashboard:catalogue-product-list'))
         products_on_page = [row.record for row
                             in page.context['products'].page.object_list]
-        assert product1 in products_on_page
-        assert product2 not in products_on_page
+        self.assertIn(product1, products_on_page)
+        self.assertNotIn(product2, products_on_page)
 
     def test_cant_create_a_child_product(self):
         parent_product = create_product(structure='parent')

--- a/tests/functional/dashboard/order_tests.py
+++ b/tests/functional/dashboard/order_tests.py
@@ -212,7 +212,7 @@ class TestOrderListSearch(WebTestCase):
                 el.text.strip() for el in
                 response.html.select('.search-filter-list .label')
             ]
-            assert applied_filters == expected_filters
+            self.assertEqual(applied_filters, expected_filters)
 
 
 class TestOrderDetailPage(WebTestCase):

--- a/tests/integration/basket/view_tests.py
+++ b/tests/integration/basket/view_tests.py
@@ -13,12 +13,15 @@ class TestVoucherAddView(TestCase):
         view = views.VoucherAddView.as_view()
         response = view(request)
 
-        assert response.status_code == 302
+        self.assertEqual(response.status_code, 302)
+
+    def _get_voucher_message(self, request):
+        return '\n'.join(unicode(m.message) for m in get_messages(request))
 
     def test_post_valid(self):
         basket = BasketFactory()
         voucher = VoucherFactory()
-        assert voucher.is_active()
+        self.assertTrue(voucher.is_active())
 
         data = {
             'code': voucher.code
@@ -27,11 +30,10 @@ class TestVoucherAddView(TestCase):
 
         view = views.VoucherAddView.as_view()
         response = view(request)
-        assert response.status_code == 302
+        self.assertEqual(response.status_code, 302)
 
         voucher = voucher.__class__.objects.get(pk=voucher.pk)
-        assert voucher.num_basket_additions == 1, (
-            [unicode(m.message) for m in get_messages(request)])
+        self.assertEqual(voucher.num_basket_additions, 1, msg=self._get_voucher_message(request))
 
 
 class TestVoucherRemoveView(TestCase):
@@ -48,7 +50,7 @@ class TestVoucherRemoveView(TestCase):
 
         view = views.VoucherRemoveView.as_view()
         response = view(request, pk=voucher.pk)
-        assert response.status_code == 302
+        self.assertEqual(response.status_code, 302)
 
         voucher = voucher.__class__.objects.get(pk=voucher.pk)
-        assert voucher.num_basket_additions == -1
+        self.assertEqual(voucher.num_basket_additions, -1)

--- a/tests/integration/basket/view_tests.py
+++ b/tests/integration/basket/view_tests.py
@@ -1,5 +1,6 @@
 from django.contrib.messages import get_messages
 from django.test import RequestFactory, TestCase
+from django.utils import six
 
 from oscar.apps.basket import views
 from oscar.test.factories import BasketFactory, VoucherFactory
@@ -16,7 +17,7 @@ class TestVoucherAddView(TestCase):
         self.assertEqual(response.status_code, 302)
 
     def _get_voucher_message(self, request):
-        return '\n'.join(unicode(m.message) for m in get_messages(request))
+        return '\n'.join(six.text_type(m.message) for m in get_messages(request))
 
     def test_post_valid(self):
         basket = BasketFactory()

--- a/tests/integration/catalogue/category_tests.py
+++ b/tests/integration/catalogue/category_tests.py
@@ -207,7 +207,7 @@ class TestCategoryTemplateTags(TestCase):
         names_set = set(names)
         # We return a set to ease testing, but need to be sure we're not
         # losing any duplicates through that conversion.
-        assert len(names_set) == len(names)
+        self.assertEqual(len(names_set), len(names))
         return names_set
 
     def test_all_categories(self):

--- a/tests/integration/dashboard/nav_tests.py
+++ b/tests/integration/dashboard/nav_tests.py
@@ -20,11 +20,11 @@ class TestCategory(TestCase):
 
     def test_staff_user_has_menu(self):
         menu = get_nodes(self.staff_user)
-        assert menu
+        self.assertTrue(menu)
 
     def test_non_staff_user_has_empty_menu(self):
         menu = get_nodes(self.non_staff_user)
-        assert menu == []
+        self.assertEqual(menu, [])
 
 
 

--- a/tests/integration/partner/test_dashboard_views.py
+++ b/tests/integration/partner/test_dashboard_views.py
@@ -21,5 +21,5 @@ class TestPartnerUserUnlinkView(TestCase):
         view = views.PartnerUserUnlinkView()
         view.unlink_user(user, partner)
 
-        assert partner.users.count() == 0
-        assert Permission.objects.filter(pk=permission.pk).exists()
+        self.assertEqual(partner.users.count(), 0)
+        self.assertTrue(Permission.objects.filter(pk=permission.pk).exists())

--- a/tests/unit/basket/model_tests.py
+++ b/tests/unit/basket/model_tests.py
@@ -42,7 +42,7 @@ class TestBasketLine(TestCase):
         basket.add_product(product)
 
         line = basket.lines.first()
-        assert line.description == "A product"
+        self.assertEqual(line.description, "A product")
 
     def test_description_with_attributes(self):
         basket = BasketFactory()
@@ -52,4 +52,4 @@ class TestBasketLine(TestCase):
         line = basket.lines.first()
         BasketLineAttributeFactory(
             line=line, value=u'\u2603', option__name='with')
-        assert line.description == u"A product (with = '\u2603')"
+        self.assertEqual(line.description, u"A product (with = '\u2603')")

--- a/tests/unit/catalogue/test_product_search_handler_setting.py
+++ b/tests/unit/catalogue/test_product_search_handler_setting.py
@@ -20,4 +20,4 @@ class TestProductSearchHandlerSetting(TestCase):
         with override_settings(OSCAR_PRODUCT_SEARCH_HANDLER=handler_override):
             handler_class = get_product_search_handler_class()
 
-        assert handler_class == TestSearchHandler
+        self.assertEqual(handler_class, TestSearchHandler)

--- a/tests/unit/core/customisation_tests.py
+++ b/tests/unit/core/customisation_tests.py
@@ -29,7 +29,7 @@ class TestForkAppFunction(TestCase):
         # We piggyback on another test which means a custom app is already in
         # the settings we use for the test suite. We just check that's still
         # the case here.
-        assert 'tests._site.apps.partner' in settings.INSTALLED_APPS
+        self.assertIn('tests._site.apps.partner', settings.INSTALLED_APPS)
         with self.assertRaises(ValueError):
             customisation.fork_app('partner', VALID_FOLDER_PATH)
 

--- a/tests/unit/forms/widget_tests.py
+++ b/tests/unit/forms/widget_tests.py
@@ -1,27 +1,22 @@
+from django.test import TestCase
+
 from oscar.forms import widgets
 
 
-def compare_date_format(format, expected):
-    assert widgets.datetime_format_to_js_date_format(format) == expected
+class TestWidgetsDatetimeFormat(TestCase):
 
+    def test_datetime_to_date_format_conversion(self):
+        format_testcases = (
+            ('%Y-%m-%d', 'yyyy-mm-dd'),
+            ('%Y-%m-%d %H:%M', 'yyyy-mm-dd'),
+        )
+        for format_, expected in format_testcases:
+            self.assertEqual(widgets.datetime_format_to_js_date_format(format_), expected)
 
-def test_datetime_to_date_format_conversion():
-    format_testcases = (
-        ('%Y-%m-%d', 'yyyy-mm-dd'),
-        ('%Y-%m-%d %H:%M', 'yyyy-mm-dd'),
-    )
-    for format, expected in format_testcases:
-        yield compare_date_format, format, expected
-
-
-def compare_time_format(format, expected):
-    assert widgets.datetime_format_to_js_time_format(format) == expected
-
-
-def test_datetime_to_time_format_conversion():
-    format_testcases = (
-        ('%Y-%m-%d %H:%M', 'hh:ii'),
-        ('%H:%M', 'hh:ii'),
-    )
-    for format, expected in format_testcases:
-        yield compare_time_format, format, expected
+    def test_datetime_to_time_format_conversion(self):
+        format_testcases = (
+            ('%Y-%m-%d %H:%M', 'hh:ii'),
+            ('%H:%M', 'hh:ii'),
+        )
+        for format_, expected in format_testcases:
+            self.assertEqual(widgets.datetime_format_to_js_time_format(format_), expected)

--- a/tests/unit/logging_tests.py
+++ b/tests/unit/logging_tests.py
@@ -1,26 +1,25 @@
 from logging import LogRecord
 
+from django.test import TestCase
+
 from oscar.core.logging.formatters import PciFormatter
 
 
-data = [
-    ('some string', 'some string'),
-    ('here is my bankcard 1000010000000007', 'here is my bankcard XXXX-XXXX-XXXX-XXXX'),
-    ('here is my bankcard 1000-0100-0000-0007', 'here is my bankcard XXXX-XXXX-XXXX-XXXX'),
-    ('here is my bankcard 1000 0100 0000 0007', 'here is my bankcard XXXX-XXXX-XXXX-XXXX'),
-    ('here is my bankcard 10 00 01-00 0-000-0007', 'here is my bankcard XXXX-XXXX-XXXX-XXXX'),
-]
+class TestLogging(TestCase):
 
+    data = [
+        ('some string', 'some string'),
+        ('here is my bankcard 1000010000000007', 'here is my bankcard XXXX-XXXX-XXXX-XXXX'),
+        ('here is my bankcard 1000-0100-0000-0007', 'here is my bankcard XXXX-XXXX-XXXX-XXXX'),
+        ('here is my bankcard 1000 0100 0000 0007', 'here is my bankcard XXXX-XXXX-XXXX-XXXX'),
+        ('here is my bankcard 10 00 01-00 0-000-0007', 'here is my bankcard XXXX-XXXX-XXXX-XXXX'),
+    ]
 
-def assert_message_filtered_correctly(string, expected):
-    formatter = PciFormatter()
-    record = LogRecord(
-        name=None, level=None, pathname='', lineno=0,
-        msg=string, args=None, exc_info=None)
-    assert formatter.format(record) == expected
-
-
-def test_pci_formatter():
-    """PCI logging formatter """
-    for string, expected in data:
-        yield assert_message_filtered_correctly, string, expected
+    def test_pci_formatter(self):
+        """PCI logging formatter """
+        for string, expected in self.data:
+            formatter = PciFormatter()
+            record = LogRecord(
+                name=None, level=None, pathname='', lineno=0,
+                msg=string, args=None, exc_info=None)
+            self.assertEqual(formatter.format(record), expected)

--- a/tests/unit/payment/bankcard_tests.py
+++ b/tests/unit/payment/bankcard_tests.py
@@ -1,50 +1,40 @@
+from django.test import TestCase
+
 from oscar.apps.payment import bankcards
 
 
-fixture_data = {
-    bankcards.VISA: ('4111111111111111',),
-    bankcards.MASTERCARD: ('5500000000000004',),
-    bankcards.DISCOVER: ('6011000000000004',),
-    bankcards.AMEX: ('340000000000009',),
-    None: ('1000010000000007',)  # Magic number
-}
+class TestBankCardValidation(TestCase):
 
+    fixture_data = {
+        bankcards.VISA: ('4111111111111111',),
+        bankcards.MASTERCARD: ('5500000000000004',),
+        bankcards.DISCOVER: ('6011000000000004',),
+        bankcards.AMEX: ('340000000000009',),
+        None: ('1000010000000007',)  # Magic number
+    }
 
-def compare(number, type):
-    assert bankcards.bankcard_type(number) == type
+    valid_numbers = [
+        '4111111111111111',
+        '5500000000000004',
+        '6011000000000004',
+        '340000000000009']
 
+    invalid_numbers = [
+        '4111111111111110',
+        '5500000000000009',
+        '6011000000000000',
+        '340000000000005']
 
-def test_bankcard_type_sniffing():
-
-    for bankcard_type, numbers in fixture_data.items():
-        for number in numbers:
-            yield compare, number, bankcard_type
-
-
-valid_numbers = [
-    '4111111111111111',
-    '5500000000000004',
-    '6011000000000004',
-    '340000000000009']
-
-invalid_numbers = [
-    '4111111111111110',
-    '5500000000000009',
-    '6011000000000000',
-    '340000000000005']
-
-
-def is_valid(n):
-    assert bankcards.luhn(n) is True
-
-
-def is_not_valid(n):
-    assert bankcards.luhn(n) is False
-
-
-def test_luhn_check():
-    for number in valid_numbers:
-        yield is_valid, number
-
-    for number in invalid_numbers:
-        yield is_not_valid, number
+    def test_bankcard_type_sniffing(self):
+        for expected_bankcard_type, numbers in self.fixture_data.items():
+            for number in numbers:
+                sniffed_bankcard_type = bankcards.bankcard_type(number)
+                self.assertEqual(expected_bankcard_type, sniffed_bankcard_type)
+    
+    def test_valid_numbers(self):
+        for number in self.valid_numbers:
+            self.assertTrue(bankcards.luhn(number))
+    
+    def test_invalid_numbers(self):
+        for number in self.invalid_numbers:
+            self.assertFalse(bankcards.luhn(number))


### PR DESCRIPTION
Should close https://github.com/django-oscar/django-oscar/issues/1850

Replace 'assert' statement with 'assert*' methods.

Convert tests.unit.forms.widget_tests to use TestCase class.

Convert bankcard tests to use TestCase.

Convert tests.unit.logging_tests to use TestCase.