### PR TITLE
- fixed sorting by title

### DIFF
--- a/src/oscar/apps/search/forms.py
+++ b/src/oscar/apps/search/forms.py
@@ -76,8 +76,8 @@ class SearchForm(FacetedSearchForm):
     }
     # Non Solr backends don't support dynamic fields so we just sort on title
     if not is_solr_supported():
-        SORT_BY_MAP[TITLE_A_TO_Z] = 'title'
-        SORT_BY_MAP[TITLE_Z_TO_A] = '-title'
+        SORT_BY_MAP[TITLE_A_TO_Z] = 'title_exact'
+        SORT_BY_MAP[TITLE_Z_TO_A] = '-title_exact'
 
     sort_by = forms.ChoiceField(
         label=_("Sort by"), choices=SORT_BY_CHOICES,

--- a/src/oscar/apps/search/search_indexes.py
+++ b/src/oscar/apps/search/search_indexes.py
@@ -16,6 +16,7 @@ class ProductIndex(indexes.SearchIndex, indexes.Indexable):
 
     upc = indexes.CharField(model_attr="upc", null=True)
     title = indexes.EdgeNgramField(model_attr='title', null=True)
+    title_exact = indexes.CharField(model_attr='title', null=True, indexed=False)
 
     # Fields for faceting
     product_class = indexes.CharField(null=True, faceted=True)


### PR DESCRIPTION
Sorting product by title doesn't work with Elasticsearch backend, because Elasticearch doesn't sort ngram fields correctly.
This request adds unanalyzed title CharField that is sorted correctly by all backends.

p.s. partially addresses #1872 
