### PR TITLE
Include explicit value for RedirectView class

### DIFF
--- a/src/oscar/apps/customer/views.py
+++ b/src/oscar/apps/customer/views.py
@@ -58,6 +58,7 @@ class AccountSummaryView(generic.RedirectView):
     having to change a lot of templates.
     """
     pattern_name = settings.OSCAR_ACCOUNTS_REDIRECT_URL
+    permanent = False
 
 
 class AccountRegistrationView(RegisterUserMixin, generic.FormView):


### PR DESCRIPTION
Just as in #2092. Default value of 'RedirectView.permanent' will change from True to False in Django 1.9. We're setting an explicit value to silence this warning when running Django.