### PR TITLE
Default datetime picker in the dashboard to zero seconds.

### DIFF
--- a/src/oscar/static/oscar/js/oscar/dashboard.js
+++ b/src/oscar/static/oscar/js/oscar/dashboard.js
@@ -26,6 +26,7 @@ var oscar = (function(o, $) {
                 'timeFormat': 'hh:ii',
                 'datetimeFormat': 'yy-mm-dd hh:ii',
                 'stepMinute': 15,
+                'initialDate': new Date(new Date().setSeconds(0)),
                 'tinyConfig': {
                     entity_encoding: 'raw',
                     statusbar: false,
@@ -155,7 +156,8 @@ var oscar = (function(o, $) {
                     'format': o.dashboard.options.datetimeFormat,
                     'minuteStep': o.dashboard.options.stepMinute,
                     'autoclose': true,
-                    'language': o.dashboard.options.languageCode
+                    'language': o.dashboard.options.languageCode,
+                    'initialDate': o.dashboard.options.initialDate
                 };
                 $datetimes = $(el).find('[data-oscarWidget="datetime"]').not('.no-widget-init').not('.no-widget-init *')
                 $datetimes.each(function(ind, ele) {
@@ -171,7 +173,8 @@ var oscar = (function(o, $) {
                     'format': o.dashboard.options.timeFormat,
                     'minuteStep': o.dashboard.options.stepMinute,
                     'autoclose': true,
-                    'language': o.dashboard.options.languageCode
+                    'language': o.dashboard.options.languageCode,
+                    'initialDate': o.dashboard.options.initialDate
                 };
                 $times = $(el).find('[data-oscarWidget="time"]').not('.no-widget-init').not('.no-widget-init *')
                 $times.each(function(ind, ele) {


### PR DESCRIPTION
Fixes #2104 