### PR TITLE
Fix makemigrations in Python 3

### DIFF
--- a/src/oscar/apps/catalogue/migrations/0006_auto_20150807_1725.py
+++ b/src/oscar/apps/catalogue/migrations/0006_auto_20150807_1725.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='productattribute',
             name='code',
-            field=models.SlugField(max_length=128, verbose_name='Code', validators=[django.core.validators.RegexValidator(regex=b'^[a-zA-Z_][0-9a-zA-Z_]*$', message="Code can only contain the letters a-z, A-Z, digits, and underscores, and can't start with a digit"), oscar.core.validators.non_python_keyword]),
+            field=models.SlugField(max_length=128, verbose_name='Code', validators=[django.core.validators.RegexValidator(regex=r'^[a-zA-Z_][0-9a-zA-Z_]*$', message="Code can only contain the letters a-z, A-Z, digits, and underscores, and can't start with a digit"), oscar.core.validators.non_python_keyword]),
             preserve_default=True,
         ),
     ]

--- a/src/oscar/apps/catalogue/migrations/0008_auto_20160304_1652.py
+++ b/src/oscar/apps/catalogue/migrations/0008_auto_20160304_1652.py
@@ -16,6 +16,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='productattribute',
             name='code',
-            field=models.SlugField(max_length=128, verbose_name='Code', validators=[django.core.validators.RegexValidator(regex=b'^[a-zA-Z_][0-9a-zA-Z_]*$', message="Code can only contain the letters a-z, A-Z, digits, and underscores, and can't start with a digit."), oscar.core.validators.non_python_keyword]),
+            field=models.SlugField(max_length=128, verbose_name='Code', validators=[django.core.validators.RegexValidator(regex=r'^[a-zA-Z_][0-9a-zA-Z_]*$', message="Code can only contain the letters a-z, A-Z, digits, and underscores, and can't start with a digit."), oscar.core.validators.non_python_keyword]),
         ),
     ]

--- a/src/oscar/apps/customer/migrations/0002_auto_20150807_1725.py
+++ b/src/oscar/apps/customer/migrations/0002_auto_20150807_1725.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='communicationeventtype',
             name='code',
-            field=oscar.models.fields.autoslugfield.AutoSlugField(populate_from=b'name', validators=[django.core.validators.RegexValidator(regex=b'^[a-zA-Z_][0-9a-zA-Z_]*$', message="Code can only contain the letters a-z, A-Z, digits, and underscores, and can't start with a digit.")], editable=False, max_length=128, separator='_', blank=True, help_text='Code used for looking up this event programmatically', unique=True, verbose_name='Code'),
+            field=oscar.models.fields.autoslugfield.AutoSlugField(populate_from='name', validators=[django.core.validators.RegexValidator(regex=r'^[a-zA-Z_][0-9a-zA-Z_]*$', message="Code can only contain the letters a-z, A-Z, digits, and underscores, and can't start with a digit.")], editable=False, max_length=128, separator='_', blank=True, help_text='Code used for looking up this event programmatically', unique=True, verbose_name='Code'),
             preserve_default=True,
         ),
     ]


### PR DESCRIPTION
The makemigrations command is broken in Python3 because the migration added in
f21c6c6a98 use byte-string regexes. This results in an exception being thrown:
`AttributeError: 'bytes' object has no attribute 'pattern'`. Switching to
raw strings fixes the issue.