### PR TITLE
Use jQuery().prop instead of jQuery().attr for toggling checked for d…

### DIFF
--- a/src/oscar/static/oscar/js/oscar/dashboard.js
+++ b/src/oscar/static/oscar/js/oscar/dashboard.js
@@ -245,8 +245,8 @@ var oscar = (function(o, $) {
             init: function() {
                 $('[data-behaviours~="remove"]').click(function() {
                     $this = $(this);
-                    $this.parents('table').find('input').attr('checked', false);
-                    $this.parents('tr').find('input').attr('checked', 'checked');
+                    $this.parents('table').find('input').prop('checked', false);
+                    $this.parents('tr').find('input').prop('checked', true);
                     $this.parents('form').submit();
                 });
             }


### PR DESCRIPTION
This fixes https://github.com/django-oscar/django-oscar/issues/1848

Basically, the dashboard client js was using the old school `jQuery().attr` method when it should be using `jQuery().prop`