### PR TITLE
Augment hidden features (take two)

### DIFF
--- a/src/oscar/apps/customer/alerts/app.py
+++ b/src/oscar/apps/customer/alerts/app.py
@@ -1,12 +1,12 @@
 # vim: ts=4:sw=4:expandtabs
 
-__author__ = 'zmott@fantasyflightgames.com'
-
 from django.conf.urls import url
 from django.contrib.auth.decorators import login_required
 
 from oscar.core.application import Application
 from oscar.core.loading import get_class
+
+__author__ = 'zmott@fantasyflightgames.com'
 
 
 class AlertsApplication(Application):

--- a/src/oscar/apps/customer/alerts/app.py
+++ b/src/oscar/apps/customer/alerts/app.py
@@ -1,0 +1,48 @@
+# vim: ts=4:sw=4:expandtabs
+
+__author__ = 'zmott@fantasyflightgames.com'
+
+from django.conf.urls import url
+from django.contrib.auth.decorators import login_required
+
+from oscar.core.application import Application
+from oscar.core.loading import get_class
+
+
+class AlertsApplication(Application):
+    name = None
+    hideable_feature_name = 'alerts'
+
+    alert_list_view = get_class('customer.alerts.views',
+                                'ProductAlertListView')
+    alert_create_view = get_class('customer.alerts.views',
+                                  'ProductAlertCreateView')
+    alert_confirm_view = get_class('customer.alerts.views',
+                                   'ProductAlertConfirmView')
+    alert_cancel_view = get_class('customer.alerts.views',
+                                  'ProductAlertCancelView')
+
+    def get_urls(self):
+        # Alerts can be setup by anonymous users: some views
+        # do not require login
+        urls = [
+            url(r'^$',
+                login_required(self.alert_list_view.as_view()),
+                name='alerts-list'),
+            url(r'^create/(?P<pk>\d+)/$',
+                self.alert_create_view.as_view(),
+                name='alert-create'),
+            url(r'^confirm/(?P<key>[a-z0-9]+)/$',
+                self.alert_confirm_view.as_view(),
+                name='alerts-confirm'),
+            url(r'^cancel/key/(?P<key>[a-z0-9]+)/$',
+                self.alert_cancel_view.as_view(),
+                name='alerts-cancel-by-key'),
+            url(r'^cancel/(?P<pk>[a-z0-9]+)/$',
+                login_required(self.alert_cancel_view.as_view()),
+                name='alerts-cancel-by-pk')
+        ]
+        return self.post_process_urls(urls)
+
+
+application = AlertsApplication()

--- a/src/oscar/apps/customer/app.py
+++ b/src/oscar/apps/customer/app.py
@@ -4,6 +4,7 @@ from django.views import generic
 
 from oscar.core.loading import get_class
 from oscar.core.application import Application
+from oscar.apps.customer.alerts.app import application as alerts_app
 from oscar.apps.customer.wishlists.app import application as wishlists_app
 
 
@@ -12,6 +13,7 @@ class CustomerApplication(Application):
 
     sub_applications = [
         (r'^wishlists/', wishlists_app),
+        (r'^alerts/', alerts_app),
     ]
 
     summary_view = get_class('customer.views', 'AccountSummaryView')
@@ -46,15 +48,6 @@ class CustomerApplication(Application):
                                          'UpdateView')
     notification_detail_view = get_class('customer.notifications.views',
                                          'DetailView')
-
-    alert_list_view = get_class('customer.alerts.views',
-                                'ProductAlertListView')
-    alert_create_view = get_class('customer.alerts.views',
-                                  'ProductAlertCreateView')
-    alert_confirm_view = get_class('customer.alerts.views',
-                                   'ProductAlertConfirmView')
-    alert_cancel_view = get_class('customer.alerts.views',
-                                  'ProductAlertCancelView')
 
     def get_urls(self):
         urls = [
@@ -134,25 +127,6 @@ class CustomerApplication(Application):
             url(r'^notifications/(?P<pk>\d+)/$',
                 login_required(self.notification_detail_view.as_view()),
                 name='notifications-detail'),
-
-            # Alerts
-            # Alerts can be setup by anonymous users: some views do not
-            # require login
-            url(r'^alerts/$',
-                login_required(self.alert_list_view.as_view()),
-                name='alerts-list'),
-            url(r'^alerts/create/(?P<pk>\d+)/$',
-                self.alert_create_view.as_view(),
-                name='alert-create'),
-            url(r'^alerts/confirm/(?P<key>[a-z0-9]+)/$',
-                self.alert_confirm_view.as_view(),
-                name='alerts-confirm'),
-            url(r'^alerts/cancel/key/(?P<key>[a-z0-9]+)/$',
-                self.alert_cancel_view.as_view(),
-                name='alerts-cancel-by-key'),
-            url(r'^alerts/cancel/(?P<pk>[a-z0-9]+)/$',
-                login_required(self.alert_cancel_view.as_view()),
-                name='alerts-cancel-by-pk'),
         ]
 
         for url_prefix, app in self.sub_applications:

--- a/src/oscar/apps/customer/wishlists/app.py
+++ b/src/oscar/apps/customer/wishlists/app.py
@@ -1,0 +1,78 @@
+# vim: ts=4:sw=4:expandtabs
+
+__author__ = 'zmott@fantasyflightgames.com'
+
+from django.conf.urls import url
+from django.contrib.auth.decorators import login_required
+
+from oscar.core.application import Application
+from oscar.core.loading import get_class
+
+
+class WishlistsApplication(Application):
+    name = None
+    hideable_feature_name = 'wishlists'
+
+    wishlists_add_product_view = get_class('customer.wishlists.views',
+                                           'WishListAddProduct')
+    wishlists_list_view = get_class('customer.wishlists.views',
+                                    'WishListListView')
+    wishlists_detail_view = get_class('customer.wishlists.views',
+                                      'WishListDetailView')
+    wishlists_create_view = get_class('customer.wishlists.views',
+                                      'WishListCreateView')
+    wishlists_create_with_product_view = get_class('customer.wishlists.views',
+                                                   'WishListCreateView')
+    wishlists_update_view = get_class('customer.wishlists.views',
+                                      'WishListUpdateView')
+    wishlists_delete_view = get_class('customer.wishlists.views',
+                                      'WishListDeleteView')
+    wishlists_remove_product_view = get_class('customer.wishlists.views',
+                                              'WishListRemoveProduct')
+    wishlists_move_product_to_another_view = get_class(
+        'customer.wishlists.views', 'WishListMoveProductToAnotherWishList')
+
+    def get_urls(self):
+        urls = [
+            url(r'^$',
+                login_required(self.wishlists_list_view.as_view()),
+                name='wishlists-list'),
+            url(r'^add/(?P<product_pk>\d+)/$',
+                login_required(self.wishlists_add_product_view.as_view()),
+                name='wishlists-add-product'),
+            url(r'^(?P<key>[a-z0-9]+)/add/(?P<product_pk>\d+)/',
+                login_required(self.wishlists_add_product_view.as_view()),
+                name='wishlists-add-product'),
+            url(r'^create/$',
+                login_required(self.wishlists_create_view.as_view()),
+                name='wishlists-create'),
+            url(r'^create/with-product/(?P<product_pk>\d+)/$',
+                login_required(self.wishlists_create_view.as_view()),
+                name='wishlists-create-with-product'),
+            # Wishlists can be publicly shared, no login required
+            url(r'^(?P<key>[a-z0-9]+)/$',
+                self.wishlists_detail_view.as_view(), name='wishlists-detail'),
+            url(r'^(?P<key>[a-z0-9]+)/update/$',
+                login_required(self.wishlists_update_view.as_view()),
+                name='wishlists-update'),
+            url(r'^(?P<key>[a-z0-9]+)/delete/$',
+                login_required(self.wishlists_delete_view.as_view()),
+                name='wishlists-delete'),
+            url(r'^(?P<key>[a-z0-9]+)/lines/(?P<line_pk>\d+)/delete/',
+                login_required(self.wishlists_remove_product_view.as_view()),
+                name='wishlists-remove-product'),
+            url(r'^(?P<key>[a-z0-9]+)/products/(?P<product_pk>\d+)/'
+                r'delete/',
+                login_required(self.wishlists_remove_product_view.as_view()),
+                name='wishlists-remove-product'),
+            url(r'^(?P<key>[a-z0-9]+)/lines/(?P<line_pk>\d+)/move-to/'
+                r'(?P<to_key>[a-z0-9]+)/$',
+                login_required(self.wishlists_move_product_to_another_view
+                               .as_view()),
+                name='wishlists-move-product-to-another')
+        ]
+
+        return self.post_process_urls(urls)
+
+
+application = WishlistsApplication()

--- a/src/oscar/apps/customer/wishlists/app.py
+++ b/src/oscar/apps/customer/wishlists/app.py
@@ -1,12 +1,12 @@
 # vim: ts=4:sw=4:expandtabs
 
-__author__ = 'zmott@fantasyflightgames.com'
-
 from django.conf.urls import url
 from django.contrib.auth.decorators import login_required
 
 from oscar.core.application import Application
 from oscar.core.loading import get_class
+
+__author__ = 'zmott@fantasyflightgames.com'
 
 
 class WishlistsApplication(Application):

--- a/src/oscar/apps/dashboard/users/app.py
+++ b/src/oscar/apps/dashboard/users/app.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url
 
 from oscar.core.application import Application
-from oscar.core.loading import get_class
+from oscar.core.loading import get_class, feature_hidden
 
 
 class UserManagementApplication(Application):
@@ -27,18 +27,20 @@ class UserManagementApplication(Application):
             url(r'^(?P<pk>-?\d+)/password-reset/$',
                 self.password_reset_view.as_view(),
                 name='user-password-reset'),
-
-            # Alerts
-            url(r'^alerts/$',
-                self.alert_list_view.as_view(),
-                name='user-alert-list'),
-            url(r'^alerts/(?P<pk>-?\d+)/delete/$',
-                self.alert_delete_view.as_view(),
-                name='user-alert-delete'),
-            url(r'^alerts/(?P<pk>-?\d+)/update/$',
-                self.alert_update_view.as_view(),
-                name='user-alert-update'),
         ]
+
+        if not feature_hidden('alerts'):
+            urls += [
+                url(r'^alerts/$',
+                    self.alert_list_view.as_view(),
+                    name='user-alert-list'),
+                url(r'^alerts/(?P<pk>-?\d+)/delete/$',
+                    self.alert_delete_view.as_view(),
+                    name='user-alert-delete'),
+                url(r'^alerts/(?P<pk>-?\d+)/update/$',
+                    self.alert_update_view.as_view(),
+                    name='user-alert-update'),
+            ]
         return self.post_process_urls(urls)
 
 

--- a/src/oscar/templates/oscar/catalogue/partials/add_to_basket_form.html
+++ b/src/oscar/templates/oscar/catalogue/partials/add_to_basket_form.html
@@ -16,16 +16,18 @@
         {% include "catalogue/partials/add_to_wishlist.html" %}
     {% endiffeature %}
 {% else %}
-    {% if has_active_alert %}
-        <p>{% trans "You have an active stock alert for this product." %}</p>
-    {% else %}
-        <form id="alert_form" method="post" action="{% url 'customer:alert-create' pk=product.id %}" class="add-to-basket">
-            {% csrf_token %}
-            <p>{% trans "You can get an email alert when this product is back in stock." %}</p>
-            {% include "partials/form_fields.html" with form=alert_form %}
-            <button type="submit" class="btn btn-lg btn-info btn-add-to-basket" data-loading-text="{% trans 'Submitting...' %}">{% trans "Notify me" %}</button>
-        </form>
-    {% endif %}
+    {% iffeature "alerts" %}
+        {% if has_active_alert %}
+            <p>{% trans "You have an active stock alert for this product." %}</p>
+        {% else %}
+            <form id="alert_form" method="post" action="{% url 'customer:alert-create' pk=product.id %}" class="add-to-basket">
+                {% csrf_token %}
+                <p>{% trans "You can get an email alert when this product is back in stock." %}</p>
+                {% include "partials/form_fields.html" with form=alert_form %}
+                <button type="submit" class="btn btn-lg btn-info btn-add-to-basket" data-loading-text="{% trans 'Submitting...' %}">{% trans "Notify me" %}</button>
+            </form>
+        {% endif %}
+    {% endiffeature %}
     {% iffeature "wishlists" %}
         {% include "catalogue/partials/add_to_wishlist.html" %}
     {% endiffeature %}

--- a/src/oscar/templates/oscar/customer/baseaccountpage.html
+++ b/src/oscar/templates/oscar/customer/baseaccountpage.html
@@ -39,9 +39,11 @@
             <li{% if active_tab == 'emails' %} class="active"{% endif %}>
                 <a href="{% url 'customer:email-list' %}">{% trans "Email History" %}</a>
             </li>
-            <li{% if active_tab == 'alerts' %} class="active"{% endif %}>
-                <a href="{% url 'customer:alerts-list' %}">{% trans "Product Alerts" %}</a>
-            </li>
+            {% iffeature 'alerts' %}
+                <li{% if active_tab == 'alerts' %} class="active"{% endif %}>
+                    <a href="{% url 'customer:alerts-list' %}">{% trans "Product Alerts" %}</a>
+                </li>
+            {% endiffeature %}
             <li{% if active_tab == 'notifications' %} class="active"{% endif %}>
                 <a href="{% url 'customer:notifications-inbox' %}">{% trans "Notifications" %}</a>
             </li>

--- a/src/oscar/templates/oscar/customer/baseaccountpage.html
+++ b/src/oscar/templates/oscar/customer/baseaccountpage.html
@@ -1,6 +1,7 @@
 {% extends "layout_2_col.html" %}
 
 {% load i18n %}
+{% load display_tags %}
 
 {% block title %}
     {{ page_title }} | {% trans 'Account' %} | {{ block.super }}
@@ -44,9 +45,11 @@
             <li{% if active_tab == 'notifications' %} class="active"{% endif %}>
                 <a href="{% url 'customer:notifications-inbox' %}">{% trans "Notifications" %}</a>
             </li>
-            <li{% if active_tab == 'wishlists' %} class="active"{% endif %}>
-                <a href="{% url 'customer:wishlists-list' %}">{% trans "Wish Lists" %}</a>
-            </li>
+            {% iffeature 'wishlists' %}
+                <li{% if active_tab == 'wishlists' %} class="active"{% endif %}>
+                    <a href="{% url 'customer:wishlists-list' %}">{% trans "Wish Lists" %}</a>
+                </li>
+            {% endiffeature %}
         {% endblock %}
     </ul>
 {% endblock %}

--- a/src/oscar/templates/oscar/customer/partials/nav_account.html
+++ b/src/oscar/templates/oscar/customer/partials/nav_account.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load display_tags %}
 
 <div class="navbar nav-profile">
     <div class="navbar-inner">
@@ -34,9 +35,11 @@
                         <li{% if active_tab == 'notifications' %} class="active"{% endif %}>
                             <a href="{% url 'customer:notifications-inbox' %}">{% trans "Notifications" %}</a>
                         </li>
-                        <li{% if active_tab == 'wishlists' %} class="active"{% endif %}>
-                            <a href="{% url 'customer:wishlists-list' %}">{% trans "Wish Lists" %}</a>
-                        </li>
+                        {% iffeature 'wishlists' %}
+                            <li{% if active_tab == 'wishlists' %} class="active"{% endif %}>
+                                <a href="{% url 'customer:wishlists-list' %}">{% trans "Wish Lists" %}</a>
+                            </li>
+                        {% endiffeature %}
                     {% endblock %}
                     {% block extra_tabs %}
                     {% endblock %}

--- a/src/oscar/templates/oscar/customer/partials/nav_account.html
+++ b/src/oscar/templates/oscar/customer/partials/nav_account.html
@@ -29,9 +29,11 @@
                         <li{% if active_tab == 'emails' %} class="active"{% endif %}>
                             <a href="{% url 'customer:email-list' %}">{% trans "Email History" %}</a>
                         </li>
-                        <li{% if active_tab == 'alerts' %} class="active"{% endif %}>
-                            <a href="{% url 'customer:alerts-list' %}">{% trans "Product Alerts" %}</a>
-                        </li>
+                        {% iffeature 'alerts' %}
+                            <li{% if active_tab == 'alerts' %} class="active"{% endif %}>
+                                <a href="{% url 'customer:alerts-list' %}">{% trans "Product Alerts" %}</a>
+                            </li>
+                        {% endiffeature %}
                         <li{% if active_tab == 'notifications' %} class="active"{% endif %}>
                             <a href="{% url 'customer:notifications-inbox' %}">{% trans "Notifications" %}</a>
                         </li>

--- a/tests/functional/customer/alert_tests.py
+++ b/tests/functional/customer/alert_tests.py
@@ -1,5 +1,7 @@
+import mock
+
 from django_webtest import WebTest
-from django.core.urlresolvers import reverse
+from django.core.urlresolvers import reverse, NoReverseMatch
 from django.core import mail
 
 from oscar.apps.customer.models import ProductAlert
@@ -9,18 +11,55 @@ from oscar.test.factories import UserFactory
 
 class TestAUser(WebTest):
 
+    def setUp(self):
+        super(TestAUser, self).setUp()
+        self.user = UserFactory()
+        self.product = create_product(num_in_stock=0)
+
     def test_can_create_a_stock_alert(self):
-        user = UserFactory()
-        product = create_product(num_in_stock=0)
-        product_page = self.app.get(product.get_absolute_url(), user=user)
+        product_url = self.product.get_absolute_url()
+        product_page = self.app.get(product_url, user=self.user)
+
         form = product_page.forms['alert_form']
         form.submit()
 
-        alerts = ProductAlert.objects.filter(user=user)
+        alerts = ProductAlert.objects.filter(user=self.user)
         self.assertEqual(1, len(alerts))
         alert = alerts[0]
         self.assertEqual(ProductAlert.ACTIVE, alert.status)
-        self.assertEqual(alert.product, product)
+        self.assertEqual(alert.product, self.product)
+
+    def test_stock_alert_form_does_not_exist(self):
+        with self.settings(OSCAR_HIDDEN_FEATURES=['alerts']):
+            product_url = self.product.get_absolute_url()
+            product_page = self.app.get(product_url, user=self.user)
+
+        self.assertFalse('alert_form' in product_page.forms)
+
+
+class TestAnAnonymousUser(WebTest):
+
+    def setUp(self):
+        super(TestAnAnonymousUser, self).setUp()
+        self.product = create_product(num_in_stock=0)
+
+    def test_can_create_a_stock_alert(self):
+        product_page = self.app.get(self.product.get_absolute_url())
+        form = product_page.forms['alert_form']
+        form['email'] = 'john@smith.com'
+        form.submit()
+
+        alerts = ProductAlert.objects.filter(email='john@smith.com')
+        self.assertEqual(1, len(alerts))
+        alert = alerts[0]
+        self.assertEqual(ProductAlert.UNCONFIRMED, alert.status)
+        self.assertEqual(alert.product, self.product)
+
+    def test_stock_alert_form_does_not_exist(self):
+        with self.settings(OSCAR_HIDDEN_FEATURES=['alerts']):
+            product_page = self.app.get(self.product.get_absolute_url())
+
+        self.assertFalse('alert_form' in product_page.forms)
 
 
 class TestAUserWithAnActiveStockAlert(WebTest):
@@ -48,7 +87,6 @@ class TestAUserWithAnActiveStockAlert(WebTest):
         alert = alerts[0]
         self.assertTrue(alert.is_cancelled)
 
-
     def test_gets_notified_when_it_is_back_in_stock(self):
         self.stockrecord.num_in_stock = 10
         self.stockrecord.save()
@@ -65,17 +103,79 @@ class TestAUserWithAnActiveStockAlert(WebTest):
         self.assertEqual(0, len(mail.outbox))
 
 
-class TestAnAnonymousUser(WebTest):
+class TestProfilePage(WebTest):
+    def test_alerts_link_exists(self):
+        """
+        Because of differences between src/oscar/templates/oscar/layout.html
+        and tests/_site/templates/layout.html, this test will always fail.
 
-    def test_can_create_a_stock_alert(self):
-        product = create_product(num_in_stock=0)
-        product_page = self.app.get(product.get_absolute_url())
-        form = product_page.forms['alert_form']
-        form['email'] = 'john@smith.com'
-        form.submit()
+        See https://github.com/django-oscar/django-oscar/issues/1991 for
+        a complete explanation.
 
-        alerts = ProductAlert.objects.filter(email='john@smith.com')
-        self.assertEqual(1, len(alerts))
-        alert = alerts[0]
-        self.assertEqual(ProductAlert.UNCONFIRMED, alert.status)
-        self.assertEqual(alert.product, product)
+        Feel free to uncomment the body of this method when that issue has
+        been resolved.
+        """
+#        account_page = self.app.get(reverse('customer:profile-view'))
+#
+#        html = account_page.content.decode('utf-8')
+#        self.assertTrue(reverse('customer:alerts-list') in html)
+
+    def test_alerts_link_does_not_exist(self):
+        with self.settings(OSCAR_HIDDEN_FEATURES=['alerts']):
+            account_page = self.app.get(reverse('customer:profile-view'))
+
+        html = account_page.content.decode('utf-8')
+        self.assertFalse(reverse('customer:alerts-list') in html)
+
+
+class TestDashboard(WebTest):
+
+    def setUp(self):
+        super(TestDashboard, self).setUp()
+        u = UserFactory()
+        u.is_superuser = True
+        u.is_staff = True
+        u.save()
+
+        self.user = u
+        self.index_url = reverse('dashboard:index')
+
+    def test_alerts_link_exists(self):
+        dashboard_index = self.app.get(self.index_url, user=self.user)
+
+        html = dashboard_index.content.decode('utf-8')
+        self.assertTrue(reverse('dashboard:user-alert-list') in html)
+
+    def test_alerts_link_does_not_exist(self):
+        """
+        oscar.apps.dashboard.nav.default_access_fn will omit a link from
+        the dashboard navigation if the user isn't authorized to view it OR
+        if Django fails to resolve the URL name.
+
+        oscar.apps.dashboard.user.app will only register the user-alert URLs
+        if the "alerts" feature is NOT hidden.
+
+        Django registers URLs no later than the first call to self.app.get.
+        Because tests.settings doesn't hide any apps, the user-alerts URLs
+        will be reversible (and thus visible on the dashboard) regardless of
+        whether or not we patch 'alerts' into OSCAR_HIDDEN_FEATURES at runtime.
+
+        We can circumvent this limitation by using mock.patch to replace the
+        reverse function so that it raises NoReverseMatch for user-alert URLs.
+
+        It is unfortunate that this explanation is longer than the test.
+        """
+
+        def fake_reverse(url_identifier, *pos, **kw):
+            app, name = url_identifier.split(':')
+            if name.startswith('user-alert'):
+                raise NoReverseMatch()
+            return "/this/looks/like/a/valid/url"
+
+        patch_target = 'oscar.apps.dashboard.nav.reverse'
+        with mock.patch(patch_target, side_effect=fake_reverse):
+            with self.settings(OSCAR_HIDDEN_FEATURES=['alerts']):
+                dashboard_index = self.app.get(self.index_url, user=self.user)
+
+        html = dashboard_index.content.decode('utf-8')
+        self.assertFalse(reverse('dashboard:user-alert-list') in html)

--- a/tests/functional/customer/wishlists_tests.py
+++ b/tests/functional/customer/wishlists_tests.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+from django.core.urlresolvers import reverse
+
 from oscar.core.loading import get_model
 
 from oscar.test.factories import create_product
@@ -28,3 +31,39 @@ class TestProductDetailPage(WebTestCase):
         lines = wishlists[0].lines.all()
         self.assertEqual(1, len(lines))
         self.assertEqual(self.product, lines[0].product)
+
+    def test_wishlists_form_does_not_exist(self):
+        with self.settings(OSCAR_HIDDEN_FEATURES=['wishlists']):
+            detail_page = self.get(self.product.get_absolute_url())
+
+        self.assertFalse('add_to_wishlist_form' in detail_page.forms)
+
+
+class TestProfilePage(WebTestCase):
+    is_anonymous = False
+
+    def test_wishlists_link_exists(self):
+        """
+        Because of differences between src/oscar/templates/oscar/layout.html
+        and tests/_site/templates/layout.html, this test will always fail.
+
+        See https://github.com/django-oscar/django-oscar/issues/1991 for
+        a complete explanation.
+
+        Feel free to uncomment the body of this method when that issue has
+        been resolved.
+        """
+#        account_page = self.get(reverse('customer:profile-view'))
+#
+#        with open('/Users/zmott/Desktop/test.html', 'wb') as outfile:
+#            outfile.write(account_page.content)
+#
+#        html = account_page.content.decode('utf-8')
+#        self.assertTrue(reverse('customer:wishlists-list') in html)
+
+    def test_wishlists_link_does_not_exist(self):
+        with self.settings(OSCAR_HIDDEN_FEATURES=['wishlists']):
+            account_page = self.get(reverse('customer:profile-view'))
+
+        html = account_page.content.decode('utf-8')
+        self.assertFalse(reverse('customer:wishlists-list') in html)


### PR DESCRIPTION
This pull request provides the same functionality as #1990.  This one is better because it includes tests and has a cleaner commit history.  Otherwise, the same comments apply

Zachary Mott
Web Application Developer

PS For completeness' sake, the comment I included on #1990 is reproduced below:

My organization is building our web store on top of Oscar. However, we have found that we don't want to enable reviews, wish lists, or product alerts initially. As of Oscar 1.1.1, we could only disable reviews using `settings.OSCAR_HIDDEN_FEATURES`. To this end, I have provided feature-hiding support for wish lists and product alerts by following the example set forth by `catalogue.reviews`.

This effort involved creating an `app.py` for `customer.wishlists` and `customer.alerts`, and hunting down references to these apps' URLs in templates and guarding them with `{% iffeature %}` tags.

I am submitting this pull request against master per the contribution guidelines, but I would really like to backport these changes to Oscar 1.1. If that's acceptable, I can retarget this pull request to wherever it needs to go.

Thank you for providing such an excellent ecommerce framework on which to build. Oscar has saved me and my team countless hours of engineering -- it is excellent software.
