### PR TITLE
Fix IntegrityError in User._migrate_alerts_to_user()

### DIFF
--- a/src/oscar/apps/customer/abstract_models.py
+++ b/src/oscar/apps/customer/abstract_models.py
@@ -94,7 +94,7 @@ class AbstractUser(auth_models.AbstractBaseUser,
         ProductAlert = self.alerts.model
         alerts = ProductAlert.objects.filter(
             email=self.email, status=ProductAlert.ACTIVE)
-        alerts.update(user=self, key=None, email=None)
+        alerts.update(user=self, key='', email='')
 
     def save(self, *args, **kwargs):
         super(AbstractUser, self).save(*args, **kwargs)

--- a/src/oscar/test/factories/customer.py
+++ b/src/oscar/test/factories/customer.py
@@ -1,8 +1,18 @@
 import factory
 
 from oscar.core.compat import get_user_model
+from oscar.core.loading import get_model
 
-__all__ = ['UserFactory']
+__all__ = ['ProductAlertFactory', 'UserFactory']
+
+
+class ProductAlertFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = get_model('customer', 'ProductAlert')
+
+    product = factory.SubFactory('oscar.test.factories.ProductFactory')
+    user = factory.SubFactory('oscar.test.factories.customer.UserFactory')
+    status = Meta.model.ACTIVE
 
 
 class UserFactory(factory.DjangoModelFactory):

--- a/tests/integration/customer/test_custom_user_model.py
+++ b/tests/integration/customer/test_custom_user_model.py
@@ -1,7 +1,8 @@
 from django.test import TestCase
 
 from oscar.apps.customer.forms import ProfileForm
-from oscar.core.compat import get_user_model, existing_user_fields
+from oscar.core.compat import existing_user_fields, get_user_model
+from oscar.test.factories.customer import ProductAlertFactory, UserFactory
 
 
 class TestACustomUserModel(TestCase):
@@ -23,3 +24,9 @@ class TestACustomUserModel(TestCase):
         form = ProfileForm(self.user_klass())
         expected_fields = set(['first_name', 'last_name', 'email'])
         self.assertTrue(expected_fields == set(form.fields))
+
+    def test_migrate_alerts_to_user(self):
+        user = UserFactory(email='a@a.com')
+        ProductAlertFactory(email=user.email)
+        user._migrate_alerts_to_user()
+        assert user.alerts.count() == 1


### PR DESCRIPTION
Set ProductAlert.email and ProductAlert.key to '' instead of None since
the fields are non nullable.


Need to add some tests