### PR TITLE
change productIndex text templete to a relative path

### DIFF
--- a/src/oscar/apps/search/search_indexes.py
+++ b/src/oscar/apps/search/search_indexes.py
@@ -12,7 +12,7 @@ class ProductIndex(indexes.SearchIndex, indexes.Indexable):
     # Search text
     text = indexes.EdgeNgramField(
         document=True, use_template=True,
-        template_name='oscar/search/indexes/product/item_text.txt')
+        template_name='search/indexes/product/item_text.txt')
 
     upc = indexes.CharField(model_attr="upc", null=True)
     title = indexes.EdgeNgramField(model_attr='title', null=True)


### PR DESCRIPTION
This PR is related to the issue [2114](https://github.com/django-oscar/django-oscar/issues/2114)
