### PR TITLE
Make product unavailable if price is empty to avoid exception when adding product without price to basket

### DIFF
--- a/src/oscar/apps/partner/strategy.py
+++ b/src/oscar/apps/partner/strategy.py
@@ -210,7 +210,7 @@ class StockRequired(object):
     """
 
     def availability_policy(self, product, stockrecord):
-        if not stockrecord:
+        if not stockrecord or stockrecord.price_excl_tax is None:
             return Unavailable()
         if not product.get_product_class().track_stock:
             return Available()

--- a/tests/integration/basket/test_forms.py
+++ b/tests/integration/basket/test_forms.py
@@ -175,3 +175,14 @@ class TestAddToBasketForm(TestCase):
         form = forms.AddToBasketForm(
             basket=basket, product=product, data=data)
         self.assertFalse(form.is_valid())
+
+    def test_for_empty_price_excl_tax(self):
+        basket = factories.BasketFactory()
+        product_class = factories.ProductClassFactory(track_stock=False)
+        product = factories.ProductFactory(product_class=product_class, stockrecords=[])
+        factories.StockRecordFactory.build(price_excl_tax=None, product=product)
+
+        data = {'quantity': 1}
+        form = forms.AddToBasketForm(basket=basket, product=product, data=data)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors['__all__'][0], 'unavailable')

--- a/tests/integration/partner/test_strategy.py
+++ b/tests/integration/partner/test_strategy.py
@@ -47,6 +47,13 @@ class TestDefaultStrategy(TestCase):
         self.assertTrue(info.availability.is_available_to_buy)
         self.assertTrue(info.price.exists)
 
+    def test_product_with_empty_price(self):
+        product_class = factories.ProductClassFactory(track_stock=False)
+        product = factories.ProductFactory(product_class=product_class, stockrecords=[])
+        factories.StockRecordFactory(price_excl_tax=None, product=product)
+        info = self.strategy.fetch_for_product(product)
+        self.assertFalse(info.availability.is_available_to_buy)
+
 
 class TestDefaultStrategyForParentProductWhoseVariantsHaveNoStockRecords(TestCase):
 


### PR DESCRIPTION
Fixes #1912 
