### PR TITLE
Fix errors with shipping discounts on free weightbased shipping.

### DIFF
--- a/src/oscar/apps/shipping/abstract_models.py
+++ b/src/oscar/apps/shipping/abstract_models.py
@@ -39,6 +39,13 @@ class AbstractBase(models.Model):
     def __str__(self):
         return self.name
 
+    def discount(self, basket):
+        """
+        Return the discount on the standard shipping charge
+        """
+        # This method is identical to the Base.discount().
+        return D('0.00')
+
 
 class AbstractOrderAndItemCharges(AbstractBase):
     """
@@ -95,7 +102,6 @@ class AbstractWeightBased(AbstractBase):
 
     code = 'weight-based-shipping'
     name = _('Weight-based shipping')
-    offer = None
 
     # The default weight to use (in kg) when a product doesn't have a weight
     # attribute.
@@ -178,10 +184,6 @@ class AbstractWeightBased(AbstractBase):
             return self.bands.order_by('-upper_limit')[0]
         except IndexError:
             return None
-
-    def discount(self, basket):
-        base_charge = self.calculate(basket)
-        return self.offer.shipping_discount(base_charge.incl_tax)
 
 
 @python_2_unicode_compatible

--- a/src/oscar/apps/shipping/methods.py
+++ b/src/oscar/apps/shipping/methods.py
@@ -40,6 +40,9 @@ class Base(object):
         """
         Return the discount on the standard shipping charge
         """
+        # The regular shipping methods don't add a default discount.
+        # For offers and vouchers, the discount will be provided
+        # by a wrapper that Repository.apply_shipping_offer() adds.
         return D('0.00')
 
 


### PR DESCRIPTION
The standard shipping methods all inherit from `shipping.methods.Base`, which has a `discount()` method.
The shipping models inherit from `shipping.abstract_models.AbstractBase`, which *does not* have a `discount()` method! This PR makes sure that standard shipping methods, and model-based shipping methods have the same base.

---
extra background:

The `Repository.apply_shipping_offer()` method returns the current shipping method object when there is no additional discount for an order. That works with the standard shipping methods that decent from `Base`, because `Base.discount()` nicely returns 0. (meaning: the shipping method does not provide an additional discount).

The `WeightBased` model does not have a working `discount()` method. It uses some copy-pasted code from `TaxInclusiveOfferDiscount`, but that does not make sense. Nor did it work, because `self.offer` would never be assigned.

Instead, it the model versions (`WeightBased`, `OrderAndItemCharges`) should have a similar default `discount()` method in their base class (`AbstractBase`) that also returns 0.