### PR TITLE
Let error pages inherit from layout.html, not base.html

### DIFF
--- a/src/oscar/templates/oscar/error.html
+++ b/src/oscar/templates/oscar/error.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "layout.html" %}
 {% load i18n %}
 
 {% block layout %}


### PR DESCRIPTION
`layout.html` is the template that pulls in all the pretty Bootstrap bits and other styling. Error pages previously inherited just from `base.html`, which made them profoundly ugly. Let them inherit from `layout.html` instead for a more professional overall experience.