### PR TITLE
passing request object to place order view

### DIFF
--- a/src/oscar/apps/checkout/mixins.py
+++ b/src/oscar/apps/checkout/mixins.py
@@ -144,7 +144,8 @@ class OrderPlacementMixin(CheckoutSessionMixin):
             shipping_charge=shipping_charge,
             total=order_total,
             billing_address=billing_address,
-            status=status, **kwargs)
+            status=status,
+            req=self.request, **kwargs)
         self.save_payment_details(order)
         return order
 

--- a/src/oscar/apps/order/utils.py
+++ b/src/oscar/apps/order/utils.py
@@ -37,7 +37,7 @@ class OrderCreator(object):
     def place_order(self, basket, total,  # noqa (too complex (12))
                     shipping_method, shipping_charge, user=None,
                     shipping_address=None, billing_address=None,
-                    order_number=None, status=None, **kwargs):
+                    order_number=None, status=None, req=None, **kwargs):
         """
         Placing an order involves creating all the relevant models based on the
         basket and session data.
@@ -60,7 +60,7 @@ class OrderCreator(object):
         # Ok - everything seems to be in order, let's place the order
         order = self.create_order_model(
             user, basket, shipping_address, shipping_method, shipping_charge,
-            billing_address, total, order_number, status, **kwargs)
+            billing_address, total, order_number, status, req,  **kwargs)
         for line in basket.all_lines():
             self.create_line_models(order, line)
             self.update_stock_records(line)
@@ -95,13 +95,13 @@ class OrderCreator(object):
 
     def create_order_model(self, user, basket, shipping_address,
                            shipping_method, shipping_charge, billing_address,
-                           total, order_number, status, **extra_order_fields):
+                           total, order_number, status, req, **extra_order_fields):
         """
         Create an order model.
         """
         order_data = {'basket': basket,
                       'number': order_number,
-                      'site': Site._default_manager.get_current(),
+                      'site': Site._default_manager.get_current(req),
                       'currency': total.currency,
                       'total_incl_tax': total.incl_tax,
                       'total_excl_tax': total.excl_tax,


### PR DESCRIPTION
It is possible to use multiple sites in the project. While placing order, oscar uses site object form 'SITE_ID' settings from project settings. I have passed request object through mixins and it does not affect any functionality but it enables developer to get current_site from SITE model.

If you feel this should be included in oscar then please accept my pull request.

Any suggestions are welcome.

Thanks,
Jay Modi 
