### PR TITLE
Fix indirect update of session data, fixes #1865

### DIFF
--- a/src/oscar/apps/checkout/views.py
+++ b/src/oscar/apps/checkout/views.py
@@ -140,6 +140,7 @@ class ShippingAddressView(CheckoutSessionMixin, generic.FormView):
     def get_initial(self):
         initial = self.checkout_session.new_shipping_address_fields()
         if initial:
+            initial = initial.copy()
             # Convert the primary key stored in the session into a Country
             # instance
             try:


### PR DESCRIPTION
This changes the issue only for ShippingAddressView.get_initial case.

If this fix isn't sufficient I could make another update and make the change in the following method
`https://github.com/django-oscar/django-oscar/blob/master/src/oscar/apps/checkout/utils.py#L24`
thus fixing the issue for all situations.

I could also write a test for this.