### PR TITLE
BankcardNumberField raise ValidationError instead of AttributeError

### DIFF
--- a/src/oscar/apps/payment/forms.py
+++ b/src/oscar/apps/payment/forms.py
@@ -44,7 +44,7 @@ class BankcardNumberField(forms.CharField):
         card types we accept
         """
         non_decimal = re.compile(r'\D+')
-        value = non_decimal.sub('', value.strip())
+        value = non_decimal.sub('', (value or '').strip())
 
         if value and not bankcards.luhn(value):
             raise forms.ValidationError(

--- a/tests/unit/payment/form_tests.py
+++ b/tests/unit/payment/form_tests.py
@@ -35,10 +35,13 @@ class TestBankcardNumberField(TestCase):
         with self.assertRaises(ValidationError):
             self.field.clean('348934265521923')
 
-
     def test_raises_error_for_invalid_card_type(self):
         with self.assertRaises(ImproperlyConfigured):
             self.field = forms.BankcardNumberField(types=['American Express', 'Nonsense'])
+
+    def test_rejects_none(self):
+        with self.assertRaises(ValidationError):
+            self.field.clean(None)
 
 
 class TestStartingMonthField(TestCase):


### PR DESCRIPTION
Fix for https://github.com/django-oscar/django-oscar/issues/2006

If the form data doesn't include the credit card, it raises a `VadliationError` instead of the (less helpful) `AttributeError`.

Includes a test.
