### PR TITLE
Update debug toolbar.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 -e .[test,docs]
 
 # Development
-django-debug-toolbar==1.4.0
+django-debug-toolbar==1.5.0
 django-extensions==1.6.1
 Werkzeug==0.9.6
 


### PR DESCRIPTION
Require debug toolbar 1.5.0 rather than 1.4.0 and thereby avoid a bug in the sql panel that breaks the entire sandbox default installation.