### PR TITLE
Remove unique=True on Benefit class

### DIFF
--- a/docs/source/releases/v1.2.rst
+++ b/docs/source/releases/v1.2.rst
@@ -47,6 +47,11 @@ What's new in Oscar 1.2?
 Minor changes
 ~~~~~~~~~~~~~
  - Fix missing page_url field in the promotions form (`#1816`_)
+ - Custom benefits now don't enforce uniqueness on the ``proxy_class``
+   field, making them more useful (`#685`_).
+
+.. _`#685`: https://github.com/django-oscar/django-oscar/issues/685
+.. _`#1816`: https://github.com/django-oscar/django-oscar/issues/1816
 
 
 .. _incompatible_in_1.2:
@@ -74,4 +79,6 @@ Backwards incompatible changes in Oscar 1.2
 Misc
 ~~~~
  
-* JQuery UI is no longer included in the dashboard (`#1792`)
+* JQuery UI is no longer included in the dashboard (`#1792`_)
+
+.. _`#1792`: https://github.com/django-oscar/django-oscar/issues/1792

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -418,7 +418,7 @@ class AbstractBenefit(models.Model):
     # A custom benefit class can be used instead.  This means the
     # type/value/max_affected_items fields should all be None.
     proxy_class = fields.NullCharField(
-        _("Custom class"), max_length=255, unique=True, default=None)
+        _("Custom class"), max_length=255, default=None)
 
     class Meta:
         abstract = True

--- a/src/oscar/apps/offer/migrations/0002_auto_20151210_1053.py
+++ b/src/oscar/apps/offer/migrations/0002_auto_20151210_1053.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import oscar.models.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('offer', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='benefit',
+            name='proxy_class',
+            field=oscar.models.fields.NullCharField(default=None, max_length=255, verbose_name='Custom class'),
+            preserve_default=True,
+        ),
+    ]


### PR DESCRIPTION
I ran into the issues detailed in #685. Basically, the uniqueness constraint
makes the custom benefit classes a lot less useful. We want to create slightly
altered versions of PercentageDiscounts with different values, and can't,
because we can only ever create one benefit with the custom class.

I don't see how removing the constraint could cause a problem.

Closes #685.