### PR TITLE
exclude current product from recently viewed

### DIFF
--- a/src/oscar/templates/oscar/catalogue/detail.html
+++ b/src/oscar/templates/oscar/catalogue/detail.html
@@ -191,7 +191,7 @@
         {% endif %}
     {% endwith %}
 
-    {% recently_viewed_products %}
+    {% recently_viewed_products current_product=product %}
 
 </article><!-- End of product page -->
 {% endblock content %}

--- a/src/oscar/templatetags/history_tags.py
+++ b/src/oscar/templatetags/history_tags.py
@@ -14,12 +14,14 @@ register = template.Library()
 
 @register.inclusion_tag('customer/history/recently_viewed_products.html',
                         takes_context=True)
-def recently_viewed_products(context):
+def recently_viewed_products(context, current_product=None):
     """
     Inclusion tag listing the most recently viewed products
     """
     request = context['request']
     products = history.get(request)
+    if current_product:
+        products = [p for p in products if p != current_product]
     return {'products': products,
             'request': request}
 


### PR DESCRIPTION
I found it a bit weird viewing a product detail page and having the same product listed underneath as recently viewed. A change to the templatetag makes it possible to exclude it.