### PR TITLE
Allow haystack 2.5.0.dev1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(name='django-oscar',
           # https://github.com/AndrewIngram/django-extra-views/issues/114
           'django-extra-views>=0.2,<0.6.5',
           # Search support
-          'django-haystack>=2.3.1,<2.5.0',
+          'django-haystack>=2.3.1,<2.6.0',
           # Treebeard is used for categories
           'django-treebeard>=4.0',
           # Sorl is used as the default thumbnailer


### PR DESCRIPTION
This will finally allow us to release a Django 1.9 compatible version