### PR TITLE
Allow BankcardExpiryMonthField to have required=False

### DIFF
--- a/src/oscar/apps/payment/forms.py
+++ b/src/oscar/apps/payment/forms.py
@@ -133,7 +133,7 @@ class BankcardExpiryMonthField(BankcardMonthField):
 
     def clean(self, value):
         expiry_date = super(BankcardExpiryMonthField, self).clean(value)
-        if date.today() > expiry_date:
+        if expiry_date and date.today() > expiry_date:
             raise forms.ValidationError(
                 _("The expiration date you entered is in the past."))
         return expiry_date

--- a/tests/unit/payment/form_tests.py
+++ b/tests/unit/payment/form_tests.py
@@ -102,6 +102,15 @@ class TestExpiryMonthField(TestCase):
                           self.field.initial)
 
 
+class TestOptionalExpiryMonthField(TestExpiryMonthField):
+
+    def setUp(self):
+        self.field = forms.BankcardExpiryMonthField(required=False)
+
+    def test_accepts_none(self):
+        self.field.clean(None)
+
+
 class TestCCVField(TestCase):
     """CCV field"""
 


### PR DESCRIPTION
Fix for https://github.com/django-oscar/django-oscar/issues/2008

Should allow for `required=False` to be set on a `BankcardExpiryMonthField`.

Test is included.
