### PR TITLE
Add two payments package for django-oscar

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -170,6 +170,8 @@ The following are community-written extensions:
 * django-oscar-przelewy24_ - Integration with the Przelewy24 payment gateway
 * oscar-sagepay_ - Payment integration with Sage Pay
 * django-oscar-erp_
+* django-oscar-payu_ - PayU transactions for Oscar
+* django-oscar-cash-on-delivery_ - Cash on delivery transactions for Oscar
 
 Let us know if you're writing a new one!
 
@@ -180,6 +182,8 @@ Let us know if you're writing a new one!
 .. _django-oscar-adyen: https://github.com/oscaro/django-oscar-adyen
 .. _django-oscar-przelewy24: https://github.com/kisiel/django-oscar-przelewy24
 .. _oscar-sagepay: https://github.com/udox/oscar-sagepay
+.. _django-oscar-payu: https://github.com/SalahAdDin/django-oscar-payu
+.. _django-oscar-cash-on-delivery: https://github.com/michaelkuty/django-oscar-cash-on-delivery/
 
 License
 -------


### PR DESCRIPTION
Isn't easy maintain this packages without community help.
 In some countries isn't easy use paypal for payment, instead, is easy pay in moment, i mean, cash on delivery. And, for example in my country, PayU offers multiply payment methods: user credit card, debit card, cash on delivery, etc.

I think that many people find useful use this packages, and i'll like the Oscar's Official Team help us with this packages.
