### PR TITLE
Weigh the basket using decimals, avoid float rounding issues

### DIFF
--- a/src/oscar/apps/shipping/scales.py
+++ b/src/oscar/apps/shipping/scales.py
@@ -1,3 +1,4 @@
+from decimal import Decimal as D
 from django.core.exceptions import ObjectDoesNotExist
 
 
@@ -20,10 +21,10 @@ class Scale(object):
             weight = self.default_weight
         else:
             weight = attr_val.value
-        return float(weight) if weight is not None else 0.0
+        return D(weight) if weight is not None else D('0.0')
 
     def weigh_basket(self, basket):
-        weight = 0.0
+        weight = D('0.0')
         for line in basket.lines.all():
             weight += self.weigh_product(line.product) * line.quantity
         return weight

--- a/tests/integration/shipping/scales_tests.py
+++ b/tests/integration/shipping/scales_tests.py
@@ -56,3 +56,18 @@ class TestScales(TestCase):
 
         scale = Scale(attribute_code='weight')
         self.assertEqual(1*3 + 2*4, scale.weigh_basket(basket))
+
+    def test_decimals(self):
+        basket = factories.create_basket(empty=True)
+        product = factories.create_product(attributes={'weight': '0.3'},
+                                           price=D('5.00'))
+        basket.add(product)
+
+        scale = Scale(attribute_code='weight')
+        self.assertEqual(D('0.3'), scale.weigh_basket(basket))
+
+        basket.add(product)
+        self.assertEqual(D('0.6'), scale.weigh_basket(basket))
+
+        basket.add(product)
+        self.assertEqual(D('0.9'), scale.weigh_basket(basket))


### PR DESCRIPTION
While the backend stores the information as floats, the calculations don't have to do be affected by this. For example:

0.3 + 0.3 + 0.3 == 0.8999999999999999

Using decimals improves the calculation, and avoid falling into the wrong weight band.