### PR TITLE
Fix blocktrans context in dashboard review update template

### DIFF
--- a/src/oscar/templates/oscar/dashboard/reviews/review_update.html
+++ b/src/oscar/templates/oscar/dashboard/reviews/review_update.html
@@ -21,7 +21,7 @@
 {% endblock %}
 
 {% block headertext %}
-    {% blocktrans %}Review #{{ review.id }}{% endblocktrans %}
+    {% blocktrans with review_id=review.id %}Review #{{ review_id }}{% endblocktrans %}
 {% endblock %}
 
 {% block dashboard_content %}


### PR DESCRIPTION
You cannot access object attributes directly from inside a blocktrans tag.