### PR TITLE
Correct allow_failures for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,8 @@ matrix:
         - python: 3.4
           env: "DJANGO=Django==1.9b1"
         - python: 3.5
+          env: "DJANGO=Django==1.8.5"
+        - python: 3.5
           env: "DJANGO=Django==1.9b1"
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
     matrix:
         - DJANGO=Django==1.7.10
         - DJANGO=Django==1.8.5
-        - DJANGO=DJANGO==1.9b1 
+        - DJANGO=Django==1.9b1 
 
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,16 +40,20 @@ env:
 matrix:
     exclude:
         - python: 3.2
-          env: DJANGO=Django==1.9b1
+          env: "DJANGO=Django==1.9b1"
         - python: 3.3
-          env: DJANGO=Django==1.9b1
+          env: "DJANGO=Django==1.9b1"
         - python: 3.5
-          env: DJANGO=Django==1.7.10
-
+          env: "DJANGO=Django==1.7.10"
     allow_failures:
-      - env: DJANGO=Django==1.9b1
-      - python: 3.5
-        env: DJANGO=Django==1.8.5
+        - python: 2.7
+          env: "DJANGO=Django==1.9b1"
+        - python: 3.3
+          env: "DJANGO=Django==1.9b1"
+        - python: 3.4
+          env: "DJANGO=Django==1.9b1"
+        - python: 3.5
+          env: "DJANGO=Django==1.9b1"
 
 
 before_install:

--- a/runtests.py
+++ b/runtests.py
@@ -77,7 +77,7 @@ if __name__ == '__main__':
         # thread safe. Behaviour with multiple threads is undefined.
         warnings.filterwarnings('error', category=DeprecationWarning)
         warnings.filterwarnings('error', category=RuntimeWarning)
-        libs = r'(sorl\.thumbnail.*|bs4.*|webtest.*)'
+        libs = r'(sorl\.thumbnail.*|bs4.*|webtest.*|inspect.*)'
         warnings.filterwarnings(
             'ignore', r'.*', DeprecationWarning, libs)
 


### PR DESCRIPTION
Django 1.8 supports Python 3.5. It does raise a DeprecationWarning, which is
safe to ignore. We only care about DeprecationWarnings in our own code.

And it seems that Travis wants all allowed failures listed explicitly, so we
do that. It should now pass again.