### PR TITLE
Remove Django 1.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,19 +32,15 @@ env:
         - PIP_WHEEL_DIR=$HOME/.cache/pip/wheels
         - PIP_FIND_LINKS=file://$HOME/.cache/pip/wheels
     matrix:
-        - DJANGO=Django==1.7.11
-        - DJANGO=Django==1.8.10
+        - DJANGO=Django==1.8.11
         - DJANGO=Django==1.9.3
 
 
 matrix:
     exclude:
-        - python: 3.2
-          env: "DJANGO=Django==1.9.3"
+        # Python 3.3 is not supported by Django 1.9
         - python: 3.3
           env: "DJANGO=Django==1.9.3"
-        - python: 3.5
-          env: "DJANGO=Django==1.7.11"
 
 before_install:
     - pip install codecov

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(name='django-oscar',
       packages=find_packages('src'),
       include_package_data=True,
       install_requires=[
-          'django>=1.7.8,<1.10',
+          'django>=1.8.8,<1.10',
           # PIL is required for image fields, Pillow is the "friendly" PIL fork
           'pillow>=1.7.8',
           # We use the ModelFormSetView from django-extra-views for the basket
@@ -67,7 +67,6 @@ setup(name='django-oscar',
           'Development Status :: 5 - Production/Stable',
           'Environment :: Web Environment',
           'Framework :: Django',
-          'Framework :: Django :: 1.7',
           'Framework :: Django :: 1.8',
           'Framework :: Django :: 1.9',
           'Intended Audience :: Developers',

--- a/sites/sandbox/apps/user/models.py
+++ b/sites/sandbox/apps/user/models.py
@@ -3,6 +3,8 @@ Sample user/profile models for testing.  These aren't enabled by default in the
 sandbox
 """
 
+from django.contrib.auth.models import (
+    AbstractUser, BaseUserManager, AbstractBaseUser)
 from django.db import models
 from django.utils import timezone
 from django.utils.encoding import python_2_unicode_compatible
@@ -25,49 +27,43 @@ class Profile(models.Model):
     age = models.PositiveIntegerField(verbose_name='Age')
 
 
-# A simple extension of the core User model for Django 1.5
-try:
-    from django.contrib.auth.models import (
-        AbstractUser, BaseUserManager, AbstractBaseUser)
-except ImportError:
-    pass
-else:
+# A simple extension of the core User model for Django 1.5+
+class ExtendedUserModel(AbstractUser):
+    twitter_username = models.CharField(max_length=255, unique=True)
 
-    class ExtendedUserModel(AbstractUser):
-        twitter_username = models.CharField(max_length=255, unique=True)
 
-    class CustomUserManager(BaseUserManager):
+class CustomUserManager(BaseUserManager):
 
-        def create_user(self, email, password=None):
-            now = timezone.now()
-            email = BaseUserManager.normalize_email(email)
-            user = self.model(email=email, last_login=now)
-            user.set_password(password)
-            user.save(using=self._db)
-            return user
+    def create_user(self, email, password=None):
+        now = timezone.now()
+        email = BaseUserManager.normalize_email(email)
+        user = self.model(email=email, last_login=now)
+        user.set_password(password)
+        user.save(using=self._db)
+        return user
 
-        def create_superuser(self, email, password):
-            return self.create_user(email, password)
+    def create_superuser(self, email, password):
+        return self.create_user(email, password)
 
-    # A user model which doesn't extend AbstractUser
-    @python_2_unicode_compatible
-    class CustomUserModel(AbstractBaseUser):
-        name = models.CharField(max_length=255, blank=True)
-        email = models.EmailField(unique=True)
-        twitter_username = models.CharField(max_length=255, unique=True)
+# A user model which doesn't extend AbstractUser
+@python_2_unicode_compatible
+class CustomUserModel(AbstractBaseUser):
+    name = models.CharField(max_length=255, blank=True)
+    email = models.EmailField(unique=True)
+    twitter_username = models.CharField(max_length=255, unique=True)
 
-        USERNAME_FIELD = 'email'
+    USERNAME_FIELD = 'email'
 
-        objects = CustomUserManager()
+    objects = CustomUserManager()
 
-        def __str__(self):
-            return self.email
+    def __str__(self):
+        return self.email
 
-        def get_full_name(self):
-            return self.name
+    def get_full_name(self):
+        return self.name
 
-        get_short_name = get_full_name
+    get_short_name = get_full_name
 
-    # A simple extension of the core Oscar User model
-    class ExtendedOscarUserModel(abstract_models.AbstractUser):
-        twitter_username = models.CharField(max_length=255, unique=True)
+# A simple extension of the core Oscar User model
+class ExtendedOscarUserModel(abstract_models.AbstractUser):
+    twitter_username = models.CharField(max_length=255, unique=True)

--- a/src/oscar/apps/catalogue/reviews/abstract_models.py
+++ b/src/oscar/apps/catalogue/reviews/abstract_models.py
@@ -43,8 +43,7 @@ class AbstractProductReview(models.Model):
     name = models.CharField(
         pgettext_lazy(u"Anonymous reviewer name", u"Name"),
         max_length=255, blank=True)
-    # TODO Remove the max_length kwarg when support for Django 1.7 is dropped
-    email = models.EmailField(_("Email"), max_length=75, blank=True)
+    email = models.EmailField(_("Email"), blank=True)
     homepage = models.URLField(_("URL"), blank=True)
 
     FOR_MODERATION, APPROVED, REJECTED = 0, 1, 2

--- a/src/oscar/apps/customer/abstract_models.py
+++ b/src/oscar/apps/customer/abstract_models.py
@@ -312,9 +312,7 @@ class AbstractProductAlert(models.Model):
     user = models.ForeignKey(AUTH_USER_MODEL, db_index=True, blank=True,
                              null=True, related_name="alerts",
                              verbose_name=_('User'))
-    # TODO Remove the max_length kwarg when support for Django 1.7 is dropped
-    email = models.EmailField(_("Email"), db_index=True, blank=True,
-                              max_length=75)
+    email = models.EmailField(_("Email"), db_index=True, blank=True)
 
     # This key are used to confirm and cancel alerts for anon users
     key = models.CharField(_("Key"), max_length=128, blank=True, db_index=True)

--- a/src/oscar/apps/order/abstract_models.py
+++ b/src/oscar/apps/order/abstract_models.py
@@ -80,9 +80,7 @@ class AbstractOrder(models.Model):
 
     # Use this field to indicate that an order is on hold / awaiting payment
     status = models.CharField(_("Status"), max_length=100, blank=True)
-    # TODO Remove the max_length kwarg when support for Django 1.7 is dropped
-    guest_email = models.EmailField(_("Guest email address"), max_length=75,
-                                    blank=True)
+    guest_email = models.EmailField(_("Guest email address"), blank=True)
 
     # Index added to this field for reporting
     date_placed = models.DateTimeField(db_index=True)

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,11 @@ max-complexity = 10
 ignore = W503
 
 [tox]
-envlist = {py27,py33,py34}-{1.7,1.8}
+envlist = {py27,py33,py34,py35}-{1.8,1.9}
 
 [testenv]
 commands = python runtests.py
 deps = 
     -r{toxinidir}/requirements.txt
-    1.7: django==1.7.8
-    1.8: django==1.8.1
+    1.8: django==1.8.8
+    1.9: django==1.9.1


### PR DESCRIPTION
We only support two versions of Django. That policy might change given that
Django has started doing LTS releases. But for now, it only makes sense to
remove Django 1.7 support.