### PR TITLE
Add range to ConditionFactory

### DIFF
--- a/src/oscar/test/factories/offer.py
+++ b/src/oscar/test/factories/offer.py
@@ -39,6 +39,7 @@ class BenefitFactory(factory.DjangoModelFactory):
 class ConditionFactory(factory.DjangoModelFactory):
     type = get_model('offer', 'Condition').COUNT
     value = 10
+    range = factory.SubFactory(RangeFactory)
 
     class Meta:
         model = get_model('offer', 'Condition')


### PR DESCRIPTION
In our project we get the products like this ``....condition.range.all_products()``. The ``Condition`` model has the ``range`` attribute which isn't added in the ``ConditionFactory``.