### PR TITLE
Update getting_started.rst

### DIFF
--- a/docs/source/internals/getting_started.rst
+++ b/docs/source/internals/getting_started.rst
@@ -144,6 +144,8 @@ your ``MIDDLEWARE_CLASSES`` setting.
         'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
     )
 
+Note: In django 1.10 and above: make sure to replace ``MIDDLEWARE`` with ``MIDDLEWARE_CLASSES``
+
 Set your auth backends to:
 
 .. code-block:: django


### PR DESCRIPTION
## Scope

As per https://docs.djangoproject.com/en/1.10/topics/http/middleware/ MIDDLEWARE_CLASSES has changed to MIDDLEWARE.

Oscar still uses MIDDLEWARE_CLASSES and it should be noted to avoid confusion during setup.

Alternatively if this change isn't made it throws the following error when running `python manage.py rusnerver`

`VariableDoesNotExist: Failed lookup for key [basket] in u"<WSGIRequest: GET '/'>"`
