### PR TITLE
address summary should use printable name

### DIFF
--- a/src/oscar/apps/address/abstract_models.py
+++ b/src/oscar/apps/address/abstract_models.py
@@ -373,7 +373,7 @@ class AbstractAddress(models.Model):
             fields = [self.salutation] + fields
         fields = [f.strip() for f in fields if f]
         try:
-            fields.append(self.country.name)
+            fields.append(self.country.printable_name)
         except exceptions.ObjectDoesNotExist:
             pass
         return fields


### PR DESCRIPTION
Currently when the shipping address is displayed in e.g. the checkout complete 'thank you' page it uses the full official name of the country.

For UK this comes out as "United Kingdom of Great Britain and Northern Ireland".

This looks a bit weird, arguably the address summary should use `printable_name` instead, which in this case would read "United Kingdom"