### PR TITLE
Update dependencies on pillow, factory-boy and django-widget-tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,24 +33,18 @@ env:
         - PIP_FIND_LINKS=file://$HOME/.cache/pip/wheels
     matrix:
         - DJANGO=Django==1.7.11
-        - DJANGO=Django==1.8.7
-        - DJANGO=Django==1.9.0
+        - DJANGO=Django==1.8.8
+        - DJANGO=Django==1.9.1
 
 
 matrix:
     exclude:
         - python: 3.2
-          env: "DJANGO=Django==1.9.0"
+          env: "DJANGO=Django==1.9.1"
         - python: 3.3
-          env: "DJANGO=Django==1.9.0"
+          env: "DJANGO=Django==1.9.1"
         - python: 3.5
           env: "DJANGO=Django==1.7.11"
-    allow_failures:
-        - python: 3.5
-          env: "DJANGO=Django==1.8.7"
-        - python: 3.5
-          env: "DJANGO=Django==1.9.0"
-
 
 before_install:
     - pip install codecov

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,45 +5,43 @@
 
 # Development
 django-debug-toolbar==1.4.0
-django-debug-toolbar-template-timings==0.6.4
-django-extensions==1.5.9
+django-extensions==1.6.1
 Werkzeug==0.9.6
 
 # Sandbox
 Whoosh==2.6.0
 pysolr==3.2.0
 requests==2.7.0
-uWSGI==2.0.11.2
+uWSGI==2.0.12
 whitenoise==2.0.6
 Pillow==2.7.0
 
 # Docs
-Sphinx==1.2.3
-sphinxcontrib-napoleon==0.2.8
-sphinx_rtd_theme==0.1.6
+Sphinx==1.3.3
+sphinxcontrib-napoleon==0.4.3
+sphinx_rtd_theme==0.1.9
 
 # Testing
 coverage==3.7.1
 spec==0.11.1
 WebTest==2.0.17
 django-webtest==1.7.8
-pytest==2.8.4
+pytest==2.8.5
 pytest-cache==1.0
 pytest-cov==2.2.0
 pytest-django==2.9.1
 pytest-xdist==1.13.1
 tox==1.8.1
 coveralls==0.4.4
-behave==1.2.4
-isort==4.2.2
 
 # Misc
-flake8==2.4.1
+flake8==2.5.1
 flake8-debugger==1.4.0
 flake8-blind-except==0.1.0
 pyprof2calltree==1.3.2
-ipdb==0.8
-ipython==2.3.0
+ipdb==0.8.1
+ipython==4.0.1
+isort==4.2.2
 
 # Country data
 pycountry==1.8

--- a/runtests.py
+++ b/runtests.py
@@ -77,7 +77,7 @@ if __name__ == '__main__':
         # thread safe. Behaviour with multiple threads is undefined.
         warnings.filterwarnings('error', category=DeprecationWarning)
         warnings.filterwarnings('error', category=RuntimeWarning)
-        libs = r'(sorl\.thumbnail.*|bs4.*|webtest.*|inspect.*)'
+        libs = r'(sorl\.thumbnail.*|bs4.*|webtest.*|inspect.*|re.*)'
         warnings.filterwarnings(
             'ignore', r'.*', DeprecationWarning, libs)
 

--- a/setup.py
+++ b/setup.py
@@ -32,10 +32,10 @@ setup(name='django-oscar',
       install_requires=[
           'django>=1.7.8,<1.10',
           # PIL is required for image fields, Pillow is the "friendly" PIL fork
-          'pillow>=1.7.8,<=2.7',
+          'pillow>=1.7.8',
           # We use the ModelFormSetView from django-extra-views for the basket
-          # page. 0.6.5 pins version of six, which causes issues:
-          # https://github.com/AndrewIngram/django-extra-views/pull/85
+          # page. > 0.6.5 has a bug which causes issues with Django > 1.6,
+          # https://github.com/AndrewIngram/django-extra-views/issues/114
           'django-extra-views>=0.2,<0.6.5',
           # Search support
           'django-haystack>=2.3.1,<2.5.0',
@@ -50,16 +50,16 @@ setup(name='django-oscar',
           # For manipulating search URLs
           'purl>=0.7',
           # For phone number field
-          'phonenumbers>=6.3.0,<7.0.0',
+          'phonenumbers>=6.3.0,<8.0.0',
           # Used for oscar.test.contextmanagers.mock_signal_receiver
-          'mock>=1.0.1,<1.1',
+          'mock>=1.0.1,<2.0',
           # Used for oscar.test.newfactories
-          'factory-boy>=2.4.1,<2.5',
+          'factory-boy>=2.4.1,<2.7',
           # Used for automatically building larger HTML tables
           'django-tables2>=1.0.4,<1.1',
           # Used for manipulating form field attributes in templates (eg: add
           # a css class)
-          'django-widget-tweaks>=1.4.1,<1.5',
+          'django-widget-tweaks>=1.4.1',
       ],
       dependency_links=[],
       # See http://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Instead of forcing a version range for theses packages specificy only
the minimal version number. This packages are stable enough and forcing
upper version limits can cause issues with other (non oscar)
dependencies.