### PR TITLE
Mobile menu fix

### DIFF
--- a/src/oscar/templates/oscar/partials/nav_primary.html
+++ b/src/oscar/templates/oscar/partials/nav_primary.html
@@ -6,7 +6,7 @@
     <div class="container-fluid">
         <div class="navbar-header pull-right">
             {# This is used in mobile view #}
-            <a class="navbar-toggle" data-toggle="collapse" data-target=".primary-collapse">
+            <a class="btn btn-default navbar-toggle collapsed" data-toggle="collapse" data-target=".primary-collapse">
                 <span>
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>


### PR DESCRIPTION
The button which toggles the mobile menu besides the Basket button is broken. By adding the class .btn (and .btn-default for proper styling) makes the button accept click events again.
Must be tested on a real-device (Chrome Developer toolbar with device mocking already worked) to re-produce this issue. This PR fixes the issue.