### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -4,4 +4,4 @@ Contributing to Oscar
 
 Thank you for wanting to contribute! You can find detailed guidance in the repository at ``docs/source/internals/contributing``, or online at:
 
-http://django-oscar.readthedocs.org/en/latest/internals/contributing/index.html
+https://django-oscar.readthedocs.io/en/latest/internals/contributing/index.html

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Contents:
     :target: http://oscarcommerce.com
 
 .. image:: https://github.com/django-oscar/django-oscar/raw/master/docs/images/screenshots/readthedocs.thumb.png
-    :target: http://django-oscar.readthedocs.org/en/latest/
+    :target: https://django-oscar.readthedocs.io/en/latest/
 
 Further reading:
 
@@ -63,7 +63,7 @@ Docs status:
 
 .. _`Official homepage`: http://oscarcommerce.com
 .. _`Sandbox site`: http://latest.oscarcommerce.com
-.. _`Documentation`: http://django-oscar.readthedocs.org/en/latest/
+.. _`Documentation`: https://django-oscar.readthedocs.io/en/latest/
 .. _`readthedocs.org`: http://readthedocs.org
 .. _`Continuous integration homepage`: http://travis-ci.org/#!/django-oscar/django-oscar
 .. _`travis-ci.org`: http://travis-ci.org/
@@ -120,8 +120,8 @@ The sandbox site can be set-up locally `in 5 commands`_.  Want to
 make changes?  Check out the `contributing guidelines`_.
 
 .. _`this gateway page`: http://latest.oscarcommerce.com/gateway/
-.. _`in 5 commands`: http://django-oscar.readthedocs.org/en/latest/internals/sandbox.html#running-the-sandbox-locally
-.. _`contributing guidelines`: http://django-oscar.readthedocs.org/en/latest/internals/contributing/index.html
+.. _`in 5 commands`: https://django-oscar.readthedocs.io/en/latest/internals/sandbox.html#running-the-sandbox-locally
+.. _`contributing guidelines`: https://django-oscar.readthedocs.io/en/latest/internals/contributing/index.html
 
 
 Extensions

--- a/docs/source/howto/how_to_create_a_custom_condition.rst
+++ b/docs/source/howto/how_to_create_a_custom_condition.rst
@@ -69,4 +69,4 @@ Deploying custom conditions
 To avoid manual steps in each of your test/stage/production environments, use
 South's `data migrations`_ to create conditions.
 
-.. _`data migrations`: http://south.readthedocs.org/en/latest/tutorial/part3.html#data-migrations
+.. _`data migrations`: https://south.readthedocs.io/en/latest/tutorial/part3.html#data-migrations

--- a/docs/source/howto/how_to_create_a_custom_range.rst
+++ b/docs/source/howto/how_to_create_a_custom_range.rst
@@ -62,4 +62,4 @@ Deploying custom ranges
 To avoid manual steps in each of your test/stage/production environments, use
 South's `data migrations`_ to create ranges.
 
-.. _`data migrations`: http://south.readthedocs.org/en/latest/tutorial/part3.html#data-migrations
+.. _`data migrations`: https://south.readthedocs.io/en/latest/tutorial/part3.html#data-migrations

--- a/docs/source/internals/contributing/running-tests.rst
+++ b/docs/source/internals/contributing/running-tests.rst
@@ -41,7 +41,7 @@ system. All other requirements are downloaded automatically.
 detox_ is a wrapper around tox_, creating the environments and running the tests
 in parallel. This greatly speeds up the process.
 
-.. _tox: http://tox.readthedocs.org/en/latest/
+.. _tox: https://tox.readthedocs.io/en/latest/
 .. _detox: https://pypi.python.org/pypi/detox
 
 Kinds of tests

--- a/docs/source/releases/v0.5.rst
+++ b/docs/source/releases/v0.5.rst
@@ -123,7 +123,7 @@ There are several noteworthy smaller improvements
 
 * Flash messages can now contain HTML.
 
-.. _django-compressor: http://django_compressor.readthedocs.org/en/latest/
+.. _django-compressor: https://django-compressor.readthedocs.io/en/latest/
 
 Minor improvements
 ~~~~~~~~~~~~~~~~~~

--- a/docs/source/releases/v0.6.2.rst
+++ b/docs/source/releases/v0.6.2.rst
@@ -35,4 +35,4 @@ The following bugs were fixed:
 .. _`#1127`: https://github.com/django-oscar/django-oscar/issues/1127
 .. _`fa1f8403`: https://github.com/django-oscar/django-oscar/commit/fa1f8403fb43af693766acafc520d10932a7f5b0
 .. _`reverting the original commit`: https://github.com/django-oscar/django-oscar/commit/ec950cf9de16c68858bc095d980e478be8146f79
-.. _`explicit installation instructions`: http://django-debug-toolbar.readthedocs.org/en/latest/installation.html#explicit-setup
+.. _`explicit installation instructions`: https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#explicit-setup

--- a/docs/source/releases/v0.7.rst
+++ b/docs/source/releases/v0.7.rst
@@ -385,4 +385,4 @@ Migrations
     - ``0002`` and ``0003`` - Convert ``[start|end]_date`` to
       ``[start|end]_datetime`` (includes data migration).
 
-.. _`convert an app`: http://south.readthedocs.org/en/latest/convertinganapp.html
+.. _`convert an app`: https://south.readthedocs.io/en/latest/convertinganapp.html

--- a/docs/source/releases/v1.0.rst
+++ b/docs/source/releases/v1.0.rst
@@ -264,7 +264,7 @@ Minor changes
 
 * ... and dozens of bugs fixed!
 
-.. _django-tables2: http://django-tables2.readthedocs.org/en/latest/
+.. _django-tables2: https://django-tables2.readthedocs.io/en/latest/
 .. _bootstrap-datetimepicker: http://www.malot.fr/bootstrap-datetimepicker/
 
 

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(name='django-oscar',
 
 # Show contributing instructions if being installed in 'develop' mode
 if len(sys.argv) > 1 and sys.argv[1] == 'develop':
-    docs_url = 'http://django-oscar.readthedocs.org/en/latest/internals/contributing/index.html'
+    docs_url = 'https://django-oscar.readthedocs.io/en/latest/internals/contributing/index.html'
     mailing_list = 'django-oscar@googlegroups.com'
     mailing_list_url = 'https://groups.google.com/forum/?fromgroups#!forum/django-oscar'
     twitter_url = 'https://twitter.com/django_oscar'

--- a/src/oscar/apps/search/views.py
+++ b/src/oscar/apps/search/views.py
@@ -15,7 +15,7 @@ class FacetedSearchView(views.FacetedSearchView):
     Note that facets are configured when the ``SearchQuerySet`` is initialised.
     This takes place in the search application class.
 
-    See http://django-haystack.readthedocs.org/en/v2.1.0/views_and_forms.html#facetedsearchform # noqa
+    See https://django-haystack.readthedocs.io/en/v2.1.0/views_and_forms.html#facetedsearchform # noqa
     """
 
     # Haystack uses a different class attribute to CBVs


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.