### PR TITLE
Set BOM in UnicodeCSVWriter in PY2 for better csv reader compatibility

### DIFF
--- a/src/oscar/core/compat.py
+++ b/src/oscar/core/compat.py
@@ -146,7 +146,7 @@ class UnicodeCSVWriter:
         self.writer = None
         # If a new file is created with UTF-8 encoding, set byte order mark at the beginning of the
         # file for better compatibility with readers like MS Excel.
-        if self.filename is None and self.encoding == "utf-8":
+        if self.filename is None and not PY3 and self.encoding == "utf-8":
                 self.f.write(codecs.BOM_UTF8)
 
     def __enter__(self):

--- a/src/oscar/core/compat.py
+++ b/src/oscar/core/compat.py
@@ -1,3 +1,4 @@
+import codecs
 import csv
 import sys
 
@@ -143,6 +144,10 @@ class UnicodeCSVWriter:
         self.encoding = encoding
         self.kw = kw
         self.writer = None
+        # If a new file is created with UTF-8 encoding, set byte order mark at the beginning of the
+        # file for better compatibility with readers like MS Excel.
+        if self.filename is None and self.encoding == "utf-8":
+                self.f.write(codecs.BOM_UTF8)
 
     def __enter__(self):
         assert self.filename is not None


### PR DESCRIPTION
We noticed that some Users, which are using MS Excel on Mac, have troubles with the encoding of the files created by the `UnicodeCSVWriter`. Setting the byte order mark at the beginning of the file solved the issue.
