### PR TITLE
Add `django.template.context_processors.i18n` context processor to the getting started documentation.

### DIFF
--- a/docs/source/internals/getting_started.rst
+++ b/docs/source/internals/getting_started.rst
@@ -74,6 +74,7 @@ context processors.
                     'django.template.context_processors.debug',
                     'django.template.context_processors.request',
                     'django.contrib.auth.context_processors.auth',
+                    'django.core.context_processors.i18n',
                     'django.contrib.messages.context_processors.messages',
 
                     'oscar.apps.search.context_processors.search_form',


### PR DESCRIPTION
Fixes #1837 