### PR TITLE
Include explicit value for RedirectView class

### DIFF
--- a/src/oscar/apps/customer/app.py
+++ b/src/oscar/apps/customer/app.py
@@ -134,7 +134,7 @@ class CustomerApplication(Application):
             # Notifications
             # Redirect to notification inbox
             url(r'^notifications/$', generic.RedirectView.as_view(
-                url='/accounts/notifications/inbox/')),
+                url='/accounts/notifications/inbox/', permanent=False)),
             url(r'^notifications/inbox/$',
                 login_required(self.notification_inbox_view.as_view()),
                 name='notifications-inbox'),


### PR DESCRIPTION
Default value of 'RedirectView.permanent' will change from True to False in Django 1.9. We're setting an explicit value to silence this warning when running Django.