### PR TITLE
Fix queryset used in ProductReviewList view.

### DIFF
--- a/src/oscar/apps/catalogue/reviews/views.py
+++ b/src/oscar/apps/catalogue/reviews/views.py
@@ -113,7 +113,7 @@ class ProductReviewList(ListView):
     paginate_by = settings.OSCAR_REVIEWS_PER_PAGE
 
     def get_queryset(self):
-        qs = self.model.approved.filter(product=self.kwargs['product_pk'])
+        qs = self.model.objects.approved().filter(product=self.kwargs['product_pk'])
         self.form = SortReviewsForm(self.request.GET)
         if self.form.is_valid():
             sort_by = self.form.cleaned_data['sort_by']


### PR DESCRIPTION
1c54fff7394fb8639d2ace1037bd71666b62574a (#1920) broke the query in `ProductReviewList`.