### PR TITLE
Update templates so that the product title isn't automatically escaped.

### DIFF
--- a/src/oscar/templates/oscar/customer/alerts/emails/alert_body.txt
+++ b/src/oscar/templates/oscar/customer/alerts/emails/alert_body.txt
@@ -1,6 +1,6 @@
 {% load i18n %}{% if alert.user and alert.user.get_short_name %}{% blocktrans with name=alert.user.get_short_name %}Dear {{ name }},{% endblocktrans %}{% else %}{% trans "Hello," %}{% endif %}
 {% blocktrans with product=alert.product path=alert.product.get_absolute_url %}
-We are happy to inform you that our product '{{ product }}' is back in stock:
+We are happy to inform you that our product '{{ product|safe }}' is back in stock:
 http://{{ site }}{{ path }}
 {% endblocktrans %}{% if hurry %}{% blocktrans with product_url=product_url %}
 Beware that the amount of items in stock is limited. Be quick or someone might get there first.

--- a/src/oscar/templates/oscar/customer/alerts/emails/alert_subject.txt
+++ b/src/oscar/templates/oscar/customer/alerts/emails/alert_subject.txt
@@ -1,1 +1,1 @@
-{% load i18n %}{% blocktrans with title=alert.product.get_title  %}{{ title }} is back in stock{% endblocktrans %}
+{% load i18n %}{% blocktrans with title=alert.product.get_title  %}{{ title|safe }} is back in stock{% endblocktrans %}

--- a/src/oscar/templates/oscar/customer/alerts/emails/confirmation_body.txt
+++ b/src/oscar/templates/oscar/customer/alerts/emails/confirmation_body.txt
@@ -1,7 +1,7 @@
 {% load i18n %}{% blocktrans with product=alert.product domain=site.domain confirm_path=alert.get_confirm_url cancel_path=alert.get_cancel_url %}Hello,
 
 Somebody (hopefully you) has requested an email alert when
-'{{ product }}' is back in stock.  Please click the following link
+'{{ product|safe }}' is back in stock.  Please click the following link
 to confirm:
 http://{{ domain }}{{ confirm_path }}
 


### PR DESCRIPTION
Here's an easy one.

Fixes https://github.com/django-oscar/django-oscar/issues/1885