### PR TITLE
Fix bootstrap column layout in shipping_address template

### DIFF
--- a/src/oscar/templates/oscar/checkout/shipping_address.html
+++ b/src/oscar/templates/oscar/checkout/shipping_address.html
@@ -20,12 +20,12 @@
     {% if user.is_authenticated %}
         {% if addresses %}
             <h3>{% trans "An address from your address book?" %}</h3>
-            <div class="row">
-                <div class="choose-block col-sm-6">
-                    <ul class="list-unstyled">
-                        {% for address in addresses %}
-                            {% block select_address_form %}
-                                <li class="well">
+            <div class="choose-block">
+                <ul class="list-unstyled row">
+                    {% for address in addresses %}
+                        {% block select_address_form %}
+                            <li class="col-sm-6">
+                                <div class="well">
                                     <address>
                                         {% block select_address_fields %}
                                             {% for field in address.active_address_fields %}
@@ -42,7 +42,7 @@
                                         {% else %}
                                             <button type="submit" class="btn btn-primary btn-large ship-address" data-loading-text="{% trans 'Saving...' %}">{% trans "Ship to this address" %}</button>
                                         {% endif %}
-                                        
+
                                         <div class="btn-group address-controls">
                                             <a href="{% url 'checkout:user-address-update' pk=address.id %}" class="btn btn-default btn-sm">{% trans "Edit address" %}</a>
                                             <button class="btn btn-default btn-sm dropdown-toggle" data-toggle="dropdown">
@@ -53,18 +53,18 @@
                                             </ul>
                                         </div>
                                     </form>
-                                </li>
-                                {% if forloop.counter|divisibleby:2 %}
-                                    </ul>
-                                    {% if not forloop.last %}<ul class="row">{% endif %}
-                                {% endif %}
-                            {% endblock %}
-                        {% endfor %}
-                    </ul>
-                </div>
+                                </div>
+                            </li>
+                            {% if forloop.counter|divisibleby:2 %}
+                                </ul>
+                                {% if not forloop.last %}<ul class="list-unstyled row">{% endif %}
+                            {% endif %}
+                        {% endblock %}
+                    {% endfor %}
+                </ul>
             </div>
             <h3>
-                {% trans "Or a new address?" %} 
+                {% trans "Or a new address?" %}
             </h3>
         {% endif %}
     {% endif %}


### PR DESCRIPTION
The [port to Bootstrap 3](https://github.com/django-oscar/django-oscar/commit/d702f47f127081e00dfadb35de0f0615191134f5#diff-f5387c20752230674cc3d54950d8d388L20) was a little broken for this template. The intention was for addresses to appear two-per-row on large screens but this wasn't actually happening and they all appeared in one column on the left of the page. 

This fixes the column layout to work as intended.