### PR TITLE
Added options attribute addition documentation

### DIFF
--- a/docs/source/topics/modelling_your_catalogue.rst
+++ b/docs/source/topics/modelling_your_catalogue.rst
@@ -43,6 +43,34 @@ they have a ``size`` attribute::
     > shirt.attr.size
     <AttributeOption: Large>
 
+You can assign ``option`` s to your product. For example you want a Language attribute
+to your product, and a couple of options to choose from, for example English and 
+Croatian. You'd first create an ``AttributeOptionGroup`` that would contain all the 
+``AttributeOption`` s you want to have available::
+
+    > language = AttributeOptionGroup.objects.create(name='Language')
+
+Assign a couple of options to the Language options group::
+
+    > AttributeOption.objects.create(
+    >     group=language,
+    >     option='English'
+    > )
+    > AttributeOption.objects.create(
+    >     group=language,
+    >     option='Croatian'
+    > )
+
+Finally assign the Language options group to your product as an attribute::
+
+    > ProductAttribute.objects.create(
+    >     product_class=klass,
+    >     name='Language',
+    >     code='language',
+    >     type='option',
+    >     option_group=language
+    > )
+
 You can go as far as associating arbitrary models with it. Use the ``entity``
 type::
 

--- a/docs/source/topics/modelling_your_catalogue.rst
+++ b/docs/source/topics/modelling_your_catalogue.rst
@@ -63,6 +63,7 @@ Assign a couple of options to the Language options group::
 
 Finally assign the Language options group to your product as an attribute::
 
+    > klass = ProductClass.objects.create(name='foo', slug='bar')
     > ProductAttribute.objects.create(
     >     product_class=klass,
     >     name='Language',


### PR DESCRIPTION
I was tasked to create a product that would be out-of-the-box available to our users, so I added the attributes in a data migration but I had a hard time finding any resource that describes adding options via code and had to dig through Oscar's code on GitHub to figure this out. People would benefit from an addition like this, at least save time from digging through code to figure this out.