### PR TITLE
Support pycountry >= 16.10.23rc1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ ipython==4.0.1
 isort==4.2.2
 
 # Country data
-pycountry==1.10
+pycountry==17.1.8

--- a/src/oscar/management/commands/oscar_populate_countries.py
+++ b/src/oscar/management/commands/oscar_populate_countries.py
@@ -48,8 +48,8 @@ class Command(BaseCommand):
 
         countries = [
             Country(
-                iso_3166_1_a2=country.alpha2,
-                iso_3166_1_a3=country.alpha3,
+                iso_3166_1_a2=country.alpha_2,
+                iso_3166_1_a3=country.alpha_3,
                 iso_3166_1_numeric=country.numeric,
                 printable_name=country.name,
                 name=getattr(country, 'official_name', ''),


### PR DESCRIPTION
Fix issue #2183 
Without support for pycountry < 16.10.23rc1
I couldn't think of any good reason for supporting older pycountry versions.