### PR TITLE
Support pycountry >= 16.10.23rc1

### DIFF
--- a/src/oscar/management/commands/oscar_populate_countries.py
+++ b/src/oscar/management/commands/oscar_populate_countries.py
@@ -46,10 +46,14 @@ class Command(BaseCommand):
                     'You already have countries in your database. This command'
                     ' currently does not support updating existing countries.')
 
+        test_country = list(pycountry.countries)[0]
+        a2 = 'alpha2' if hasattr(test_country, 'alpha2') else 'alpha_2'
+        a3 = 'alpha3' if hasattr(test_country, 'alpha3') else 'alpha_3'
+
         countries = [
             Country(
-                iso_3166_1_a2=country.alpha2,
-                iso_3166_1_a3=country.alpha3,
+                iso_3166_1_a2=getattr(country, a2),
+                iso_3166_1_a3=getattr(country, a3),
                 iso_3166_1_numeric=country.numeric,
                 printable_name=country.name,
                 name=getattr(country, 'official_name', ''),


### PR DESCRIPTION
Fix issue #2183 
Since pycountry >= 16.10.23rc1: 

> Note that "alpha2", "alpha4", etc. are now using an underscore as that's the pattern in the upstream packages. So it's "alpha_2" now.
[Source](https://bitbucket.org/flyingcircus/pycountry/src/4b3a8c9ca4604270b4aa6d92f7b53bfd1eb7454d/HISTORY.txt?at=default&fileviewer=file-view-default)