### PR TITLE
In Range.contains_product, use get_product_class().id instead of product_class_id

### DIFF
--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -858,7 +858,7 @@ class AbstractRange(models.Model):
             return False
         if self.includes_all_products:
             return True
-        if product.product_class_id in self._class_ids():
+        if product.get_product_class().id in self._class_ids():
             return True
         included_product_ids = self._included_product_ids()
         # If the product's parent is in the range, the child is automatically included as well


### PR DESCRIPTION
Fixes https://github.com/django-oscar/django-oscar/issues/1860