### PR TITLE
Fix UnicodeCSVWriter __enter__ method, breaking class usage as context manager, added test.

### DIFF
--- a/src/oscar/core/compat.py
+++ b/src/oscar/core/compat.py
@@ -151,6 +151,7 @@ class UnicodeCSVWriter:
                           encoding=self.encoding, newline='')
         else:
             self.f = open(self.filename, 'wb')
+        return self
 
     def __exit__(self, type, value, traceback):
         assert self.filename is not None


### PR DESCRIPTION
Fixes #2026 