### PR TITLE
Add default ordering for Partner instances

### DIFF
--- a/docs/source/releases/v1.2.rst
+++ b/docs/source/releases/v1.2.rst
@@ -49,6 +49,7 @@ What's new in Oscar 1.2?
 Minor changes
 ~~~~~~~~~~~~~
  - Fix missing page_url field in the promotions form (`#1816`_)
+ - `Partner` instances got a default ordering by name.
 
 
 .. _incompatible_in_1.2:

--- a/src/oscar/apps/partner/abstract_models.py
+++ b/src/oscar/apps/partner/abstract_models.py
@@ -68,6 +68,7 @@ class AbstractPartner(models.Model):
     class Meta:
         abstract = True
         app_label = 'partner'
+        ordering = ('name', 'code')
         permissions = (('dashboard_access', 'Can access dashboard'), )
         verbose_name = _('Fulfillment partner')
         verbose_name_plural = _('Fulfillment partners')

--- a/src/oscar/apps/partner/migrations/0004_auto_20160107_1755.py
+++ b/src/oscar/apps/partner/migrations/0004_auto_20160107_1755.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('partner', '0003_auto_20150604_1450'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='partner',
+            options={'ordering': ('name', 'code'), 'verbose_name': 'Fulfillment partner', 'verbose_name_plural': 'Fulfillment partners', 'permissions': (('dashboard_access', 'Can access dashboard'),)},
+        ),
+    ]


### PR DESCRIPTION
I was toying with the partner dashboard when I realized the order isn't 
consistent. So I fixed it.

It probably would make sense to go through all Oscar models and check that
they have an ordering defined. It should make sense for most of them.