### PR TITLE
Add missing end slash - fix error when APPEND_SLASH is set to True.

### DIFF
--- a/src/oscar/apps/customer/app.py
+++ b/src/oscar/apps/customer/app.py
@@ -101,7 +101,7 @@ class CustomerApplication(Application):
             url(r'^orders/(?P<order_number>[\w-]*)/$',
                 login_required(self.order_detail_view.as_view()),
                 name='order'),
-            url(r'^orders/(?P<order_number>[\w-]*)/(?P<line_id>\d+)$',
+            url(r'^orders/(?P<order_number>[\w-]*)/(?P<line_id>\d+)/$',
                 login_required(self.order_line_view.as_view()),
                 name='order-line'),
 


### PR DESCRIPTION
RuntimeError: You called this URL via POST, but the URL doesn't end in a slash and you have APPEND_SLASH set. Django can't redirect to the slash URL while maintaining POST data. Change your form to point to host.cz/en/user-profile/orders/100030/1/ (note the trailing slash), or set APPEND_SLASH=False in your Django settings.