### PR TITLE
Fixed performance issue in offer dashboard detail page

### DIFF
--- a/src/oscar/apps/dashboard/offers/views.py
+++ b/src/oscar/apps/dashboard/offers/views.py
@@ -360,7 +360,8 @@ class OfferDetailView(ListView):
             reverse('dashboard:offer-detail', kwargs={'pk': self.offer.pk}))
 
     def get_queryset(self):
-        return self.model.objects.filter(offer_id=self.offer.pk)
+        return self.model.objects.filter(offer_id=self.offer.pk) \
+            .select_related('order')
 
     def get_context_data(self, **kwargs):
         ctx = super(OfferDetailView, self).get_context_data(**kwargs)


### PR DESCRIPTION
There was an N-query issue while displaying all orders the offer was applied to.

On one of our offers, it was a jump from 1000+ queries back to 24.