### PR TITLE
Fix create_line_reference for options already enconded to utf-8

### DIFF
--- a/src/oscar/apps/basket/abstract_models.py
+++ b/src/oscar/apps/basket/abstract_models.py
@@ -338,7 +338,9 @@ class AbstractBasket(models.Model):
         base = '%s_%s' % (product.id, stockrecord.id)
         if not options:
             return base
-        return "%s_%s" % (base, zlib.crc32(repr([{'option':repr(option['option']),'value': repr(option['value'])} for option in options]).encode('utf8')))
+        repr_options = [{'option': repr(option['option']),
+                         'value': repr(option['value'])} for option in options]
+        return "%s_%s" % (base, zlib.crc32(repr(repr_options).encode('utf8')))
 
     def _get_total(self, property):
         """

--- a/src/oscar/apps/basket/abstract_models.py
+++ b/src/oscar/apps/basket/abstract_models.py
@@ -338,7 +338,7 @@ class AbstractBasket(models.Model):
         base = '%s_%s' % (product.id, stockrecord.id)
         if not options:
             return base
-        return "%s_%s" % (base, zlib.crc32(repr(options)))
+        return "%s_%s" % (base, zlib.crc32(repr([{'option':repr(option['option']),'value': repr(option['value'])} for option in options]).encode('utf8')))
 
     def _get_total(self, property):
         """

--- a/src/oscar/apps/basket/abstract_models.py
+++ b/src/oscar/apps/basket/abstract_models.py
@@ -338,7 +338,7 @@ class AbstractBasket(models.Model):
         base = '%s_%s' % (product.id, stockrecord.id)
         if not options:
             return base
-        return "%s_%s" % (base, zlib.crc32(repr(options).encode('utf8')))
+        return "%s_%s" % (base, zlib.crc32(repr(options)))
 
     def _get_total(self, property):
         """

--- a/tests/unit/basket/model_tests.py
+++ b/tests/unit/basket/model_tests.py
@@ -1,9 +1,10 @@
+# -*- coding: utf-8 -*-
 from django.test import TestCase
 
 from oscar.apps.basket.models import Basket
 from oscar.apps.partner import strategy
 from oscar.test.factories import (
-    BasketFactory, BasketLineAttributeFactory, ProductFactory)
+    BasketFactory, BasketLineAttributeFactory, ProductFactory, OptionFactory)
 
 
 class TestANewBasket(TestCase):
@@ -53,3 +54,13 @@ class TestBasketLine(TestCase):
         BasketLineAttributeFactory(
             line=line, value=u'\u2603', option__name='with')
         self.assertEqual(line.description, u"A product (with = '\u2603')")
+        
+    def test_create_line_reference(self):
+        basket = BasketFactory()
+        product = ProductFactory(title="A product")
+        option = OptionFactory(name="product_option", code="product_option")
+        option_product = ProductFactory(title=u'Asunción')
+        options = [{'option' : option, 'value': option_product}]
+        basket.add_product(product, options = options)
+        
+        


### PR DESCRIPTION
Issue #1868 

Just remove the utf-8 encoding done in create_line_reference when adding a Product to Basket with Options already encoded to utf-8.

Unit test provided.


