### PR TITLE
Proposal: show 404 pages for inactive offers

### DIFF
--- a/src/oscar/apps/offer/views.py
+++ b/src/oscar/apps/offer/views.py
@@ -27,7 +27,7 @@ class OfferDetailView(ListView):
 
     def get(self, request, *args, **kwargs):
         try:
-            self.offer = ConditionalOffer.objects.select_related().get(
+            self.offer = ConditionalOffer.active.select_related().get(
                 slug=self.kwargs['slug'])
         except ConditionalOffer.DoesNotExist:
             raise http.Http404


### PR DESCRIPTION
Offers that are suspended are not visible in the list view, but will still be shown as detail page.
I wonder whether this is intended, or accidentally.

One of my clients requested to hide such pages (as I've done in the project code).

With this PR I'd hope to receive feedback on whether this should be the default, or not.