### PR TITLE
Some review form fields do not always exist

### DIFF
--- a/src/oscar/templates/oscar/catalogue/reviews/review_form.html
+++ b/src/oscar/templates/oscar/catalogue/reviews/review_form.html
@@ -35,8 +35,12 @@
                 </div>
 
                 {% include 'partials/form_field.html' with field=form.body %}
-                {% include 'partials/form_field.html' with field=form.name %}
-                {% include 'partials/form_field.html' with field=form.email %}
+                {% if form.name %}
+                    {% include 'partials/form_field.html' with field=form.name %}
+                {% endif %}
+                {% if form.email %}
+                    {% include 'partials/form_field.html' with field=form.email %}
+                {% endif %}
 
 
                 <button type="submit" class="btn btn-primary btn-lg" data-loading-text="{% trans 'Saving...' %}">{% trans "Save review" %}</button>


### PR DESCRIPTION
For logged in users, the `name` and `email` fields do not exist in the form. Check whether they exist before attempting to render them.