### PR TITLE
Range.all_products can return duplicates - ensure it doesn't

### DIFF
--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -954,7 +954,7 @@ class AbstractRange(models.Model):
             Q(id__in=self._included_product_ids()) |
             Q(product_class_id__in=self._class_ids()) |
             Q(productcategory__category_id__in=self._category_ids())
-        ).exclude(id__in=self._excluded_product_ids())
+        ).exclude(id__in=self._excluded_product_ids()).distinct()
 
     @property
     def is_editable(self):


### PR DESCRIPTION
`Range.all_products` does a few OR joins on ManytoMany relationships. Because of the OUTER JOINs that are generated by this query, it is possible to end up with duplicates in the resulting queryset.

To reproduce, create a range which has only one product (which has been added using its SKU rather than by applying a category to the range). When the range is saved, the product will appear three (or four) times in the queryset returned by `all_products`.

This patch just adds a `distinct()` to the end of the query to ensure that this doesn't happen.