### PR TITLE
Enforce order of basket, order, wishlist lines

### DIFF
--- a/docs/source/releases/v1.2.rst
+++ b/docs/source/releases/v1.2.rst
@@ -49,6 +49,9 @@ What's new in Oscar 1.2?
 Minor changes
 ~~~~~~~~~~~~~
  - Fix missing page_url field in the promotions form (`#1816`_)
+ - The order of basket, order and wishlist lines in now guaranteed
+   to be in the order of creation. Previously, this wasn't guaranteed,
+   but still almost always the case.
 
 
 .. _incompatible_in_1.2:

--- a/src/oscar/apps/basket/abstract_models.py
+++ b/src/oscar/apps/basket/abstract_models.py
@@ -562,6 +562,22 @@ class AbstractBasket(models.Model):
 class AbstractLine(models.Model):
     """
     A line of a basket (product and a quantity)
+
+    Common approaches on ordering basket lines:
+    a) First added at top. That's the history-like approach; new items are
+       added to the bottom of the list. Changing quantities doesn't impact
+       position.
+       Oscar does this by default. It just sorts by Line.pk, which is
+       guaranteed to increment after each creation.
+    b) Last modified at top. That means items move to the top when you add
+       another one, and new items are added to the top as well.
+       Amazon mostly does this, but doesn't change the position when you
+       update the quantity in the basket view.
+       To get this behaviour, add a date_updated field, change
+       Meta.ordering and optionally do something similar on wishlist lines.
+       Order lines should already be created in the order of the basket lines,
+       and are sorted by their primary key, so no changes should be necessary
+       there.
     """
     basket = models.ForeignKey('basket.Basket', related_name='lines',
                                verbose_name=_("Basket"))
@@ -607,6 +623,8 @@ class AbstractLine(models.Model):
     class Meta:
         abstract = True
         app_label = 'basket'
+        # Enforce sorting by order of creation.
+        ordering = ['date_created', 'pk']
         unique_together = ("basket", "line_reference")
         verbose_name = _('Basket line')
         verbose_name_plural = _('Basket lines')

--- a/src/oscar/apps/basket/migrations/0006_auto_20160111_1108.py
+++ b/src/oscar/apps/basket/migrations/0006_auto_20160111_1108.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('basket', '0005_auto_20150604_1450'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='line',
+            options={'ordering': ['date_created', 'pk'], 'verbose_name': 'Basket line', 'verbose_name_plural': 'Basket lines'},
+        ),
+    ]

--- a/src/oscar/apps/order/abstract_models.py
+++ b/src/oscar/apps/order/abstract_models.py
@@ -502,6 +502,8 @@ class AbstractLine(models.Model):
     class Meta:
         abstract = True
         app_label = 'order'
+        # Enforce sorting in order of creation.
+        ordering = ['pk']
         verbose_name = _("Order Line")
         verbose_name_plural = _("Order Lines")
 

--- a/src/oscar/apps/order/migrations/0004_auto_20160111_1108.py
+++ b/src/oscar/apps/order/migrations/0004_auto_20160111_1108.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('order', '0003_auto_20150113_1629'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='line',
+            options={'ordering': ['pk'], 'verbose_name': 'Order Line', 'verbose_name_plural': 'Order Lines'},
+        ),
+    ]

--- a/src/oscar/apps/wishlists/abstract_models.py
+++ b/src/oscar/apps/wishlists/abstract_models.py
@@ -133,5 +133,7 @@ class AbstractLine(models.Model):
     class Meta:
         abstract = True
         app_label = 'wishlists'
+        # Enforce sorting by order of creation.
+        ordering = ['pk']
         unique_together = (('wishlist', 'product'), )
         verbose_name = _('Wish list line')

--- a/src/oscar/apps/wishlists/migrations/0002_auto_20160111_1108.py
+++ b/src/oscar/apps/wishlists/migrations/0002_auto_20160111_1108.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wishlists', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='line',
+            options={'ordering': ['pk'], 'verbose_name': 'Wish list line'},
+        ),
+    ]


### PR DESCRIPTION
When working on an Oscar project, I noted that the order of the basket lines
was different from the order of the order lines created from that basket. This
made me investigate how exactly Oscar approaches this.

It turned out that Oscar had no notion of ordering those lines. That means,
the order of them was determined by the database. That will work in most
cases, because at least PostgreSQL tends to return them in the order of
creation - but this is not guaranteed. From 
http://www.postgresql.org/docs/9.1/static/queries-order.html:

> If sorting is not chosen, the rows will be returned in an unspecified
> order. The actual order in that case will depend on the scan and join
> plan types and the order on disk, but it must not be relied on. A
> particular output ordering can only be guaranteed if the sort step is
> explicitly chosen.

Luckily, Django's AutoIntegerField guarantees that the primary keys are 
incremented. So to get the behaviour we most likely want, we just enforce
ordering by primary keys. I also documented how one would go about switching
to an Amazon-style handling. Implementing that is left as an exercise to the
reader.