### PR TITLE
Re-add Category.full_name and Category.full_slug

### DIFF
--- a/src/oscar/apps/catalogue/categories.py
+++ b/src/oscar/apps/catalogue/categories.py
@@ -12,7 +12,7 @@ def create_from_sequence(bits):
         name = bits[0]
         try:
             # Category names should be unique at the depth=1
-            root = Category.objects.get(depth=1, name=name)
+            root = Category.get_root_nodes().get(name=name)
         except Category.DoesNotExist:
             root = Category.add_root(name=name)
         except Category.MultipleObjectsReturned:

--- a/src/oscar/apps/catalogue/migrations/0008_auto_20160215_1532.py
+++ b/src/oscar/apps/catalogue/migrations/0008_auto_20160215_1532.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.core.validators
+import oscar.core.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('catalogue', '0007_auto_20151207_1440'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='category',
+            name='full_name',
+            field=models.CharField(default='', verbose_name='Full Name', max_length=255, editable=False, db_index=True),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='category',
+            name='full_slug',
+            field=models.CharField(default='', verbose_name='Full Slug', max_length=255, editable=False, db_index=True),
+            preserve_default=False,
+        ),
+    ]

--- a/src/oscar/apps/catalogue/receivers.py
+++ b/src/oscar/apps/catalogue/receivers.py
@@ -1,19 +1,26 @@
 # -*- coding: utf-8 -*-
 
 from django.conf import settings
+from django.db.models.signals import post_save
+from django.dispatch.dispatcher import receiver
+
+from oscar.core.loading import get_model
+
+ProductImage = get_model('catalogue', 'ProductImage')
+Category = get_model('catalogue', 'Category')
+
+
+@receiver(post_save, sender=Category)
+def denormalise_category_fields(sender, instance, **kwargs):
+    instance.__class__.denormalise_fields()
 
 if settings.OSCAR_DELETE_IMAGE_FILES:
-
-    from oscar.core.loading import get_model
 
     from django.db import models
     from django.db.models.signals import post_delete
 
     from sorl import thumbnail
     from sorl.thumbnail.helpers import ThumbnailError
-
-    ProductImage = get_model('catalogue', 'ProductImage')
-    Category = get_model('catalogue', 'Category')
 
     def delete_image_files(sender, instance, **kwargs):
         """

--- a/src/oscar/management/commands/oscar_denormalise_categories.py
+++ b/src/oscar/management/commands/oscar_denormalise_categories.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from django.core.management.base import BaseCommand
+
+from oscar.core.loading import get_model
+
+Category = get_model('catalogue', 'Category')
+
+
+class Command(BaseCommand):
+    help = "Populates the full_name and full_slug fields for Category."
+
+    def handle(self, *args, **options):
+        Category.denormalise_fields()

--- a/tests/integration/catalogue/category_tests.py
+++ b/tests/integration/catalogue/category_tests.py
@@ -14,7 +14,7 @@ class TestCategory(TestCase):
         self.books = self.products.add_child(name=u"Bücher")
 
     def test_includes_parents_name_in_full_name(self):
-        self.assertTrue(self.products.name in self.books.full_name)
+        self.assertIn(self.products.name, self.books.full_name)
 
     def test_has_children_method(self):
         self.assertTrue(self.products.has_children())


### PR DESCRIPTION
Here we go again!

Trying to fix https://github.com/django-oscar/django-oscar/issues/1828

This PR adds `full_slug` and `full_name` attributes.

I think the big reason that they were removed before is because they're messy and it's hard to understand how they work. I fixed that by putting all of the denormalization logic into a single `classmethod` `denormalise_fields` which I then wired up to a signal.

I added a management command that wraps that method. It will be necessary to call it if you migrate from `1.1`.

@maikhoepfel Do you think an approach like this would be a reasonable compromise?

Please let me know if you have any questions.

Thanks.
John
