### PR TITLE
Fix error when no shipping method is set

### DIFF
--- a/src/oscar/apps/checkout/session.py
+++ b/src/oscar/apps/checkout/session.py
@@ -234,7 +234,10 @@ class CheckoutSessionMixin(object):
             # It's unusual to get here as a shipping method should be set by
             # the time this skip-condition is called. In the absence of any
             # other evidence, we assume the shipping charge is zero.
-            shipping_charge = prices.Price(excl_tax=D('0.00'), tax=D('0.00'))
+            shipping_charge = prices.Price(
+                currency=request.basket.currency, excl_tax=D('0.00'),
+                tax=D('0.00')
+            )
         total = self.get_order_totals(request.basket, shipping_charge)
         if total.excl_tax == D('0.00'):
             raise exceptions.PassedSkipCondition(


### PR DESCRIPTION
`currency` is a required parameter for the `Price` constructor.