### PR TITLE
Wrap Category.full_name and Category.full_slug properties with lru_cache

### DIFF
--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -16,6 +16,7 @@ from django.db.models import Count, Sum
 from django.utils import six
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.functional import cached_property
+from django.utils.lru_cache import lru_cache
 from django.utils.html import strip_tags
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
@@ -100,8 +101,8 @@ class AbstractCategory(MP_Node):
     def __str__(self):
         return self.full_name
 
-    @property
-    def full_name(self):
+    @lru_cache(maxsize=256)
+    def _get_full_name(self):
         """
         Returns a string representation of the category and it's ancestors,
         e.g. 'Books > Non-fiction > Essential programming'.
@@ -114,7 +115,11 @@ class AbstractCategory(MP_Node):
         return self._full_name_separator.join(names)
 
     @property
-    def full_slug(self):
+    def full_name(self):
+        return self._get_full_name()
+
+    @lru_cache(maxsize=256)
+    def _get_full_slug(self):
         """
         Returns a string of this category's slug concatenated with the slugs
         of it's ancestors, e.g. 'books/non-fiction/essential-programming'.
@@ -125,6 +130,10 @@ class AbstractCategory(MP_Node):
         """
         slugs = [category.slug for category in self.get_ancestors_and_self()]
         return self._slug_separator.join(slugs)
+
+    @property
+    def full_slug(self):
+        return self._get_full_slug()
 
     def generate_slug(self):
         """
@@ -168,6 +177,9 @@ class AbstractCategory(MP_Node):
             # for that, we need to wait until the instance is saved. We
             # update the slug and save again if necessary.
             self.ensure_slug_uniqueness()
+        # Invalidate fulL_name and full_slug cache
+        self._get_full_name.cache_clear()
+        self._get_full_slug.cache_clear()
 
     def get_ancestors_and_self(self):
         """


### PR DESCRIPTION
This is supposed to help mitigate some performance issues. Fix for https://github.com/django-oscar/django-oscar/issues/1910 and partial fix for https://github.com/django-oscar/django-oscar/issues/1828

I think we might want to add a setting: `CATEGORY_LRU_MAXSIZE` or something instead of hard coding 256 in.

Cache invalidation is handled in `Category.save()`. 

@mvantellingen Could you please test this and provide some feedback?