### PR TITLE
Include explicit value for RedirectView class 

### DIFF
--- a/src/oscar/apps/customer/notifications/views.py
+++ b/src/oscar/apps/customer/notifications/views.py
@@ -77,6 +77,7 @@ class UpdateView(BulkEditMixin, generic.RedirectView):
     model = Notification
     actions = ('archive', 'delete')
     checkbox_object_name = 'notification'
+    permanent = False
 
     def get_object_dict(self, ids):
         return self.model.objects.filter(


### PR DESCRIPTION
Just as in #2092 and #2093 . Default value of 'RedirectView.permanent' will change from True to False in Django 1.9. We're setting an explicit value to silence this warning when running Django.