### PR TITLE
Use a datepicker widget in some more forms in the dashboard.

### DIFF
--- a/src/oscar/apps/dashboard/orders/forms.py
+++ b/src/oscar/apps/dashboard/orders/forms.py
@@ -18,9 +18,11 @@ SourceType = get_model('payment', 'SourceType')
 
 class OrderStatsForm(forms.Form):
     date_from = forms.DateField(
-        required=False, label=pgettext_lazy(u"start date", u"From"))
+        required=False, label=pgettext_lazy(u"start date", u"From"),
+        widget=DatePickerInput)
     date_to = forms.DateField(
-        required=False, label=pgettext_lazy(u"end date", u"To"))
+        required=False, label=pgettext_lazy(u"end date", u"To"),
+        widget=DatePickerInput)
 
     _filters = _description = None
 

--- a/src/oscar/apps/dashboard/reports/forms.py
+++ b/src/oscar/apps/dashboard/reports/forms.py
@@ -2,6 +2,8 @@ from django import forms
 from django.utils.translation import ugettext_lazy as _
 
 from oscar.core.loading import get_class
+from oscar.forms.widgets import DatePickerInput
+
 
 GeneratorRepository = get_class('dashboard.reports.utils',
                                 'GeneratorRepository')
@@ -20,11 +22,13 @@ class ReportForm(forms.Form):
                                                 " reports use the selected"
                                                 " date range"))
 
-    date_from = forms.DateField(label=_("Date from"), required=False)
+    date_from = forms.DateField(label=_("Date from"), required=False,
+                                widget=DatePickerInput)
     date_to = forms.DateField(label=_("Date to"),
                               help_text=_("The report is inclusive of this"
                                           " date"),
-                              required=False)
+                              required=False,
+                              widget=DatePickerInput)
     download = forms.BooleanField(label=_("Download"), required=False)
 
     def clean(self):

--- a/src/oscar/static/oscar/css/dashboard.css
+++ b/src/oscar/static/oscar/css/dashboard.css
@@ -5638,6 +5638,9 @@ form.flat {
 .form-inline .select2-container.form-control {
   display: inline-block;
 }
+.form-inline .form-group .form-inline {
+  display: inline-block;
+}
 .form-inline {
   margin-bottom: 0;
 }

--- a/src/oscar/static/oscar/less/dashboard/forms.less
+++ b/src/oscar/static/oscar/less/dashboard/forms.less
@@ -32,6 +32,9 @@ form.flat {
   .select2-container.form-control {
       display: inline-block;
   }
+  .form-group .form-inline {
+      display: inline-block;
+  }
 }
 
 .form-inline {
@@ -168,4 +171,3 @@ textarea {
     width: 140px;
   }
 }
-


### PR DESCRIPTION
Currently the date range inputs on the Reports and Fulfilment Statistics pages on the dashboard don't have a datepicker widget - the user has to manually enter the date in YYYY-MM-DD format with no cues that this is the format they should use.

This patch adds the datepicker widget to these fields. It also adds a small styling hack so that these display inline correctly - otherwise the label sits on its own line.