### PR TITLE
Add a message if baskets are merged

### DIFF
--- a/src/oscar/apps/basket/middleware.py
+++ b/src/oscar/apps/basket/middleware.py
@@ -1,6 +1,8 @@
 from django.conf import settings
+from django.contrib import messages
 from django.core.signing import Signer, BadSignature
 from django.utils.functional import SimpleLazyObject, empty
+from django.utils.translation import ugettext_lazy as _
 
 from oscar.core.loading import get_model
 from oscar.core.loading import get_class
@@ -139,6 +141,9 @@ class BasketMiddleware(object):
                 # We merge them and create a fresh one
                 old_baskets = list(manager.filter(owner=request.user))
                 basket = old_baskets[0]
+                messages.add_message(request, messages.WARNING, _("An attempt has been made to "
+                    "merge a basket from a previous session. The contents of your basket may "
+                    "have changed."))
                 for other_basket in old_baskets[1:]:
                     self.merge_baskets(basket, other_basket)
 
@@ -148,6 +153,9 @@ class BasketMiddleware(object):
 
             if cookie_basket:
                 self.merge_baskets(basket, cookie_basket)
+                messages.add_message(request, messages.WARNING, _("An attempt has been made to "
+                    "merge a basket from a previous session. The contents of your basket may "
+                    "have changed."))
                 request.cookies_to_delete.append(cookie_key)
 
         elif cookie_basket:

--- a/src/oscar/apps/basket/middleware.py
+++ b/src/oscar/apps/basket/middleware.py
@@ -167,9 +167,8 @@ class BasketMiddleware(object):
 
         if num_baskets_merged > 0:
             messages.add_message(request, messages.WARNING,
-                                 _("An attempt has been made to merge a basket from a "
-                                   "previous session. The contents of your basket may "
-                                   "have changed."))
+                                 _("We have merged a basket from a previous session. Its contents "
+                                   "might have changed."))
 
         return basket
 

--- a/src/oscar/apps/basket/middleware.py
+++ b/src/oscar/apps/basket/middleware.py
@@ -140,9 +140,10 @@ class BasketMiddleware(object):
                 # We merge them and create a fresh one
                 old_baskets = list(manager.filter(owner=request.user))
                 basket = old_baskets[0]
-                messages.add_message(request, messages.WARNING, _("An attempt has been made to "
-                    "merge a basket from a previous session. The contents of your basket may "
-                    "have changed."))
+                messages.add_message(request, messages.WARNING,
+                                     _("An attempt has been made to merge a basket from a "
+                                       "previous session. The contents of your basket may "
+                                       "have changed."))
                 for other_basket in old_baskets[1:]:
                     self.merge_baskets(basket, other_basket)
 
@@ -152,9 +153,10 @@ class BasketMiddleware(object):
 
             if cookie_basket:
                 self.merge_baskets(basket, cookie_basket)
-                messages.add_message(request, messages.WARNING, _("An attempt has been made to "
-                    "merge a basket from a previous session. The contents of your basket may "
-                    "have changed."))
+                messages.add_message(request, messages.WARNING,
+                                     _("An attempt has been made to merge a basket from a "
+                                       "previous session. The contents of your basket may "
+                                       "have changed."))
                 request.cookies_to_delete.append(cookie_key)
 
         elif cookie_basket:


### PR DESCRIPTION
Fix for https://github.com/django-oscar/django-oscar/issues/1615

Adds a simple message if baskets have to be merged.

It might be better in the future to generate a more accurate/verbose message letting the user know exactly how the cart changed.
