### PR TITLE
Enable the TinyMCE 'lists' plugin as this functionality was dropped from the core

### DIFF
--- a/src/oscar/static/oscar/js/oscar/dashboard.js
+++ b/src/oscar/static/oscar/js/oscar/dashboard.js
@@ -31,7 +31,7 @@ var oscar = (function(o, $) {
                     entity_encoding: 'raw',
                     statusbar: false,
                     menubar: false,
-                    plugins: "link",
+                    plugins: "link lists",
                     style_formats: [
                         {title: 'Text', block: 'p'},
                         {title: 'Heading', block: 'h2'},


### PR DESCRIPTION
TinyMCE 4.5 removed `bullist` and `numlist` from the core, meaning that these buttons disappeared from the editor in the product edit dashboard view (see https://github.com/tinymce/tinymce/issues/3342). This patch enables the `lists` plugin so that these buttons become available again.