### PR TITLE
Remove three custom managers from reviews app

### DIFF
--- a/docs/source/releases/v1.2.rst
+++ b/docs/source/releases/v1.2.rst
@@ -66,6 +66,10 @@ Backwards incompatible changes in Oscar 1.2
   were not up-to-date anymore. These might return in the future as 
   separate repositories.
 
+- The `RecentReviewsManager`, `TopScoredReviewsManager` and 
+  `TopVotedReviewsManager` managers are removed from the reviews app 
+  since they were broken and unused.
+
 
 Misc
 ~~~~

--- a/src/oscar/apps/catalogue/reviews/managers.py
+++ b/src/oscar/apps/catalogue/reviews/managers.py
@@ -4,22 +4,4 @@ from django.db import models
 class ApprovedReviewsManager(models.Manager):
     def get_queryset(self):
         queryset = super(ApprovedReviewsManager, self).get_queryset()
-        return queryset.filter(status=1)
-
-
-class RecentReviewsManager(models.Manager):
-    def get_queryset(self):
-        queryset = super(RecentReviewsManager, self).get_queryset()
-        return queryset.filter(approved=True).order_by('-date_created')
-
-
-class TopScoredReviewsManager(models.Manager):
-    def get_queryset(self):
-        queryset = super(TopScoredReviewsManager, self).get_queryset()
-        return queryset.filter(approved=True).order_by('-score')
-
-
-class TopVotedReviewsManager(models.Manager):
-    def get_queryset(self):
-        queryset = super(TopVotedReviewsManager, self).get_queryset()
-        return queryset.filter(approved=True).order_by('-delta_votes')
+        return queryset.filter(status=self.model.APPROVED)


### PR DESCRIPTION
The managers reference the `approved` field but it doesn't exist
(anymore)
