### PR TITLE
Fix determination of hurry_mode for alerts

### DIFF
--- a/src/oscar/apps/customer/alerts/utils.py
+++ b/src/oscar/apps/customer/alerts/utils.py
@@ -70,11 +70,11 @@ def send_product_alerts(product):
     if num_stockrecords == 1:
         num_in_stock = stockrecords[0].num_in_stock
         # hurry_mode is false if num_in_stock is None
-        hurry_mode = num_in_stock is not None and num_alerts < num_in_stock
+        hurry_mode = num_in_stock is not None and num_alerts > num_in_stock
     else:
         result = stockrecords.aggregate(max_in_stock=Max('num_in_stock'))
         hurry_mode = result['max_in_stock'] is not None and \
-            num_alerts < result['max_in_stock']
+            num_alerts > result['max_in_stock']
 
     # Load templates
     message_tpl = loader.get_template('customer/alerts/message.html')


### PR DESCRIPTION
Hurry mode should be True if there are more active alerts than available stock for a product. Fixes #2100 
