### PR TITLE
Remove django-compressor

### DIFF
--- a/docs/source/howto/how_to_handle_statics.rst
+++ b/docs/source/howto/how_to_handle_statics.rst
@@ -39,31 +39,10 @@ LESS/CSS
 
 By default, CSS files compiled from their LESS sources are used rather than the
 LESS ones.  To use Less directly, set ``USE_LESS = True`` in your settings file.
-You will also need to ensure that the ``lessc`` executable is installed and is
-configured using a setting like::
-
-    COMPRESS_PRECOMPILERS = (
-        ('text/less', 'lessc {infile} {outfile}'),
-    )
-
+This will enable the on-the-fly pre-processor which lets you trial changes with
+a page reload. If you want to commit your changes, use the ``make css`` Makefile
+command, making sure you have the ``lessc`` binary available on your command line.
 A few other CSS files are used to provide styles for javascript libraries.
-
-Using offline compression
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Django compressor also provides a way of running offline compression which can
-be used during deployment to automatically generate CSS files from your LESS
-files. To make sure that compressor is obeying the ``USE_LESS`` setting and
-is not trying to compress CSS files that are not available, the setting has to
-be passed into the ``COMPRESS_OFFLINE_CONTEXT``. You should add something like
-this to your settings file::
-
-    COMPRESS_OFFLINE_CONTEXT = {
-        # this is the only default value from compressor itself
-        'STATIC_URL': STATIC_URL,
-        'use_less': USE_LESS,
-    }
-
 
 Javascript
 ----------
@@ -127,3 +106,4 @@ and replace the 'less' block::
     {% block less %}
         <link rel="stylesheet" type="text/less" href="{{ STATIC_URL }}myproject/less/styles.less" />
     {% endblock %}
+

--- a/docs/source/internals/contributing/development-environment.rst
+++ b/docs/source/internals/contributing/development-environment.rst
@@ -43,7 +43,7 @@ against::
 Writing LESS/CSS
 ----------------
 
-Oscar's CSS files are built using LESS_ V1.  However, the sandbox defaults to
+Oscar's CSS files are built using LESS_.  However, the sandbox defaults to
 serving CSS files directly, bypassing LESS compilation.
 
 .. _LESS: http://lesscss.org/
@@ -51,20 +51,19 @@ serving CSS files directly, bypassing LESS compilation.
 If you want to develop the LESS files, set::
 
     USE_LESS = True
-    COMPRESS_ENABLED = False
 
-in ``sites/sandbox/settings_local.py``.  This will cause Oscar to use
-`django-compressor`_ to compile the LESS files as they are requested.  For this to
-work, you will need to ensure that the LESS compiler ``lessc`` is installed.
-Using npm, install LESS using::
-
-    npm install less@'<2.0.0'
-
-.. _`django-compressor`: http://django_compressor.readthedocs.org/en/latest/
+in ``sites/sandbox/settings_local.py``.  This will include the on-the-fly
+``less`` pre-processor. That will allow you to see changes to the LESS
+files after a page reload.
 
 You can manually compile the CSS files by running::
 
     make css
+
+For this to work, you will need to ensure that the pre-processor binary
+``lessc`` is installed. Using npm, install LESS using::
+
+    npm install less
 
 .. warning::
 

--- a/docs/source/internals/getting_started.rst
+++ b/docs/source/internals/getting_started.rst
@@ -87,7 +87,7 @@ context processors.
 
 
 Next, modify ``INSTALLED_APPS`` to be a list, add ``django.contrib.sites``, 
-``django.contrib.flatpages``, ``compressor`` and ``widget_tweaks`` and append 
+``django.contrib.flatpages``, and ``widget_tweaks`` and append
 Oscar's core apps. Also set ``SITE_ID``:
 
 .. code-block:: django

--- a/docs/source/releases/v1.2.rst
+++ b/docs/source/releases/v1.2.rst
@@ -29,7 +29,18 @@ Oscar 1.2 is compatible with...
 
 What's new in Oscar 1.2?
 ------------------------
+ - ``django-compressor`` has been removed as a dependency, and as a way
+   of building ``less`` files for development. Removing or disabling it
+   was commonly required as it didn't work well with deploying on PaaS
+   providers, and many current projects understandably prefer to use
+   Javascript build chains (``gulp``, ``grunt``, etc.) for all their
+   statics.
+   But ``django-compressor`` was hard to remove  on a per-project basis,
+   so the decision was made to remove it altogether.
 
+   For development, ``USE_LESS`` now enables the browser-based on-the-fly
+   pre-processor. ``make css`` continues to run a locally installed
+   LESS binary.
 
 .. _minor_changes_in_1.2:
 
@@ -42,6 +53,12 @@ Minor changes
 
 Backwards incompatible changes in Oscar 1.2
 -------------------------------------------
+
+- The ``mainstyles`` template block was removed. It served as a wrapper
+  for the ``styles`` content black and was needed to be extensible while
+  still being able to compress CSS. As ``django-compressor`` has been
+  removed, it's not needed any more. Just use ``styles`` instead if you
+  happened to use it.
 
 
 Misc

--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,6 @@ setup(name='django-oscar',
           'sorl-thumbnail>=11.12.1b,<=12.2',
           # Babel is used for currency formatting
           'Babel>=1.0,<1.4',
-          # Oscar's default templates use compressor (but you can override
-          # this)
-          'django-compressor>=1.4',
           # For converting non-ASCII to ASCII when creating slugs
           'Unidecode>=0.04.12,<0.05',
           # For manipulating search URLs

--- a/sites/demo/settings.py
+++ b/sites/demo/settings.py
@@ -87,7 +87,6 @@ STATIC_ROOT = location('public/static')
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-    'compressor.finders.CompressorFinder',
 )
 
 # Make this unique, and don't share it with anybody.
@@ -230,7 +229,6 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django.contrib.gis',
     # Oscar dependencies
-    'compressor',
     'widget_tweaks',
     # Oscar extensions
     'stores',
@@ -280,11 +278,6 @@ OSCAR_ALLOW_ANON_CHECKOUT = True
 
 OSCAR_SHOP_NAME = 'Oscar'
 OSCAR_SHOP_TAGLINE = 'Demo'
-
-COMPRESS_ENABLED = False
-COMPRESS_PRECOMPILERS = (
-    ('text/less', 'lessc {infile} {outfile}'),
-)
 
 THUMBNAIL_KEY_PREFIX = 'oscar-demo'
 

--- a/sites/demo/settings_docker.py
+++ b/sites/demo/settings_docker.py
@@ -1,5 +1,4 @@
 USE_LESS = False
-COMPRESS_ENABLED = False
 
 HAYSTACK_CONNECTIONS = {
     'default': {

--- a/sites/demo/templates/base.html
+++ b/sites/demo/templates/base.html
@@ -1,27 +1,21 @@
 {% extends "oscar/base.html" %}
-{% load i18n compress %}
+{% load i18n %}
 {% load staticfiles %}
 
-{% block mainstyles %}
-    {% block styles %}
-        {% compress css %}
-            {% if use_less %}
-                <link rel="stylesheet" type="text/less" href="{% static "demo/less/styles.less" %}" />
-                <link rel="stylesheet" type="text/less" href="{% static "demo/less/responsive.less" %}" />
-            {% else %}
-                <link rel="stylesheet" type="text/css" href="{% static "demo/css/styles.css" %}" />
-                <link rel="stylesheet" type="text/css" href="{% static "demo/css/responsive.css" %}" />
-            {% endif %}
-        {% endcompress %}
-    {% endblock %}
+{% block styles %}
+    {% if use_less %}
+        <link rel="stylesheet" type="text/less" href="{% static "demo/less/styles.less" %}" />
+        <link rel="stylesheet" type="text/less" href="{% static "demo/less/responsive.less" %}" />
+    {% else %}
+        <link rel="stylesheet" type="text/css" href="{% static "demo/css/styles.css" %}" />
+        <link rel="stylesheet" type="text/css" href="{% static "demo/css/responsive.css" %}" />
+    {% endif %}
 {% endblock %}
 
 
 {% block scripts %}
-{% compress js %}
 <!-- Twitter Bootstrap -->
 <script type="text/javascript" src="{% static "oscar/js/bootstrap/bootstrap.min.js" %}"></script>
 <!-- Oscar -->
 <script src="{% static "oscar/js/oscar/ui.js" %}" type="text/javascript" charset="utf-8"></script>
-{% endcompress %}
 {% endblock scripts %}

--- a/sites/demo/templates/catalogue/detail.html
+++ b/sites/demo/templates/catalogue/detail.html
@@ -1,6 +1,5 @@
 {% extends "oscar/catalogue/detail.html" %}
 
-{% load compress %}
 {% load currency_filters %}
 {% load history_tags %}
 {% load reviews_tags %}
@@ -186,7 +185,5 @@
 {% endblock content %}
 
 {% block extrascripts %}
-{% compress js %}
     {% include "partials/extrascripts.html" %}
-{% endcompress %}
 {% endblock %}

--- a/sites/demo/templates/checkout/layout.html
+++ b/sites/demo/templates/checkout/layout.html
@@ -3,7 +3,6 @@
 {% load currency_filters %}
 {% load promotion_tags %}
 {% load category_tags %}
-{% load compress %}
 {% load staticfiles %}
 {% load i18n %}
 
@@ -75,7 +74,5 @@
 {% endblock %}
 
 {% block extrascripts %}
-{% compress js %}
     {% include "partials/extrascripts.html" %}
-{% endcompress %}
 {% endblock %}

--- a/sites/demo/templates/layout.html
+++ b/sites/demo/templates/layout.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-{% load compress %}
 {% load category_tags %}
 {% load staticfiles %}
 {% load i18n %}
@@ -63,7 +62,5 @@
 {% endblock %}
 
 {% block extrascripts %}
-{% compress js %}
     {% include "partials/extrascripts.html" %}
-{% endcompress %}
 {% endblock %}

--- a/sites/sandbox/settings.py
+++ b/sites/sandbox/settings.py
@@ -411,15 +411,13 @@ OSCAR_ORDER_STATUS_CASCADE = {
     'Complete': 'Shipped',
 }
 
-# LESS/CSS/statics
-# ================
+# LESS/CSS
+# ========
 
 # We default to using CSS files, rather than the LESS files that generate them.
-# If you want to develop Oscar's CSS, then set USE_LESS=True and
-# COMPRESS_ENABLED=False in your settings_local module and ensure you have
-# 'lessc' installed.
-
-USE_LESS = False
+# If you want to develop Oscar's CSS, then set USE_LESS=True to enable the
+# on-the-fly less processor.
+USE_LESS = True
 
 # Logging
 # =======

--- a/sites/sandbox/settings.py
+++ b/sites/sandbox/settings.py
@@ -115,7 +115,6 @@ STATICFILES_DIRS = (
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-    'compressor.finders.CompressorFinder',
 )
 
 # Make this unique, and don't share it with anybody.
@@ -302,7 +301,6 @@ INSTALLED_APPS = [
     # Debug toolbar + extensions
     'debug_toolbar',
     'template_timings_panel',
-    'compressor',       # Oscar's templates use compressor
     'apps.gateway',     # For allowing dashboard access
     'widget_tweaks',
 ]
@@ -422,21 +420,6 @@ OSCAR_ORDER_STATUS_CASCADE = {
 # 'lessc' installed.
 
 USE_LESS = False
-
-COMPRESS_ENABLED = True
-COMPRESS_PRECOMPILERS = (
-    ('text/less', 'lessc {infile} {outfile}'),
-)
-COMPRESS_OFFLINE_CONTEXT = {
-    'STATIC_URL': 'STATIC_URL',
-    'use_less': USE_LESS,
-}
-
-# We do this to work around an issue in compressor where the LESS files are
-# compiled but compression isn't enabled.  When this happens, the relative URL
-# is wrong between the generated CSS file and other assets:
-# https://github.com/jezdez/django_compressor/issues/226
-COMPRESS_OUTPUT_DIR = 'oscar'
 
 # Logging
 # =======

--- a/sites/us/settings.py
+++ b/sites/us/settings.py
@@ -332,13 +332,12 @@ OSCAR_SHOP_TAGLINE = 'US Sandbox'
 OSCAR_DEFAULT_CURRENCY = 'USD'
 OSCAR_ALLOW_ANON_CHECKOUT = True
 
-# LESS/CSS/statics
-# ================
+# LESS/CSS
+# ========
 
 # We default to using CSS files, rather than the LESS files that generate them.
-# If you want to develop Oscar's CSS, then set USE_LESS=True and
-# COMPRESS_ENABLED=False in your settings_local module and ensure you have
-# 'lessc' installed.
+# If you want to develop Oscar's CSS, then set USE_LESS=True to enable the
+# on-the-fly less processor.
 USE_LESS = False
 
 # Logging

--- a/sites/us/settings.py
+++ b/sites/us/settings.py
@@ -85,7 +85,6 @@ STATICFILES_DIRS = (
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-    'compressor.finders.CompressorFinder',
 )
 
 # Make this unique, and don't share it with anybody.
@@ -272,7 +271,6 @@ INSTALLED_APPS = [
     # Debug toolbar + extensions
     'debug_toolbar',
     'template_timings_panel',
-    'compressor',       # Oscar's templates use compressor
     'widget_tweaks',
 ]
 from oscar import get_core_apps
@@ -342,21 +340,6 @@ OSCAR_ALLOW_ANON_CHECKOUT = True
 # COMPRESS_ENABLED=False in your settings_local module and ensure you have
 # 'lessc' installed.
 USE_LESS = False
-
-COMPRESS_ENABLED = True
-COMPRESS_PRECOMPILERS = (
-    ('text/less', 'lessc {infile} {outfile}'),
-)
-COMPRESS_OFFLINE_CONTEXT = {
-    'STATIC_URL': 'STATIC_URL',
-    'use_less': USE_LESS,
-}
-
-# We do this to work around an issue in compressor where the LESS files are
-# compiled but compression isn't enabled.  When this happens, the relative URL
-# is wrong between the generated CSS file and other assets:
-# https://github.com/jezdez/django_compressor/issues/226
-COMPRESS_OUTPUT_DIR = 'oscar'
 
 # Logging
 # =======

--- a/src/oscar/templates/oscar/base.html
+++ b/src/oscar/templates/oscar/base.html
@@ -1,4 +1,4 @@
-{% load i18n compress %}
+{% load i18n %}
 {% load staticfiles %}
 <!DOCTYPE html>
 <!--[if lt IE 7]>      <html lang="{{ LANGUAGE_CODE|default:"en-gb" }}" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
@@ -24,22 +24,8 @@
             <link rel="shortcut icon" href="{% static "oscar/favicon.ico" %}" />
         {% endblock %}
 
-        {% block mainstyles %}
-            {% comment %}
-            We use an inner block to work-around the fact that django-compressor doesn't work with
-            template inheritance.  Ie, we can't just wrap the {% block mainstyles %} with compress tags and
-            expect it to compress CSS files added in child templates.
-            {% endcomment %}
-            {% block styles %}
-                {% comment %}
-                If you are developing Oscar's CSS, or overriding Oscar's CSS
-                files in your project, then set USE_LESS = True in your
-                settings file.  You will also need to ensure that the 'lessc'
-                executable is available and you have COMPRESS_PRECOMPILERS specified
-                correctly.
-                {% endcomment %}
-            {% endblock %}
-        {% endblock %}
+        {# Block where global CSS will go. #}
+        {% block styles %}{% endblock %}
 
         {# Additional CSS - specific to certain pages #}
         {% block extrastyles %}{% endblock %}
@@ -56,10 +42,7 @@
         {# Main content goes in this 'layout' block #}
         {% block layout %}{% endblock %}
 
-        {% comment %}
-        Scripts loaded from a CDN.  These can't be wrapped by the 'compress' tag and so we
-        use a separate block for them.
-        {% endcomment %}
+        {# Scripts loaded from a CDN. #}
         {% block cdn_scripts %}
             <!-- jQuery -->
             <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>

--- a/src/oscar/templates/oscar/dashboard/layout.html
+++ b/src/oscar/templates/oscar/dashboard/layout.html
@@ -3,27 +3,22 @@
 {% load category_tags %}
 {% load dashboard_tags %}
 {% load i18n %}
-{% load compress %}
 {% load staticfiles %}
 
-{% block mainstyles %}
-    {% compress css %}
-        {% if use_less %}
-            <link rel="stylesheet" type="text/less" href="{% static "oscar/less/dashboard.less" %}" />
-        {% else %}
-            <link rel="stylesheet" type="text/css" href="{% static "oscar/css/dashboard.css" %}" />
-        {% endif %}
-    {% endcompress %}
+{% block styles %}
+    {% if use_less %}
+        <link rel="stylesheet" type="text/less" href="{% static "oscar/less/dashboard.less" %}" />
+    {% else %}
+        <link rel="stylesheet" type="text/css" href="{% static "oscar/css/dashboard.css" %}" />
+    {% endif %}
 {% endblock %}
 
 {% block extrastyles %}
     {{ block.super }}
-    {% compress css %}
-        <link rel="stylesheet" href="{% static "oscar/js/select2/select2.css" %}" />
-        <link rel="stylesheet" href="{% static "oscar/css/select2-bootstrap.css" %}" />
-        <link rel="stylesheet" href="{% static "oscar/js/bootstrap-datetimepicker/bootstrap-datetimepicker.css" %}" />
-        <link rel="stylesheet" href="{% static "oscar/css/datetimepicker.css" %}" />
-    {% endcompress %}
+    <link rel="stylesheet" href="{% static "oscar/js/select2/select2.css" %}" />
+    <link rel="stylesheet" href="{% static "oscar/css/select2-bootstrap.css" %}" />
+    <link rel="stylesheet" href="{% static "oscar/js/bootstrap-datetimepicker/bootstrap-datetimepicker.css" %}" />
+    <link rel="stylesheet" href="{% static "oscar/css/datetimepicker.css" %}" />
 {% endblock %}
 
 {% block title %}
@@ -143,27 +138,22 @@
 
 {# Local scripts #}
 {% block scripts %}
-    {% compress js %}
     <!-- Twitter Bootstrap -->
     <script type="text/javascript" src="{% static "oscar/js/bootstrap3/bootstrap.min.js" %}"></script>
     <!-- Oscar -->
     <script src="{% static "oscar/js/oscar/ui.js" %}" type="text/javascript" charset="utf-8"></script>
-    {% endcompress %}
 {% endblock %}
 
 {% block extrascripts %}
     {{ block.super }}
 
-
-    {% compress js %}
-        {# jQuery plugins #}
-        <script src="{% static "oscar/js/mousewheel/jquery.mousewheel.min.js" %}" type="text/javascript" charset="utf-8"></script>
-        <script src="{% static "oscar/js/bootstrap-datetimepicker/bootstrap-datetimepicker.js" %}" type="text/javascript" charset="utf-8"></script>
-        <script src="{% static "oscar/js/bootstrap-datetimepicker/locales/bootstrap-datetimepicker.all.js" %}" type="text/javascript" charset="utf-8"></script>
-        <script src="{% static "oscar/js/inputmask/jquery.inputmask.bundle.min.js" %}" type="text/javascript" charset="utf-8"></script>
-        <script src="{% static "oscar/js/select2/select2.js" %}" type="text/javascript" charset="utf-8"></script>
-        <script src="{% static "oscar/js/oscar/dashboard.js" %}" type="text/javascript" charset="utf-8"></script>
-    {% endcompress %}
+    {# jQuery plugins #}
+    <script src="{% static "oscar/js/mousewheel/jquery.mousewheel.min.js" %}" type="text/javascript" charset="utf-8"></script>
+    <script src="{% static "oscar/js/bootstrap-datetimepicker/bootstrap-datetimepicker.js" %}" type="text/javascript" charset="utf-8"></script>
+    <script src="{% static "oscar/js/bootstrap-datetimepicker/locales/bootstrap-datetimepicker.all.js" %}" type="text/javascript" charset="utf-8"></script>
+    <script src="{% static "oscar/js/inputmask/jquery.inputmask.bundle.min.js" %}" type="text/javascript" charset="utf-8"></script>
+    <script src="{% static "oscar/js/select2/select2.js" %}" type="text/javascript" charset="utf-8"></script>
+    <script src="{% static "oscar/js/oscar/dashboard.js" %}" type="text/javascript" charset="utf-8"></script>
 
     {# We don't use a fallback for tinyMCE as it dynamically loads several other files #}
     <script src="//tinymce.cachefly.net/4.0/tinymce.min.js" type="text/javascript" charset="utf-8"></script>

--- a/src/oscar/templates/oscar/layout.html
+++ b/src/oscar/templates/oscar/layout.html
@@ -4,14 +4,12 @@
 
 {% block styles %}
     {% comment %}
-    If you are developing Oscar's CSS, or overriding Oscar's CSS
-    files in your project, then set USE_LESS = True in your
-    settings file.  You will also need to ensure that the 'lessc'
-    executable is available and you have COMPRESS_PRECOMPILERS specified
-    correctly.
+        If you are developing Oscar's CSS, or overriding Oscar's CSS
+        files in your project, then set USE_LESS = True in your
+        settings file. This will enable the on-the-fly less compiler.
     {% endcomment %}
     {% if use_less %}
-        <link rel="stylesheet" type="text/less" href="{% static "oscar/less/styles.less" %}" />
+        <link rel="stylesheet/less" type="text/css" href="{% static "oscar/less/styles.less" %}" />
     {% else %}
         <link rel="stylesheet" type="text/css" href="{% static "oscar/css/styles.css" %}" />
     {% endif %}
@@ -67,6 +65,14 @@
     {% endblock %}
 
     {% include "partials/footer.html" %}
+{% endblock %}
+
+{% block cdn_scripts %}
+  {{ block.super }}
+  {% if use_less and debug %}
+    {# Load the on-the-fly less compiler. Never do this in production. #}
+    <script src="//cdnjs.cloudflare.com/ajax/libs/less.js/2.5.3/less.min.js"></script>
+  {% endif %}
 {% endblock %}
 
 {# Local scripts #}

--- a/src/oscar/templates/oscar/layout.html
+++ b/src/oscar/templates/oscar/layout.html
@@ -1,20 +1,22 @@
 {% extends "base.html" %}
 {% load staticfiles %}
-{% load compress %}
 {% load promotion_tags %}
 
-{% block mainstyles %}
-    {% block styles %}
-        {% compress css %}
-            {% if use_less %}
-                <link rel="stylesheet" type="text/less" href="{% static "oscar/less/styles.less" %}" />
-            {% else %}
-                <link rel="stylesheet" type="text/css" href="{% static "oscar/css/styles.css" %}" />
-            {% endif %}
-            <link rel="stylesheet" href="{% static "oscar/js/bootstrap-datetimepicker/bootstrap-datetimepicker.css" %}" />
-            <link rel="stylesheet" type="text/css" href="{% static "oscar/css/datetimepicker.css" %}" />
-        {% endcompress %}
-    {% endblock %}
+{% block styles %}
+    {% comment %}
+    If you are developing Oscar's CSS, or overriding Oscar's CSS
+    files in your project, then set USE_LESS = True in your
+    settings file.  You will also need to ensure that the 'lessc'
+    executable is available and you have COMPRESS_PRECOMPILERS specified
+    correctly.
+    {% endcomment %}
+    {% if use_less %}
+        <link rel="stylesheet" type="text/less" href="{% static "oscar/less/styles.less" %}" />
+    {% else %}
+        <link rel="stylesheet" type="text/css" href="{% static "oscar/css/styles.css" %}" />
+    {% endif %}
+    <link rel="stylesheet" href="{% static "oscar/js/bootstrap-datetimepicker/bootstrap-datetimepicker.css" %}" />
+    <link rel="stylesheet" type="text/css" href="{% static "oscar/css/datetimepicker.css" %}" />
 {% endblock %}
 
 {% block layout %}
@@ -70,7 +72,6 @@
 {# Local scripts #}
 {% block scripts %}
     {{ block.super }}
-    {% compress js %}
     <!-- Twitter Bootstrap -->
     <script type="text/javascript" src="{% static "oscar/js/bootstrap3/bootstrap.min.js" %}"></script>
     <!-- Oscar -->
@@ -78,7 +79,6 @@
 
     <script src="{% static "oscar/js/bootstrap-datetimepicker/bootstrap-datetimepicker.js" %}" type="text/javascript" charset="utf-8"></script>
     <script src="{% static "oscar/js/bootstrap-datetimepicker/locales/bootstrap-datetimepicker.all.js" %}" type="text/javascript" charset="utf-8"></script>
-    {% endcompress %}
 {% endblock %}
 
 {% block extrascripts %}

--- a/src/oscar/templates/oscar/partials/extrascripts.html
+++ b/src/oscar/templates/oscar/partials/extrascripts.html
@@ -1,5 +1,4 @@
-{% load staticfiles %}
-{% load compress %}
-
-{% compress js %}
-{% endcompress %}
+{% comment %}
+    This file exists so you can easily add your own Javascript without
+    having to fork layout.html etc. Instead, just override this file.
+{% endcomment %}

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -15,7 +15,6 @@ INSTALLED_APPS = [
     'django.contrib.sites',
     'django.contrib.flatpages',
     'django.contrib.staticfiles',
-    'compressor',
     'widget_tweaks',
 
     # contains models we need for testing
@@ -69,8 +68,6 @@ PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher']
 ROOT_URLCONF = 'tests._site.urls'
 LOGIN_REDIRECT_URL = '/accounts/'
 STATIC_URL = '/static/'
-COMPRESS_ENABLED = False
-COMPRESS_ROOT = ''  # needed to avoid issue #1214
 DEBUG = False
 SITE_ID = 1
 USE_TZ = 1


### PR DESCRIPTION
django-compressor served it's purpose, but given the advent of
more and more frontend JS work, and the accompanying build tools (grunt,
gulp, etc.), it makes less and less sense to use compressor. Jannis
Leidel himself also stepped back from maintaining it.

In my experience with Oscar projects, it has also become a bit of a
liability to have compressor as a dependency. Most projects don't use it
any more, but it's not easy to disable/override because all our
templates include it.

So, let's keep things simple and remove it as a dependency. That paves
the way for using other tools, while it's always easy to add back.