### PR TITLE
Revert use of safe template filter in product alert email templates

### DIFF
--- a/src/oscar/templates/oscar/customer/alerts/emails/alert_body.txt
+++ b/src/oscar/templates/oscar/customer/alerts/emails/alert_body.txt
@@ -1,5 +1,5 @@
-{% load i18n %}{% autoescape off %}{% if alert.user and alert.user.get_short_name %}{% blocktrans with name=alert.user.get_short_name %}Dear {{ name }},{% endblocktrans %}{% else %}{% trans "Hello," %}{% endif %}
-{% blocktrans with title=alert.product.get_title path=alert.product.get_absolute_url %}
+{% load i18n %}{% if alert.user and alert.user.get_short_name %}{% blocktrans with name=alert.user.get_short_name %}Dear {{ name }},{% endblocktrans %}{% else %}{% trans "Hello," %}{% endif %}
+{% blocktrans with title=alert.product.get_title|safe path=alert.product.get_absolute_url %}
 We are happy to inform you that our product '{{ title }}' is back in stock:
 http://{{ site }}{{ path }}
 {% endblocktrans %}{% if hurry %}{% blocktrans with product_url=product_url %}
@@ -11,4 +11,3 @@ receive any further email regarding this product.
 Thanks for your interest,
 The {{ site_name }} Team
 {% endblocktrans %}
-{% endautoescape %}

--- a/src/oscar/templates/oscar/customer/alerts/emails/alert_body.txt
+++ b/src/oscar/templates/oscar/customer/alerts/emails/alert_body.txt
@@ -1,6 +1,6 @@
-{% load i18n %}{% if alert.user and alert.user.get_short_name %}{% blocktrans with name=alert.user.get_short_name %}Dear {{ name }},{% endblocktrans %}{% else %}{% trans "Hello," %}{% endif %}
-{% blocktrans with product=alert.product path=alert.product.get_absolute_url %}
-We are happy to inform you that our product '{{ product|safe }}' is back in stock:
+{% load i18n %}{% autoescape off %}{% if alert.user and alert.user.get_short_name %}{% blocktrans with name=alert.user.get_short_name %}Dear {{ name }},{% endblocktrans %}{% else %}{% trans "Hello," %}{% endif %}
+{% blocktrans with title=alert.product.get_title path=alert.product.get_absolute_url %}
+We are happy to inform you that our product '{{ title }}' is back in stock:
 http://{{ site }}{{ path }}
 {% endblocktrans %}{% if hurry %}{% blocktrans with product_url=product_url %}
 Beware that the amount of items in stock is limited. Be quick or someone might get there first.
@@ -11,3 +11,4 @@ receive any further email regarding this product.
 Thanks for your interest,
 The {{ site_name }} Team
 {% endblocktrans %}
+{% endautoescape %}

--- a/src/oscar/templates/oscar/customer/alerts/emails/alert_subject.txt
+++ b/src/oscar/templates/oscar/customer/alerts/emails/alert_subject.txt
@@ -1,1 +1,1 @@
-{% load i18n %}{% autoescape off %}{% blocktrans with title=alert.product.get_title  %}{{ title }} is back in stock{% endblocktrans %}{% endautoescape %}
+{% load i18n %}{% blocktrans with title=alert.product.get_title|safe  %}{{ title }} is back in stock{% endblocktrans %}

--- a/src/oscar/templates/oscar/customer/alerts/emails/alert_subject.txt
+++ b/src/oscar/templates/oscar/customer/alerts/emails/alert_subject.txt
@@ -1,1 +1,1 @@
-{% load i18n %}{% blocktrans with title=alert.product.get_title  %}{{ title|safe }} is back in stock{% endblocktrans %}
+{% load i18n %}{% autoescape off %}{% blocktrans with title=alert.product.get_title  %}{{ title }} is back in stock{% endblocktrans %}{% endautoescape %}

--- a/src/oscar/templates/oscar/customer/alerts/emails/confirmation_body.txt
+++ b/src/oscar/templates/oscar/customer/alerts/emails/confirmation_body.txt
@@ -1,7 +1,7 @@
-{% load i18n %}{% blocktrans with product=alert.product domain=site.domain confirm_path=alert.get_confirm_url cancel_path=alert.get_cancel_url %}Hello,
+{% load i18n %}{% autoescape off %}{% blocktrans with title=alert.product.get_title domain=site.domain confirm_path=alert.get_confirm_url cancel_path=alert.get_cancel_url %}Hello,
 
 Somebody (hopefully you) has requested an email alert when
-'{{ product|safe }}' is back in stock.  Please click the following link
+'{{ title }}' is back in stock.  Please click the following link
 to confirm:
 http://{{ domain }}{{ confirm_path }}
 
@@ -11,3 +11,4 @@ http://{{ domain }}{{ cancel_path }}
 Thanks for your interest,
 The {{ site }} Team
 {% endblocktrans %}
+{% endautoescape %}

--- a/src/oscar/templates/oscar/customer/alerts/emails/confirmation_body.txt
+++ b/src/oscar/templates/oscar/customer/alerts/emails/confirmation_body.txt
@@ -1,4 +1,4 @@
-{% load i18n %}{% autoescape off %}{% blocktrans with title=alert.product.get_title domain=site.domain confirm_path=alert.get_confirm_url cancel_path=alert.get_cancel_url %}Hello,
+{% load i18n %}{% blocktrans with title=alert.product.get_title|safe domain=site.domain confirm_path=alert.get_confirm_url cancel_path=alert.get_cancel_url %}Hello,
 
 Somebody (hopefully you) has requested an email alert when
 '{{ title }}' is back in stock.  Please click the following link
@@ -11,4 +11,3 @@ http://{{ domain }}{{ cancel_path }}
 Thanks for your interest,
 The {{ site }} Team
 {% endblocktrans %}
-{% endautoescape %}

--- a/src/oscar/templates/oscar/customer/alerts/emails/confirmation_subject.txt
+++ b/src/oscar/templates/oscar/customer/alerts/emails/confirmation_subject.txt
@@ -1,1 +1,1 @@
-{% load i18n %}{% blocktrans %}Confirmation required for stock alert{% endblocktrans %}
+{% load i18n %}{% autoescape off %}{% blocktrans %}Confirmation required for stock alert{% endblocktrans %}{% endautoescape %}

--- a/src/oscar/templates/oscar/customer/alerts/emails/confirmation_subject.txt
+++ b/src/oscar/templates/oscar/customer/alerts/emails/confirmation_subject.txt
@@ -1,1 +1,1 @@
-{% load i18n %}{% autoescape off %}{% blocktrans %}Confirmation required for stock alert{% endblocktrans %}{% endautoescape %}
+{% load i18n %}{% blocktrans %}Confirmation required for stock alert{% endblocktrans %}


### PR DESCRIPTION
1b549d1 made product titles disappear from the product alert emails because they use the `safe` filter inside `{% blocktrans %}`.

From the [Django docs](https://docs.djangoproject.com/en/1.9/topics/i18n/translation/#blocktrans-template-tag):
> To translate a template expression – say, accessing
> object attributes or using template filters – you need to bind the expression
> to a local variable for use within the translation block.

The templates in question are txt emails so I have used `{% autoescape off %}`
on the whole content as any escaping will be unwelcome and of no benefit. An
alternative would be `{% blocktrans title=alert.product.get_title|safe %}`

Note, I have also standardised on the use of `Product.get_title` in these
templates as that seems to be the more common than using `Product.__str__`?