### PR TITLE
Prevent trying to save a negative quantity to a Basket

### DIFF
--- a/src/oscar/apps/basket/abstract_models.py
+++ b/src/oscar/apps/basket/abstract_models.py
@@ -217,7 +217,7 @@ class AbstractBasket(models.Model):
                 line.attributes.create(option=option_dict['option'],
                                        value=option_dict['value'])
         else:
-            line.quantity += quantity
+            line.quantity = max(0, line.quantity + quantity)
             line.save()
         self.reset_offer_applications()
 

--- a/tests/integration/basket/model_tests.py
+++ b/tests/integration/basket/model_tests.py
@@ -28,6 +28,13 @@ class TestAddingAProductToABasket(TestCase):
         self.assertEqual(line.price_incl_tax, self.purchase_info.price.incl_tax)
         self.assertEqual(line.price_excl_tax, self.purchase_info.price.excl_tax)
 
+    def test_adding_negative_quantity(self):
+        self.assertEqual(1, self.basket.num_lines)
+        self.basket.add(self.product, quantity=4)
+        self.assertEqual(5, self.basket.line_quantity(self.product, self.record))
+        self.basket.add(self.product, quantity=-10)
+        self.assertEqual(0, self.basket.line_quantity(self.product, self.record))
+
     def test_means_another_currency_product_cannot_be_added(self):
         product = factories.create_product()
         factories.create_stockrecord(


### PR DESCRIPTION
basket.Line.quantity is a positive integer field, but the quantity sumation in
basket.Basket.add_product made it possible to try and save negative values. This
makes add_product never go below 0-quantity, thereby preventing a db exception
from being thrown. Also adds a test for the described behavior.