### PR TITLE
Issue/1881/save anonymous email

### DIFF
--- a/src/oscar/apps/customer/abstract_models.py
+++ b/src/oscar/apps/customer/abstract_models.py
@@ -112,7 +112,8 @@ class AbstractEmail(models.Model):
     Normally, we only record order-related emails.
     """
     user = models.ForeignKey(AUTH_USER_MODEL, related_name='emails',
-                             verbose_name=_("User"))
+                             verbose_name=_("User"), null=True)
+    email = models.EmailField(_('email address'))
     subject = models.TextField(_('Subject'), max_length=255)
     body_text = models.TextField(_("Body Text"))
     body_html = models.TextField(_("Body HTML"), blank=True)

--- a/src/oscar/apps/customer/abstract_models.py
+++ b/src/oscar/apps/customer/abstract_models.py
@@ -126,8 +126,12 @@ class AbstractEmail(models.Model):
         verbose_name_plural = _('Emails')
 
     def __str__(self):
-        return _(u"Email to %(user)s with subject '%(subject)s'") % {
-            'user': self.user.get_username(), 'subject': self.subject}
+        if self.user:
+            return _(u"Email to %(user)s with subject '%(subject)s'") % {
+                'user': self.user.get_username(), 'subject': self.subject}
+        else:
+            return _(u"Anonymous email to %(email)s with subject '%(subject)s'") % {
+                'email': self.email, 'subject': self.subject}
 
 
 @python_2_unicode_compatible

--- a/src/oscar/apps/customer/migrations/0002_auto_20151020_1533.py
+++ b/src/oscar/apps/customer/migrations/0002_auto_20151020_1533.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('customer', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='email',
+            name='email',
+            field=models.EmailField(default='', max_length=254, verbose_name='email address'),
+            preserve_default=False,
+        ),
+        migrations.AlterField(
+            model_name='email',
+            name='user',
+            field=models.ForeignKey(related_name='emails', verbose_name='User', to=settings.AUTH_USER_MODEL, null=True),
+        ),
+    ]

--- a/src/oscar/apps/customer/migrations/0003_auto_20151020_1536.py
+++ b/src/oscar/apps/customer/migrations/0003_auto_20151020_1536.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def forwards_func(apps, schema_editor):
+    User = apps.get_model("auth", "User")
+
+    for user in User.objects.all():
+        user.emails.update(email=user.email)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('customer', '0002_auto_20151020_1533'),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards_func),
+    ]

--- a/src/oscar/apps/customer/utils.py
+++ b/src/oscar/apps/customer/utils.py
@@ -74,6 +74,7 @@ class Dispatcher(object):
         # Is user is signed in, record the event for audit
         if email and user.is_authenticated():
             Email._default_manager.create(user=user,
+                                          email=user.email,
                                           subject=email.subject,
                                           body_text=email.body,
                                           body_html=messages['html'])


### PR DESCRIPTION
Fix for https://github.com/django-oscar/django-oscar/issues/1881

The email field is set even if user is not null, so if the user changes their address, we still have a reasonable record of the email.

This does _not_ automatically save anonymous email. Anyone who wants to enable that feature likely has to override `apps.customer.utils.Dispatcher` or modify some view code. This is intentional, as I'm trying to keep this PR as small as possible.
