### PR TITLE
Added a default ordering so get_queryset will not query the database again

### DIFF
--- a/src/oscar/apps/basket/abstract_models.py
+++ b/src/oscar/apps/basket/abstract_models.py
@@ -125,7 +125,8 @@ class AbstractBasket(models.Model):
                 self.lines
                 .select_related('product', 'stockrecord')
                 .prefetch_related(
-                    'attributes', 'product__images'))
+                    'attributes', 'product__images')
+                .order_by(self._meta.pk.name))
         return self._lines
 
     def is_quantity_allowed(self, qty):

--- a/tests/unit/basket/model_tests.py
+++ b/tests/unit/basket/model_tests.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 from oscar.apps.basket.models import Basket
 from oscar.apps.partner import strategy
 from oscar.test.factories import (
-    BasketFactory, BasketLineAttributeFactory, ProductFactory, OptionFactory)
+    BasketFactory, BasketLineAttributeFactory, OptionFactory, ProductFactory)
 
 
 class TestANewBasket(TestCase):
@@ -54,13 +54,22 @@ class TestBasketLine(TestCase):
         BasketLineAttributeFactory(
             line=line, value=u'\u2603', option__name='with')
         self.assertEqual(line.description, u"A product (with = '\u2603')")
-        
+
     def test_create_line_reference(self):
         basket = BasketFactory()
         product = ProductFactory(title="A product")
         option = OptionFactory(name="product_option", code="product_option")
         option_product = ProductFactory(title=u'Asunción')
-        options = [{'option' : option, 'value': option_product}]
-        basket.add_product(product, options = options)
-        
-        
+        options = [{'option': option, 'value': option_product}]
+        basket.add_product(product, options=options)
+
+    def test_basket_lines_queryset_is_ordered(self):
+        # This is needed to make sure a formset is not performing the query
+        # again with an order_by clause (losing all calculated discounts)
+        basket = BasketFactory()
+        product = ProductFactory(title="A product")
+        another_product = ProductFactory(title="Another product")
+        basket.add_product(product)
+        basket.add_product(another_product)
+        queryset = basket.all_lines()
+        self.assertTrue(queryset.ordered)


### PR DESCRIPTION
I tried customizing the basket view by adjusting the ``basket_content.html`` to display the discounts of each line. I encountered that the discounts were not there, however, the summary with the totals below it shows the discounts.

After some debugging I figured out that the queryset that is used (``basket.all_lines()``) contains the discounts applied as it uses a cached resultset with all offers applied:
```python
# oscar/apps/basket/views.py
class BasketView(ModelFormSetView):
    model = get_model('basket', 'Line')
    ...
    def get_queryset(self):
        return self.request.basket.all_lines()
```

This Formset which is used in the view is using this queryset, so the question is why the discount values are empty:
```python
# oscar/apps/basket/forms.py
class BaseBasketLineFormSet(BaseModelFormSet):

    def __init__(self, strategy, *args, **kwargs):
        self.strategy = strategy
        super(BaseBasketLineFormSet, self).__init__(*args, **kwargs)
        ...
```
The BaseModelFormSet is using the following code for getting the queryset:
```python
# django/forms/models.py
class BaseModelFormSet(BaseFormSet):
    ...
    def get_queryset(self):
        if not hasattr(self, '_queryset'):
            if self.queryset is not None:
                qs = self.queryset
            else:
                qs = self.model._default_manager.get_queryset()

            # If the queryset isn't already ordered we need to add an
            # artificial ordering here to make sure that all formsets
            # constructed from this queryset have the same form order.
            if not qs.ordered:
                qs = qs.order_by(self.model._meta.pk.name)

            # Removed queryset limiting here. As per discussion re: #13023
            # on django-dev, max_num should not prevent existing
            # related objects/inlines from being displayed.
            self._queryset = qs
        return self._queryset
```
So when the queryset is not ordered, it will query the database again with an ``order_by``, so then all discount values are lost. 

So that's the reason of this pull request :)