### PR TITLE
Unicode slugs for Django 1.9

### DIFF
--- a/docs/source/ref/settings.rst
+++ b/docs/source/ref/settings.rst
@@ -465,6 +465,17 @@ Example::
 
     OSCAR_SLUG_BLACKLIST = ['the', 'a', 'but']
 
+``OSCAR_SLUG_ALLOW_UNICODE``
+----------------------------
+
+Default: ``False``
+
+Allows to disable unicode to ASCII conversion and enable `allow_unicode` option
+for ``AutoSlugField``, which is supported by ``SlugField`` in Django>=1.9
+(https://docs.djangoproject.com/es/1.9/ref/models/fields/#django.db.models.SlugField.allow_unicode).
+This will allow to have
+automatically generated unicode-containing slugs.
+
 Misc settings
 =============
 

--- a/src/oscar/apps/basket/abstract_models.py
+++ b/src/oscar/apps/basket/abstract_models.py
@@ -14,6 +14,7 @@ from oscar.apps.offer import results
 from oscar.apps.partner import availability
 from oscar.core.compat import AUTH_USER_MODEL
 from oscar.core.utils import get_default_currency
+from oscar.models.fields.slugfield import SlugField
 from oscar.templatetags.currency_filters import currency
 
 
@@ -586,7 +587,7 @@ class AbstractLine(models.Model):
     # We can't just use product.id as you can have customised products
     # which should be treated as separate lines.  Set as a
     # SlugField as it is included in the path for certain views.
-    line_reference = models.SlugField(
+    line_reference = SlugField(
         _("Line Reference"), max_length=128, db_index=True)
 
     product = models.ForeignKey(

--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -28,6 +28,7 @@ from oscar.core.loading import get_class, get_classes, get_model
 from oscar.core.utils import slugify
 from oscar.core.validators import non_python_keyword
 from oscar.models.fields import AutoSlugField, NullCharField
+from oscar.models.fields.slugfield import SlugField
 
 ProductManager, BrowsableProductManager = get_classes(
     'catalogue.managers', ['ProductManager', 'BrowsableProductManager'])
@@ -93,7 +94,7 @@ class AbstractCategory(MP_Node):
     description = models.TextField(_('Description'), blank=True)
     image = models.ImageField(_('Image'), upload_to='categories', blank=True,
                               null=True, max_length=255)
-    slug = models.SlugField(_('Slug'), max_length=255, db_index=True)
+    slug = SlugField(_('Slug'), max_length=255, db_index=True)
 
     _slug_separator = '/'
     _full_name_separator = ' > '

--- a/src/oscar/defaults.py
+++ b/src/oscar/defaults.py
@@ -87,6 +87,7 @@ OSCAR_FROM_EMAIL = 'oscar@example.com'
 OSCAR_SLUG_FUNCTION = 'oscar.core.utils.default_slugifier'
 OSCAR_SLUG_MAP = {}
 OSCAR_SLUG_BLACKLIST = []
+OSCAR_SLUG_ALLOW_UNICODE = False
 
 # Cookies
 OSCAR_COOKIES_DELETE_ON_LOGOUT = ['oscar_recently_viewed_products', ]

--- a/src/oscar/models/fields/autoslugfield.py
+++ b/src/oscar/models/fields/autoslugfield.py
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 import re
 
-from django.db.models import SlugField
+from django.conf import settings
 from django.utils import six
 
 from oscar.core.utils import slugify
@@ -35,6 +35,8 @@ try:
     from django.utils.encoding import force_unicode  # NOQA
 except ImportError:
     from django.utils.encoding import force_text as force_unicode  # NOQA
+
+from .slugfield import SlugField
 
 
 class AutoSlugField(SlugField):
@@ -71,6 +73,12 @@ class AutoSlugField(SlugField):
         self.overwrite = kwargs.pop('overwrite', False)
         self.uppercase = kwargs.pop('uppercase', False)
         self.allow_duplicates = kwargs.pop('allow_duplicates', False)
+
+        # not override parameter if it was passed explicitly,
+        # so passed parameters takes precedence over the setting
+        if settings.OSCAR_SLUG_ALLOW_UNICODE:
+            kwargs.setdefault('allow_unicode', settings.OSCAR_SLUG_ALLOW_UNICODE)
+
         super(AutoSlugField, self).__init__(*args, **kwargs)
 
     def _slug_strip(self, value):

--- a/src/oscar/models/fields/slugfield.py
+++ b/src/oscar/models/fields/slugfield.py
@@ -1,0 +1,12 @@
+from django.conf import settings
+from django.db.models import SlugField as DjangoSlugField
+
+
+class SlugField(DjangoSlugField):
+    def __init__(self, *args, **kwargs):
+        # not override parameter if it was passed explicitly,
+        # so passed parameters takes precedence over the setting
+        if settings.OSCAR_SLUG_ALLOW_UNICODE:
+            kwargs.setdefault('allow_unicode', settings.OSCAR_SLUG_ALLOW_UNICODE)
+
+        super(SlugField, self).__init__(*args, **kwargs)

--- a/tests/integration/catalogue/category_tests.py
+++ b/tests/integration/catalogue/category_tests.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
-from django import template
+from unittest import skipIf
+
+from django import VERSION as DJANGO_VERSION
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from oscar.apps.catalogue.models import Category
 from oscar.apps.catalogue.categories import create_from_breadcrumbs
@@ -35,6 +38,15 @@ class TestCategory(TestCase):
     def test_duplicate_slugs_allowed_for_non_siblings(self):
         more_books = Category.add_root(name=self.books.name)
         self.assertEqual(more_books.slug, self.books.slug)
+
+    @skipIf(DJANGO_VERSION < (1, 9),
+            "unicode slugs not supported by Django<1.9")
+    def test_unicode_slug(self):
+        with override_settings(OSCAR_SLUG_ALLOW_UNICODE=True):
+            root_category = Category.add_root(name=u"Vins français")
+            child_category = root_category.add_child(name=u"Château d'Yquem")
+            self.assertEqual(root_category.slug, u'vins-français')
+            self.assertEqual(child_category.slug, u'château-dyquem')
 
 
 class TestMovingACategory(TestCase):

--- a/tests/unit/core/slugfield_tests.py
+++ b/tests/unit/core/slugfield_tests.py
@@ -1,0 +1,20 @@
+# coding=utf-8
+
+from unittest import skipIf
+
+from django import VERSION as DJANGO_VERSION
+from django.test import TestCase
+from django.test.utils import override_settings
+
+
+class SlugFieldTest(TestCase):
+
+    @skipIf(DJANGO_VERSION < (1, 9),
+            "unicode slugs not supported by Django<1.9")
+    def test_slugfield_allow_unicode_kwargs_precedence(self):
+        from oscar.models.fields.slugfield import SlugField
+        with override_settings(OSCAR_SLUG_ALLOW_UNICODE=True):
+            slug_field = SlugField(allow_unicode=False)
+            self.assertFalse(slug_field.allow_unicode)
+            slug_field = SlugField()
+            self.assertTrue(slug_field.allow_unicode)


### PR DESCRIPTION
Fixes #1994 

Initial feature design has trade-offs in favor of backwards compatibility.
Improvement suggestions welcomed.