### PR TITLE
Layout fixes in shipping_address template.

### DIFF
--- a/src/oscar/static/oscar/css/dashboard.css
+++ b/src/oscar/static/oscar/css/dashboard.css
@@ -3406,6 +3406,9 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 .navbar-form .select2-container.form-control {
   display: inline-block;
 }
+.navbar-form .form-group .form-inline {
+  display: inline-block;
+}
 .navbar-form .help-block:first-child,
 .navbar-form .error-block:first-child {
   display: none;

--- a/src/oscar/static/oscar/css/styles.css
+++ b/src/oscar/static/oscar/css/styles.css
@@ -9223,22 +9223,6 @@ input[type="number"][id*="quantity"] {
 .total {
   background-color: #FDF5D9!important;
 }
-.choose-block ul:before,
-.choose-block ul:after {
-  content: " ";
-  display: table;
-}
-.choose-block ul:after {
-  clear: both;
-}
-.choose-block ul:before,
-.choose-block ul:after {
-  content: " ";
-  display: table;
-}
-.choose-block ul:after {
-  clear: both;
-}
 .choose-block .well {
   position: relative;
   min-height: 240px;

--- a/src/oscar/static/oscar/less/page/checkout.less
+++ b/src/oscar/static/oscar/less/page/checkout.less
@@ -65,9 +65,6 @@ input[type="text"][id*="quantity"], input[type="number"][id*="quantity"] {
 
 // Choosing a shipping address
 .choose-block {
-    ul {
-        .clearfix();
-    }
     .well {
         position:relative;
         min-height:240px;

--- a/src/oscar/templates/oscar/checkout/shipping_address.html
+++ b/src/oscar/templates/oscar/checkout/shipping_address.html
@@ -14,6 +14,7 @@
 {% block order_contents %}{% endblock %}
 
 {% block shipping_address %}
+<div class="col-sm-12">
     <div class="sub-header">
         <h2>{% trans "Where should we ship to?" %}</h2>
     </div>
@@ -21,10 +22,10 @@
         {% if addresses %}
             <h3>{% trans "An address from your address book?" %}</h3>
             <div class="choose-block">
-                <ul class="list-unstyled row">
+                <div class="row">
                     {% for address in addresses %}
                         {% block select_address_form %}
-                            <li class="col-sm-6">
+                            <div class="col-sm-6">
                                 <div class="well">
                                     <address>
                                         {% block select_address_fields %}
@@ -54,18 +55,15 @@
                                         </div>
                                     </form>
                                 </div>
-                            </li>
+                            </div>
                             {% if forloop.counter|divisibleby:2 %}
-                                </ul>
-                                {% if not forloop.last %}<ul class="list-unstyled row">{% endif %}
+                                </div><div class="row">
                             {% endif %}
                         {% endblock %}
                     {% endfor %}
-                </ul>
+                </div>
             </div>
-            <h3>
-                {% trans "Or a new address?" %}
-            </h3>
+            <h3>{% trans "Or a new address?" %}</h3>
         {% endif %}
     {% endif %}
 
@@ -78,12 +76,12 @@
                     <div class="col-sm-offset-4 col-sm-8">
                         <button type="submit" class="btn btn-lg btn-primary" data-loading-text="{% trans 'Continuing...' %}">{% trans "Continue" %}</button>
                         {% trans "or" %} <a href="{% url 'basket:summary' %}">{% trans "return to basket" %}</a>
-
                     </div>
                 </div>
             </form>
         </div>
     {% endblock %}
+</div>
 {% endblock shipping_address %}
 
 {% block shipping_method %}{% endblock %}


### PR DESCRIPTION
Follow-up from #2056 to fix a few more issues in this template:

- Add an outer column class to the main block, because the parent template expects one.
- Remove use of UL in the address list, because it causes styling issues.
- Fix div closure logic in for loop.

There is also one line of dashboard CSS that was not compiled from the LESS.