### PR TITLE
Serve parent image if child image is missing

### DIFF
--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -622,13 +622,18 @@ class AbstractProduct(models.Model):
         try:
             return images[0]
         except IndexError:
-            # We return a dict with fields that mirror the key properties of
-            # the ProductImage class so this missing image can be used
-            # interchangeably in templates.  Strategy pattern ftw!
-            return {
-                'original': self.get_missing_image(),
-                'caption': '',
-                'is_missing': True}
+            if self.is_child:
+                # By default, Oscar's dashboard doesn't support child images.
+                # We just serve the parents image instead.
+                return self.parent.primary_image
+            else:
+                # We return a dict with fields that mirror the key properties of
+                # the ProductImage class so this missing image can be used
+                # interchangeably in templates.  Strategy pattern ftw!
+                return {
+                    'original': self.get_missing_image(),
+                    'caption': '',
+                    'is_missing': True}
 
     # Updating methods
 


### PR DESCRIPTION
When child products are added to the basket in stock Oscar, there never will
be an image associated with them because the Oscar dashboard doesn't support
it to keep things simple.

But if that is the case, we can easily attempt to serve the parent product
image, which is the better default.