### PR TITLE
Introduce new Voucher.created datetime, deprecate Voucher.date_created

### DIFF
--- a/docs/source/releases/v1.2.rst
+++ b/docs/source/releases/v1.2.rst
@@ -47,7 +47,14 @@ What's new in Oscar 1.2?
 Minor changes
 ~~~~~~~~~~~~~
  - Fix missing page_url field in the promotions form (`#1816`_)
-
+ - ``Voucher.date_created`` and ``VoucherApplication.date_created``
+   are date fields that have been deprecated.
+   Their intended replacements are the new ``.created`` datetime
+   fields, which we hope are more generally useful. If you have been happy
+   with just having the date, we suggest to keep using the old fields
+   for now, and only switch to the new field when ``date_created`` is
+   removed as part of Oscar 1.3. But you can always write a data migration
+   should it be necessary to keep the old creation dates around.
 
 .. _incompatible_in_1.2:
 
@@ -65,3 +72,11 @@ Misc
 ~~~~
  
 * JQuery UI is no longer included in the dashboard (`#1792`)
+
+Deprecated features
+~~~~~~~~~~~~~~~~~~~
+
+The following features have been deprecated in this release:
+
+* ``Voucher.date_created``, as it's replaced by ``Voucher.created``.
+  To be removed in Oscar 1.3.

--- a/src/oscar/apps/voucher/abstract_models.py
+++ b/src/oscar/apps/voucher/abstract_models.py
@@ -51,6 +51,11 @@ class AbstractVoucher(models.Model):
         _("Total discount"), decimal_places=2, max_digits=12,
         default=Decimal('0.00'))
 
+    #: Creation timestamp. Supersedes Voucher.date_created.
+    # TODO: Remove null=True with Oscar 1.3.
+    created = models.DateTimeField(_("Created"), auto_now_add=True, null=True)
+    #: Deprecated: Creation date. Superseded by Voucher.created.
+    # TODO: Remove with Oscar 1.3.
     date_created = models.DateField(auto_now_add=True)
 
     class Meta:
@@ -153,6 +158,12 @@ class AbstractVoucherApplication(models.Model):
     user = models.ForeignKey(AUTH_USER_MODEL, blank=True, null=True,
                              verbose_name=_("User"))
     order = models.ForeignKey('order.Order', verbose_name=_("Order"))
+
+    #: Creation timestamp. Supersedes VoucherApplication.date_created.
+    # TODO: Remove null=True with Oscar 1.3.
+    created = models.DateTimeField(_("Created"), auto_now_add=True, null=True)
+    #: Deprecated: Creation date. Superseded by VoucherApplication.created.
+    # TODO: Remove with Oscar 1.3.
     date_created = models.DateField(_("Date Created"), auto_now_add=True)
 
     class Meta:

--- a/src/oscar/apps/voucher/migrations/0002_auto_20151113_1747.py
+++ b/src/oscar/apps/voucher/migrations/0002_auto_20151113_1747.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('voucher', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='voucher',
+            name='created',
+            field=models.DateTimeField(auto_now_add=True, verbose_name='Created', null=True),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='voucherapplication',
+            name='created',
+            field=models.DateTimeField(auto_now_add=True, verbose_name='Created', null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/src/oscar/templates/oscar/dashboard/vouchers/voucher_list.html
+++ b/src/oscar/templates/oscar/dashboard/vouchers/voucher_list.html
@@ -56,7 +56,7 @@
                     <th>{% trans "Status" %}</th>
                     <th>{% anchor 'num_basket_additions' _("Num baskets") %}</th>
                     <th>{% anchor 'num_orders' _("Num orders") %}</th>
-                    <th>{% anchor 'date_created' _("Date created") %}</th>
+                    <th>{% anchor 'created' _("Date created") %}</th>
                     <th></th>
                 </tr>
                 {% endblock table_head %}
@@ -76,7 +76,7 @@
                             </td>
                             <td>{{ voucher.num_basket_additions }}</td>
                             <td>{{ voucher.num_orders }}</td>
-                            <td>{{ voucher.date_created }}</td>
+                            <td>{{ voucher.created|default:voucher.date_created }}</td>
                             <td>
                                 {% block row_actions %}
                                     <div class="btn-toolbar">


### PR DESCRIPTION
I think almost always datetime fields are more useful than date fields. We
wanted to be able to sort by last created vouchers, which is not useful when
only the day of the year is available.

I'm being a bit handwavy with the migration procedure, because I think it's
overall quite simple to implement, and my guess is that most deployments don't
really care about creation dates for older vouchers. Hence just doing the
switch when Oscar 1.3 comes around should be sufficient.
