### PR TITLE
don't use ngram for main search field, returns irrelevant results

### DIFF
--- a/src/oscar/apps/search/search_indexes.py
+++ b/src/oscar/apps/search/search_indexes.py
@@ -10,7 +10,7 @@ strategy = Selector().strategy()
 
 class ProductIndex(indexes.SearchIndex, indexes.Indexable):
     # Search text
-    text = indexes.EdgeNgramField(
+    text = indexes.CharField(
         document=True, use_template=True,
         template_name='oscar/search/indexes/product/item_text.txt')
 


### PR DESCRIPTION
see issue #2127 

I assume `EdgeNgramField` was chosen to support autocomplete type of functionality.  I could not find where that was actually implemented anywhere though. In the meantime, using ngram field here causes lots of irrelevant results to appear in search.  So I think this is the right change.

If autocomplete is implemented I think it maybe makes sense to autocomplete on product titles only (rather than words from description) and the `title` field is still defined as another `EdgeNgramField` so that would work.
