### PR TITLE
Use option name instead of slug as field label

### DIFF
--- a/docs/source/releases/v1.5.rst
+++ b/docs/source/releases/v1.5.rst
@@ -55,6 +55,17 @@ Minor changes
    addresses tracked separately: billing address in `UserAddress.num_orders_as_billing_address` field
    and shipping address in `UserAddress.num_order_as_shipping_address` accordingly.
 
+.. _incompatible_in_1.5:
+
+Backwards incompatible changes in Oscar 1.5
+-------------------------------------------
+
+- `SimpleAddToBasketForm` doesn't override the quantity field any
+  more. Instead, it just hides the field declared by AddToBasketForm
+  and sets the quantity to one. This means `SimpleAddToBasketForm`
+  doesn't need to be overridden for most cases, but please check
+  things still work as expected for you if you have customized it.
+
 
 Dependency changes
 ------------------

--- a/src/oscar/apps/basket/forms.py
+++ b/src/oscar/apps/basket/forms.py
@@ -199,8 +199,8 @@ class AddToBasketForm(forms.Form):
         This is designed to be overridden so that specific widgets can be used
         for certain types of options.
         """
-        kwargs = {'required': option.is_required}
-        self.fields[option.code] = forms.CharField(**kwargs)
+        self.fields[option.code] = forms.CharField(
+            label=option.name, required=option.is_required)
 
     # Cleaning
 

--- a/src/oscar/apps/basket/forms.py
+++ b/src/oscar/apps/basket/forms.py
@@ -283,6 +283,13 @@ class SimpleAddToBasketForm(AddToBasketForm):
     """
     Simplified version of the add to basket form where the quantity is
     defaulted to 1 and rendered in a hidden widget
+
+    Most of the time, you won't need to override this class. Just change
+    AddToBasketForm to change behaviour in both forms at once.
     """
-    quantity = forms.IntegerField(
-        initial=1, min_value=1, widget=forms.HiddenInput, label=_('Quantity'))
+
+    def __init__(self, *args, **kwargs):
+        super(SimpleAddToBasketForm, self).__init__(*args, **kwargs)
+        if 'quantity' in self.fields:
+            self.fields['quantity'].initial = 1
+            self.fields['quantity'].widget = forms.HiddenInput()


### PR DESCRIPTION
When building the AddToBasketForm for a product with options, Oscar didn't
specify a label for the form field. Hence the field name was used, which is
the rather human-unfriendly slug. Options have a name field, so we can just
use that.
