### PR TITLE
Update the currency filter to support the same params as babel.numbers.format_currency

### DIFF
--- a/docs/source/ref/settings.rst
+++ b/docs/source/ref/settings.rst
@@ -368,6 +368,29 @@ the ``format_currency`` function from the `Babel library`_.
 
 .. _`Babel library`: http://babel.pocoo.org/docs/api/numbers/#babel.numbers.format_currency
 
+``OSCAR_CURRENCY_DIGITS``
+-------------------------
+
+Default: ``True``
+
+This can be used show or hide the digits, overriding the default for the given
+currency. The value will be passed to the ``format_currency`` function from the
+`Babel library`_.
+
+.. _`Babel library`: http://babel.pocoo.org/docs/api/numbers/#babel.numbers.format_currency
+
+``OSCAR_CURRENCY_FORMAT_TYPE``
+-------------------------
+
+Default: ``standard``
+
+This can be used choose an alternate format for a currency where available. The
+value will be passed to the ``format_currency`` function from the
+`Babel library`_.
+
+.. _`Babel library`: http://babel.pocoo.org/docs/api/numbers/#babel.numbers.format_currency
+
+
 Upload/media settings
 =====================
 

--- a/src/oscar/templatetags/currency_filters.py
+++ b/src/oscar/templatetags/currency_filters.py
@@ -21,8 +21,11 @@ def currency(value, currency=None):
     # Using Babel's currency formatting
     # http://babel.pocoo.org/en/latest/api/numbers.html#babel.numbers.format_currency
     kwargs = {
-        'currency': currency if currency else settings.OSCAR_DEFAULT_CURRENCY,
+        'currency': (currency if not currency is None else
+            settings.OSCAR_DEFAULT_CURRENCY),
         'format': getattr(settings, 'OSCAR_CURRENCY_FORMAT', None),
         'locale': to_locale(get_language() or settings.LANGUAGE_CODE),
+        'currency_digits': getattr(settings, 'OSCAR_CURRENCY_DIGITS', True),
+        'format_type': getattr(settings, 'OSCAR_CURRENCY_FORMAT_TYPE', 'standard'),
     }
     return format_currency(value, **kwargs)


### PR DESCRIPTION
The current implementation of the `currency` filter does not allow all the parameters provided by `format_currency` to be configured, this PR adds to settings `OSCAR_CURRENCY_DIGITS` and `OSCAR_CURRENCY_FORMAT_TYPE`.

As `currency` is a filter I've used settings rather than arguments to configure the parameters.
