### PR TITLE
fix oscar_populate_countries with current pycountry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,5 @@ ipython==4.0.1
 isort==4.2.2
 
 # Country data
-pycountry==1.10
+pycountry==16.11.27.1
+

--- a/src/oscar/management/commands/oscar_populate_countries.py
+++ b/src/oscar/management/commands/oscar_populate_countries.py
@@ -47,10 +47,10 @@ class Command(BaseCommand):
                 num_created = 0
                 for country in pycountry.countries:
                     oscar_country, created = Country.objects.get_or_create(
-                        iso_3166_1_a2=country.alpha2
+                        iso_3166_1_a2=country.alpha_2
                     )
-                    oscar_country.iso_3166_1_a2 = country.alpha2
-                    oscar_country.iso_3166_1_a3 = country.alpha3
+                    oscar_country.iso_3166_1_a2 = country.alpha_2
+                    oscar_country.iso_3166_1_a3 = country.alpha_3
                     oscar_country.iso_3166_1_numeric = country.numeric
                     oscar_country.printable_name = country.name
                     oscar_country.name = getattr(country, 'official_name', country.name)
@@ -68,8 +68,8 @@ class Command(BaseCommand):
         else:
             countries = [
                 Country(
-                    iso_3166_1_a2=country.alpha2,
-                    iso_3166_1_a3=country.alpha3,
+                    iso_3166_1_a2=country.alpha_2,
+                    iso_3166_1_a3=country.alpha_3,
                     iso_3166_1_numeric=country.numeric,
                     printable_name=country.name,
                     name=getattr(country, 'official_name', country.name),


### PR DESCRIPTION
pycountry has changed the format of the alpha* attributes[0], thus
breaking oscar_populate_countries. This commit updates the
oscar_populate_countries management command to work with current
versions of pycountry.

[0] https://bitbucket.org/flyingcircus/pycountry/src/06ef9e89c25d7d9286a5ac9da150f832ed4cb02f/HISTORY.txt?at=default&fileviewer=file-view-default#HISTORY.txt-102