### PR TITLE
- added documentation for facet sorting

### DIFF
--- a/docs/source/ref/settings.rst
+++ b/docs/source/ref/settings.rst
@@ -86,7 +86,9 @@ all default to 20.
 
 A dictionary that specifies the facets to use with the search backend.  It
 needs to be a dict with keys ``fields`` and ``queries`` for field- and
-query-type facets.  The default is::
+query-type facets. Field-type facets can get an 'options' element with parameters like facet
+sorting, filtering, etc.
+The default is::
 
     OSCAR_SEARCH_FACETS = {
         'fields': OrderedDict([

--- a/src/oscar/defaults.py
+++ b/src/oscar/defaults.py
@@ -224,7 +224,10 @@ OSCAR_SEARCH_FACETS = {
         ('product_class', {'name': _('Type'), 'field': 'product_class'}),
         ('rating', {'name': _('Rating'), 'field': 'rating'}),
         # You can specify an 'options' element that will be passed to the
-        # SearchQuerySet.facet() call.  It's hard to get 'missing' to work
+        # SearchQuerySet.facet() call.
+        # For instance, with Elasticsearch backend, 'options': {'order': 'term'}
+        # will sort items in a facet by title instead of number of items.
+        # It's hard to get 'missing' to work
         # correctly though as of Solr's hilarious syntax for selecting
         # items without a specific facet:
         # http://wiki.apache.org/solr/SimpleFacetParameters#facet.method


### PR DESCRIPTION
django-oscar provides an easy way of sorting/filtering faceted items, you just pass sorting/filtering parameter through 'options'. 
Yet, the documentation says almost nothing about it, so it took a while for me to understand it. By this documentation improvement I want to make it a bit more clear how to do facet sorting/filtering.