### PR TITLE
Fix various deprecation warnings

### DIFF
--- a/sandbox/urls.py
+++ b/sandbox/urls.py
@@ -34,7 +34,7 @@ urlpatterns += i18n_patterns(
     # Custom functionality to allow dashboard users to be created
     url(r'gateway/', include(gateway_urls)),
     # Oscar's normal URLs
-    url(r'^', include(application.urls)),
+    url(r'^', application.urls),
 )
 
 if settings.DEBUG:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,12 @@
 [bdist_wheel]
 universal=1
 
-[pytest]
+[tool:pytest]
 python_files=test_*.py *tests.py
 testpaths = tests/
+filterwarnings = 
+    ignore:.*is deprecated.*:Warning:django_webtest.middleware
+    ignore::DeprecationWarning:sorl.thumbnail.base
 
 [flake8]
 exclude = migrations

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ docs_requires = [
 ]
 
 test_requires = [
-    'WebTest==2.0.23',
+    'WebTest==2.0.24',
     'coverage==4.3.4',
     'django-webtest==1.8.0',
     'py>=1.4.31',

--- a/src/oscar/app.py
+++ b/src/oscar/app.py
@@ -1,7 +1,7 @@
 # flake8: noqa, because URL syntax is more readable with long lines
 
 from django.conf import settings
-from django.conf.urls import include, url
+from django.conf.urls import url
 from django.contrib.auth import views as auth_views
 from django.core.urlresolvers import reverse_lazy
 
@@ -27,13 +27,13 @@ class Shop(Application):
 
     def get_urls(self):
         urls = [
-            url(r'^catalogue/', include(self.catalogue_app.urls)),
-            url(r'^basket/', include(self.basket_app.urls)),
-            url(r'^checkout/', include(self.checkout_app.urls)),
-            url(r'^accounts/', include(self.customer_app.urls)),
-            url(r'^search/', include(self.search_app.urls)),
-            url(r'^dashboard/', include(self.dashboard_app.urls)),
-            url(r'^offers/', include(self.offer_app.urls)),
+            url(r'^catalogue/', self.catalogue_app.urls),
+            url(r'^basket/', self.basket_app.urls),
+            url(r'^checkout/', self.checkout_app.urls),
+            url(r'^accounts/', self.customer_app.urls),
+            url(r'^search/', self.search_app.urls),
+            url(r'^dashboard/', self.dashboard_app.urls),
+            url(r'^offers/', self.offer_app.urls),
 
             # Password reset - as we're using Django's default view functions,
             # we can't namespace these urls as that prevents
@@ -59,7 +59,7 @@ class Shop(Application):
         ]
 
         if settings.OSCAR_PROMOTIONS_ENABLED:
-            urls.append(url(r'', include(self.promotions_app.urls)))
+            urls.append(url(r'', self.promotions_app.urls))
         return urls
 
 application = Shop()

--- a/src/oscar/apps/analytics/receivers.py
+++ b/src/oscar/apps/analytics/receivers.py
@@ -5,6 +5,7 @@ from django.db.models import F
 from django.dispatch import receiver
 
 from oscar.apps.search.signals import user_search
+from oscar.core.compat import user_is_authenticated
 from oscar.core.loading import get_class, get_classes
 
 UserSearch, UserRecord, ProductRecord, UserProductView = get_classes(
@@ -77,14 +78,14 @@ def receive_product_view(sender, product, user, **kwargs):
     if kwargs.get('raw', False):
         return
     _update_counter(ProductRecord, 'num_views', {'product': product})
-    if user and user.is_authenticated():
+    if user and user_is_authenticated(user):
         _update_counter(UserRecord, 'num_product_views', {'user': user})
         UserProductView.objects.create(product=product, user=user)
 
 
 @receiver(user_search)
 def receive_product_search(sender, query, user, **kwargs):
-    if user and user.is_authenticated() and not kwargs.get('raw', False):
+    if user and user_is_authenticated(user) and not kwargs.get('raw', False):
         UserSearch._default_manager.create(user=user, query=query)
 
 
@@ -94,7 +95,7 @@ def receive_basket_addition(sender, product, user, **kwargs):
         return
     _update_counter(
         ProductRecord, 'num_basket_additions', {'product': product})
-    if user and user.is_authenticated():
+    if user and user_is_authenticated(user):
         _update_counter(UserRecord, 'num_basket_additions', {'user': user})
 
 
@@ -103,5 +104,5 @@ def receive_order_placed(sender, order, user, **kwargs):
     if kwargs.get('raw', False):
         return
     _record_products_in_order(order)
-    if user and user.is_authenticated():
+    if user and user_is_authenticated(user):
         _record_user_order(user, order)

--- a/src/oscar/apps/basket/middleware.py
+++ b/src/oscar/apps/basket/middleware.py
@@ -4,7 +4,7 @@ from django.core.signing import BadSignature, Signer
 from django.utils.functional import SimpleLazyObject, empty
 from django.utils.translation import ugettext_lazy as _
 
-from oscar.core.compat import MiddlewareMixin
+from oscar.core.compat import MiddlewareMixin, user_is_authenticated
 from oscar.core.loading import get_class, get_model
 
 Applicator = get_class('offer.utils', 'Applicator')
@@ -81,7 +81,7 @@ class BasketMiddleware(MiddlewareMixin):
 
         # If a basket has had products added to it, but the user is anonymous
         # then we need to assign it to a cookie
-        if (request.basket.id and not request.user.is_authenticated()
+        if (request.basket.id and not user_is_authenticated(request.user)
                 and not has_basket_cookie):
             cookie = self.get_basket_hash(request.basket.id)
             response.set_cookie(
@@ -131,7 +131,7 @@ class BasketMiddleware(MiddlewareMixin):
         cookie_key = self.get_cookie_key(request)
         cookie_basket = self.get_cookie_basket(cookie_key, request, manager)
 
-        if hasattr(request, 'user') and request.user.is_authenticated():
+        if hasattr(request, 'user') and user_is_authenticated(request.user):
             # Signed-in user: if they have a cookie basket too, it means
             # that they have just signed in and we need to merge their cookie
             # basket into their user basket, then delete the cookie.

--- a/src/oscar/apps/basket/views.py
+++ b/src/oscar/apps/basket/views.py
@@ -14,6 +14,7 @@ from extra_views import ModelFormSetView
 
 from oscar.apps.basket import signals
 from oscar.core import ajax
+from oscar.core.compat import user_is_authenticated
 from oscar.core.loading import get_class, get_classes, get_model
 from oscar.core.utils import redirect_to_referrer, safe_referrer
 
@@ -113,7 +114,7 @@ class BasketView(ModelFormSetView):
         context['upsell_messages'] = self.get_upsell_messages(
             self.request.basket)
 
-        if self.request.user.is_authenticated():
+        if user_is_authenticated(self.request.user):
             try:
                 saved_basket = self.basket_model.saved.get(
                     owner=self.request.user)
@@ -148,7 +149,7 @@ class BasketView(ModelFormSetView):
             if (hasattr(form, 'cleaned_data') and
                     form.cleaned_data['save_for_later']):
                 line = form.instance
-                if self.request.user.is_authenticated():
+                if user_is_authenticated(self.request.user):
                     self.move_line_to_saved_basket(line)
 
                     msg = render_to_string(

--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -22,6 +22,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import get_language, pgettext_lazy
 from treebeard.mp_tree import MP_Node
 
+from oscar.core.compat import user_is_anonymous, user_is_authenticated
 from oscar.core.decorators import deprecated
 from oscar.core.loading import get_class, get_classes, get_model
 from oscar.core.utils import slugify
@@ -674,7 +675,7 @@ class AbstractProduct(models.Model):
         return rating
 
     def has_review_by(self, user):
-        if user.is_anonymous():
+        if user_is_anonymous(user):
             return False
         return self.reviews.filter(user=user).exists()
 
@@ -688,7 +689,7 @@ class AbstractProduct(models.Model):
         Override this if you want to alter the default behaviour; e.g. enforce
         that a user purchased the product to be allowed to leave a review.
         """
-        if user.is_authenticated() or settings.OSCAR_ALLOW_ANON_REVIEWS:
+        if user_is_authenticated(user) or settings.OSCAR_ALLOW_ANON_REVIEWS:
             return not self.has_review_by(user)
         else:
             return False

--- a/src/oscar/apps/catalogue/app.py
+++ b/src/oscar/apps/catalogue/app.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.conf.urls import url
 
 from oscar.apps.catalogue.reviews.app import application as reviews_app
 from oscar.core.application import Application
@@ -36,7 +36,7 @@ class ReviewsApplication(Application):
         urlpatterns = super(ReviewsApplication, self).get_urls()
         urlpatterns += [
             url(r'^(?P<product_slug>[\w-]*)_(?P<product_pk>\d+)/reviews/',
-                include(self.reviews_app.urls)),
+                self.reviews_app.urls)
         ]
         return self.post_process_urls(urlpatterns)
 

--- a/src/oscar/apps/catalogue/reviews/abstract_models.py
+++ b/src/oscar/apps/catalogue/reviews/abstract_models.py
@@ -9,7 +9,7 @@ from django.utils.translation import pgettext_lazy
 from oscar.apps.catalogue.reviews.managers import ProductReviewQuerySet
 from oscar.apps.catalogue.reviews.utils import get_default_review_status
 from oscar.core import validators
-from oscar.core.compat import AUTH_USER_MODEL
+from oscar.core.compat import AUTH_USER_MODEL, user_is_authenticated
 
 
 @python_2_unicode_compatible
@@ -169,7 +169,7 @@ class AbstractProductReview(models.Model):
         Test whether the passed user is allowed to vote on this
         review
         """
-        if not user.is_authenticated():
+        if not user_is_authenticated(user):
             return False, _(u"Only signed in users can vote")
         vote = self.votes.model(review=self, user=user, delta=1)
         try:

--- a/src/oscar/apps/catalogue/reviews/forms.py
+++ b/src/oscar/apps/catalogue/reviews/forms.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 
+from oscar.core.compat import user_is_authenticated
 from oscar.core.loading import get_model
 
 Vote = get_model('reviews', 'vote')
@@ -14,7 +15,7 @@ class ProductReviewForm(forms.ModelForm):
     def __init__(self, product, user=None, *args, **kwargs):
         super(ProductReviewForm, self).__init__(*args, **kwargs)
         self.instance.product = product
-        if user and user.is_authenticated():
+        if user and user_is_authenticated(user):
             self.instance.user = user
             del self.fields['name']
             del self.fields['email']

--- a/src/oscar/apps/catalogue/views.py
+++ b/src/oscar/apps/catalogue/views.py
@@ -9,6 +9,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.views.generic import DetailView, TemplateView
 
 from oscar.apps.catalogue.signals import product_viewed
+from oscar.core.compat import user_is_authenticated
 from oscar.core.loading import get_class, get_model
 
 Product = get_model('catalogue', 'product')
@@ -71,7 +72,7 @@ class ProductDetailView(DetailView):
     def get_alert_status(self):
         # Check if this user already have an alert for this product
         has_alert = False
-        if self.request.user.is_authenticated():
+        if user_is_authenticated(self.request.user):
             alerts = ProductAlert.objects.filter(
                 product=self.object, user=self.request.user,
                 status=ProductAlert.ACTIVE)

--- a/src/oscar/apps/checkout/mixins.py
+++ b/src/oscar/apps/checkout/mixins.py
@@ -2,6 +2,7 @@ import logging
 
 from django.contrib.sites.models import Site
 from django.contrib.sites.shortcuts import get_current_site
+from oscar.core.compat import user_is_authenticated
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import NoReverseMatch, reverse
 from django.http import HttpResponseRedirect
@@ -160,7 +161,7 @@ class OrderPlacementMixin(CheckoutSessionMixin):
         if not shipping_address:
             return None
         shipping_address.save()
-        if user.is_authenticated():
+        if user_is_authenticated(user):
             self.update_address_book(user, shipping_address)
         return shipping_address
 
@@ -288,7 +289,7 @@ class OrderPlacementMixin(CheckoutSessionMixin):
             'lines': order.lines.all()
         }
 
-        if not self.request.user.is_authenticated():
+        if not user_is_authenticated(self.request.user):
             # Attempt to add the anon order status URL to the email template
             # ctx.
             try:

--- a/src/oscar/apps/checkout/session.py
+++ b/src/oscar/apps/checkout/session.py
@@ -7,6 +7,7 @@ from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 
 from oscar.core import prices
+from oscar.core.compat import user_is_authenticated
 from oscar.core.loading import get_class, get_model
 
 from . import exceptions
@@ -141,7 +142,7 @@ class CheckoutSessionMixin(object):
             )
 
     def check_user_email_is_captured(self, request):
-        if not request.user.is_authenticated() \
+        if not user_is_authenticated(request.user) \
                 and not self.checkout_session.get_guest_email():
             raise exceptions.FailedPreCondition(
                 url=reverse('checkout:index'),
@@ -298,7 +299,7 @@ class CheckoutSessionMixin(object):
 
         # Set guest email after overrides as we need to update the order_kwargs
         # entry.
-        if (not submission['user'].is_authenticated() and
+        if (not user_is_authenticated(submission['user']) and
                 'guest_email' not in submission['order_kwargs']):
             email = self.checkout_session.get_guest_email()
             submission['order_kwargs']['guest_email'] = email

--- a/src/oscar/apps/checkout/views.py
+++ b/src/oscar/apps/checkout/views.py
@@ -3,6 +3,7 @@ import logging
 from django import http
 from django.contrib import messages
 from django.contrib.auth import login
+from oscar.core.compat import user_is_authenticated
 from django.core.urlresolvers import reverse, reverse_lazy
 from django.shortcuts import redirect
 from django.utils import six
@@ -58,7 +59,7 @@ class IndexView(CheckoutSessionMixin, generic.FormView):
     def get(self, request, *args, **kwargs):
         # We redirect immediately to shipping address stage if the user is
         # signed in.
-        if request.user.is_authenticated():
+        if user_is_authenticated(request.user):
             # We raise a signal to indicate that the user has entered the
             # checkout process so analytics tools can track this event.
             signals.start_checkout.send_robust(
@@ -154,7 +155,7 @@ class ShippingAddressView(CheckoutSessionMixin, generic.FormView):
 
     def get_context_data(self, **kwargs):
         ctx = super(ShippingAddressView, self).get_context_data(**kwargs)
-        if self.request.user.is_authenticated():
+        if user_is_authenticated(self.request.user):
             # Look up address book data
             ctx['addresses'] = self.get_available_addresses()
         return ctx
@@ -170,7 +171,7 @@ class ShippingAddressView(CheckoutSessionMixin, generic.FormView):
     def post(self, request, *args, **kwargs):
         # Check if a shipping address was selected directly (eg no form was
         # filled in)
-        if self.request.user.is_authenticated() \
+        if user_is_authenticated(self.request.user) \
                 and 'address_id' in self.request.POST:
             address = UserAddress._default_manager.get(
                 pk=self.request.POST['address_id'], user=self.request.user)
@@ -507,7 +508,7 @@ class PaymentDetailsView(OrderPlacementMixin, generic.TemplateView):
         Note, this isn't used in core oscar as there is no billing address form
         by default.
         """
-        if not self.request.user.is_authenticated():
+        if not user_is_authenticated(self.request.user):
             return None
         try:
             return self.request.user.addresses.get(is_default_for_billing=True)

--- a/src/oscar/apps/customer/alerts/views.py
+++ b/src/oscar/apps/customer/alerts/views.py
@@ -7,6 +7,7 @@ from django.views import generic
 
 from oscar.apps.customer.alerts import utils
 from oscar.apps.customer.mixins import PageTitleMixin
+from oscar.core.compat import user_is_authenticated
 from oscar.core.loading import get_class, get_model
 
 Product = get_model('catalogue', 'Product')
@@ -109,7 +110,7 @@ class ProductAlertCancelView(generic.RedirectView):
     def get(self, request, *args, **kwargs):
         if 'key' in kwargs:
             self.alert = get_object_or_404(ProductAlert, key=kwargs['key'])
-        elif 'pk' in kwargs and request.user.is_authenticated():
+        elif 'pk' in kwargs and user_is_authenticated(request.user):
             self.alert = get_object_or_404(ProductAlert,
                                            user=self.request.user,
                                            pk=kwargs['pk'])

--- a/src/oscar/apps/customer/forms.py
+++ b/src/oscar/apps/customer/forms.py
@@ -12,7 +12,8 @@ from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import pgettext_lazy
 
 from oscar.apps.customer.utils import get_password_reset_url, normalise_email
-from oscar.core.compat import existing_user_fields, get_user_model
+from oscar.core.compat import (
+    existing_user_fields, get_user_model, user_is_authenticated)
 from oscar.core.loading import get_class, get_model, get_profile_class
 from oscar.core.validators import password_validators
 from oscar.forms import widgets
@@ -375,13 +376,13 @@ class ProductAlertForm(forms.ModelForm):
         super(ProductAlertForm, self).__init__(*args, **kwargs)
 
         # Only show email field to unauthenticated users
-        if user and user.is_authenticated():
+        if user and user_is_authenticated(user):
             self.fields['email'].widget = forms.HiddenInput()
             self.fields['email'].required = False
 
     def save(self, commit=True):
         alert = super(ProductAlertForm, self).save(commit=False)
-        if self.user.is_authenticated():
+        if user_is_authenticated(self.user):
             alert.user = self.user
         alert.product = self.product
         if commit:
@@ -401,7 +402,7 @@ class ProductAlertForm(forms.ModelForm):
             else:
                 raise forms.ValidationError(_(
                     "There is already an active stock alert for %s") % email)
-        elif self.user.is_authenticated():
+        elif user_is_authenticated(self.user):
             try:
                 ProductAlert.objects.get(product=self.product,
                                          user=self.user,

--- a/src/oscar/apps/customer/notifications/context_processors.py
+++ b/src/oscar/apps/customer/notifications/context_processors.py
@@ -1,3 +1,4 @@
+from oscar.core.compat import user_is_authenticated
 from oscar.core.loading import get_model
 
 Notification = get_model('customer', 'Notification')
@@ -5,7 +6,7 @@ Notification = get_model('customer', 'Notification')
 
 def notifications(request):
     ctx = {}
-    if getattr(request, 'user', None) and request.user.is_authenticated():
+    if getattr(request, 'user', None) and user_is_authenticated(request.user):
         num_unread = Notification.objects.filter(
             recipient=request.user, date_read=None).count()
         ctx['num_unread_notifications'] = num_unread

--- a/src/oscar/apps/customer/utils.py
+++ b/src/oscar/apps/customer/utils.py
@@ -7,6 +7,7 @@ from django.core.urlresolvers import reverse
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
 
+from oscar.core.compat import user_is_authenticated
 from oscar.core.loading import get_model
 
 CommunicationEvent = get_model('order', 'CommunicationEvent')
@@ -72,7 +73,7 @@ class Dispatcher(object):
         email = self.send_email_messages(user.email, messages)
 
         # Is user is signed in, record the event for audit
-        if email and user.is_authenticated():
+        if email and user_is_authenticated(user):
             Email._default_manager.create(user=user,
                                           subject=email.subject,
                                           body_text=email.body,

--- a/src/oscar/apps/customer/views.py
+++ b/src/oscar/apps/customer/views.py
@@ -12,7 +12,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.views import generic
 
 from oscar.apps.customer.utils import get_password_reset_url
-from oscar.core.compat import get_user_model
+from oscar.core.compat import get_user_model, user_is_authenticated
 from oscar.core.loading import (
     get_class, get_classes, get_model, get_profile_class)
 from oscar.core.utils import safe_referrer
@@ -67,7 +67,7 @@ class AccountRegistrationView(RegisterUserMixin, generic.FormView):
     redirect_field_name = 'next'
 
     def get(self, request, *args, **kwargs):
-        if request.user.is_authenticated():
+        if user_is_authenticated(request.user):
             return redirect(settings.LOGIN_REDIRECT_URL)
         return super(AccountRegistrationView, self).get(
             request, *args, **kwargs)
@@ -107,7 +107,7 @@ class AccountAuthView(RegisterUserMixin, generic.TemplateView):
     redirect_field_name = 'next'
 
     def get(self, request, *args, **kwargs):
-        if request.user.is_authenticated():
+        if user_is_authenticated(request.user):
             return redirect(settings.LOGIN_REDIRECT_URL)
         return super(AccountAuthView, self).get(
             request, *args, **kwargs)

--- a/src/oscar/apps/dashboard/app.py
+++ b/src/oscar/apps/dashboard/app.py
@@ -1,6 +1,6 @@
 from django.contrib.auth import views as auth_views
 from django.contrib.auth.forms import AuthenticationForm
-from django.conf.urls import include, url
+from django.conf.urls import url
 
 from oscar.core.application import DashboardApplication
 from oscar.core.loading import get_class
@@ -30,19 +30,19 @@ class DashboardApplication(DashboardApplication):
     def get_urls(self):
         urls = [
             url(r'^$', self.index_view.as_view(), name='index'),
-            url(r'^catalogue/', include(self.catalogue_app.urls)),
-            url(r'^reports/', include(self.reports_app.urls)),
-            url(r'^orders/', include(self.orders_app.urls)),
-            url(r'^users/', include(self.users_app.urls)),
-            url(r'^content-blocks/', include(self.promotions_app.urls)),
-            url(r'^pages/', include(self.pages_app.urls)),
-            url(r'^partners/', include(self.partners_app.urls)),
-            url(r'^offers/', include(self.offers_app.urls)),
-            url(r'^ranges/', include(self.ranges_app.urls)),
-            url(r'^reviews/', include(self.reviews_app.urls)),
-            url(r'^vouchers/', include(self.vouchers_app.urls)),
-            url(r'^comms/', include(self.comms_app.urls)),
-            url(r'^shipping/', include(self.shipping_app.urls)),
+            url(r'^catalogue/', self.catalogue_app.urls),
+            url(r'^reports/', self.reports_app.urls),
+            url(r'^orders/', self.orders_app.urls),
+            url(r'^users/', self.users_app.urls),
+            url(r'^content-blocks/', self.promotions_app.urls),
+            url(r'^pages/', self.pages_app.urls),
+            url(r'^partners/', self.partners_app.urls),
+            url(r'^offers/', self.offers_app.urls),
+            url(r'^ranges/', self.ranges_app.urls),
+            url(r'^reviews/', self.reviews_app.urls),
+            url(r'^vouchers/', self.vouchers_app.urls),
+            url(r'^comms/', self.comms_app.urls),
+            url(r'^shipping/', self.shipping_app.urls),
 
             url(r'^login/$', auth_views.login, {
                 'template_name': 'dashboard/login.html',

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -1120,7 +1120,7 @@ class AbstractRangeProductFileUpload(models.Model):
         Extract all SKU- or UPC-like strings from the file
         """
         with open(self.filepath, 'r') as fh:
-            for line in fh.readlines():
+            for line in fh:
                 for id in re.split('[^\w:\.-]', line):
                     if id:
                         yield id

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -1119,10 +1119,11 @@ class AbstractRangeProductFileUpload(models.Model):
         """
         Extract all SKU- or UPC-like strings from the file
         """
-        for line in open(self.filepath, 'r'):
-            for id in re.split('[^\w:\.-]', line):
-                if id:
-                    yield id
+        with open(self.filepath, 'r') as fh:
+            for line in fh.readlines():
+                for id in re.split('[^\w:\.-]', line):
+                    if id:
+                        yield id
 
     def delete_file(self):
         os.unlink(self.filepath)

--- a/src/oscar/apps/order/utils.py
+++ b/src/oscar/apps/order/utils.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.contrib.sites.models import Site
 from django.utils.translation import ugettext_lazy as _
 
+from oscar.core.compat import user_is_authenticated
 from oscar.core.loading import get_class, get_model
 
 from . import exceptions
@@ -112,7 +113,7 @@ class OrderCreator(object):
             order_data['shipping_address'] = shipping_address
         if billing_address:
             order_data['billing_address'] = billing_address
-        if user and user.is_authenticated():
+        if user and user_is_authenticated(user):
             order_data['user_id'] = user.id
         if status:
             order_data['status'] = status

--- a/src/oscar/apps/partner/strategy.py
+++ b/src/oscar/apps/partner/strategy.py
@@ -1,5 +1,7 @@
 from collections import namedtuple
 from decimal import Decimal as D
+
+from oscar.core.compat import user_is_authenticated
 from oscar.core.loading import get_class
 
 Unavailable = get_class('partner.availability', 'Unavailable')
@@ -57,7 +59,7 @@ class Base(object):
     def __init__(self, request=None):
         self.request = request
         self.user = None
-        if request and request.user.is_authenticated():
+        if request and user_is_authenticated(request.user):
             self.user = request.user
 
     def fetch_for_product(self, product, stockrecord=None):

--- a/src/oscar/apps/voucher/abstract_models.py
+++ b/src/oscar/apps/voucher/abstract_models.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
-from oscar.core.compat import AUTH_USER_MODEL
+from oscar.core.compat import AUTH_USER_MODEL, user_is_authenticated
 
 
 @python_2_unicode_compatible
@@ -105,7 +105,7 @@ class AbstractVoucher(models.Model):
         elif self.usage == self.MULTI_USE:
             is_available = True
         elif self.usage == self.ONCE_PER_CUSTOMER:
-            if not user.is_authenticated():
+            if not user_is_authenticated(user):
                 is_available = False
                 message = _(
                     "This voucher is only available to signed in users")
@@ -121,7 +121,7 @@ class AbstractVoucher(models.Model):
         """
         Records a usage of this voucher in an order.
         """
-        if user.is_authenticated():
+        if user_is_authenticated(user):
             self.applications.create(voucher=self, order=order, user=user)
         else:
             self.applications.create(voucher=self, order=order)

--- a/src/oscar/core/compat.py
+++ b/src/oscar/core/compat.py
@@ -91,6 +91,13 @@ def user_is_anonymous(user):
         return user.is_anonymous()
 
 
+def assignment_tag(register):
+    if django.VERSION >= (1, 9):
+        return register.simple_tag
+    else:
+        return register.assignment_tag
+
+
 # Python3 compatibility layer
 
 """

--- a/src/oscar/core/compat.py
+++ b/src/oscar/core/compat.py
@@ -77,6 +77,20 @@ else:
     MiddlewareMixin = object
 
 
+def user_is_authenticated(user):
+    if django.VERSION >= (1, 10):
+        return user.is_authenticated
+    else:
+        return user_is_authenticated(user)
+
+
+def user_is_anonymous(user):
+    if django.VERSION >= (1, 10):
+        return user.is_anonymous
+    else:
+        return user.is_anonymous()
+
+
 # Python3 compatibility layer
 
 """

--- a/src/oscar/core/compat.py
+++ b/src/oscar/core/compat.py
@@ -81,7 +81,7 @@ def user_is_authenticated(user):
     if django.VERSION >= (1, 10):
         return user.is_authenticated
     else:
-        return user_is_authenticated(user)
+        return user.is_authenticated()
 
 
 def user_is_anonymous(user):

--- a/src/oscar/templatetags/basket_tags.py
+++ b/src/oscar/templatetags/basket_tags.py
@@ -1,5 +1,6 @@
 from django import template
 
+from oscar.core.compat import assignment_tag
 from oscar.core.loading import get_class, get_model
 
 AddToBasketForm = get_class('basket.forms', 'AddToBasketForm')
@@ -11,7 +12,7 @@ register = template.Library()
 QNT_SINGLE, QNT_MULTIPLE = 'single', 'multiple'
 
 
-@register.assignment_tag()
+@assignment_tag(register)
 def basket_form(request, product, quantity_type='single'):
     if not isinstance(product, Product):
         return ''

--- a/src/oscar/templatetags/category_tags.py
+++ b/src/oscar/templatetags/category_tags.py
@@ -1,12 +1,15 @@
 from django import template
 
+from oscar.core.compat import assignment_tag
 from oscar.core.loading import get_model
 
 register = template.Library()
 Category = get_model('catalogue', 'category')
 
+assignment_tag = assignment_tag(register)
 
-@register.assignment_tag(name="category_tree")
+
+@assignment_tag(name="category_tree")
 def get_annotated_list(depth=None, parent=None):
     """
     Gets an annotated list from a tree branch.

--- a/src/oscar/templatetags/dashboard_tags.py
+++ b/src/oscar/templatetags/dashboard_tags.py
@@ -1,11 +1,12 @@
 from django import template
 
+from oscar.core.compat import assignment_tag
 from oscar.core.loading import get_class
 
 get_nodes = get_class('dashboard.menu', 'get_nodes')
 register = template.Library()
 
 
-@register.assignment_tag()
+@assignment_tag(register)
 def dashboard_navigation(user):
     return get_nodes(user)

--- a/src/oscar/templatetags/history_tags.py
+++ b/src/oscar/templatetags/history_tags.py
@@ -5,11 +5,13 @@ from django.utils.six.moves.urllib import parse
 from django.utils.translation import ugettext_lazy as _
 
 from oscar.apps.customer import history
+from oscar.core.compat import assignment_tag
 from oscar.core.loading import get_model
 
 Site = get_model('sites', 'Site')
 
 register = template.Library()
+assignment_tag = assignment_tag(register)
 
 
 @register.inclusion_tag('customer/history/recently_viewed_products.html',
@@ -26,7 +28,7 @@ def recently_viewed_products(context, current_product=None):
             'request': request}
 
 
-@register.assignment_tag(takes_context=True)  # noqa (too complex (11))
+@assignment_tag(takes_context=True)  # noqa (too complex (11))
 def get_back_button(context):
     """
     Show back button, custom title available for different urls, for

--- a/src/oscar/templatetags/purchase_info_tags.py
+++ b/src/oscar/templatetags/purchase_info_tags.py
@@ -1,9 +1,11 @@
 from django import template
 
+from oscar.core.compat import assignment_tag
+
 register = template.Library()
 
 
-@register.assignment_tag
+@assignment_tag(register)
 def purchase_info_for_product(request, product):
     if product.is_parent:
         return request.strategy.fetch_for_parent(product)
@@ -11,6 +13,6 @@ def purchase_info_for_product(request, product):
     return request.strategy.fetch_for_product(product)
 
 
-@register.assignment_tag
+@assignment_tag(register)
 def purchase_info_for_line(request, line):
     return request.strategy.fetch_for_line(line)

--- a/src/oscar/templatetags/shipping_tags.py
+++ b/src/oscar/templatetags/shipping_tags.py
@@ -1,9 +1,11 @@
 from django import template
 
+from oscar.core.compat import assignment_tag
+
 register = template.Library()
 
 
-@register.assignment_tag
+@assignment_tag(register)
 def shipping_charge(method, basket):
     """
     Template tag for calculating the shipping charge for a given shipping
@@ -12,7 +14,7 @@ def shipping_charge(method, basket):
     return method.calculate(basket)
 
 
-@register.assignment_tag
+@assignment_tag(register)
 def shipping_charge_discount(method, basket):
     """
     Template tag for calculating the shipping discount for a given shipping
@@ -21,7 +23,7 @@ def shipping_charge_discount(method, basket):
     return method.discount(basket)
 
 
-@register.assignment_tag
+@assignment_tag(register)
 def shipping_charge_excl_discount(method, basket):
     """
     Template tag for calculating the shipping charge (excluding discounts) for

--- a/src/oscar/views/decorators.py
+++ b/src/oscar/views/decorators.py
@@ -10,6 +10,8 @@ from django.shortcuts import render
 from django.utils.six.moves.urllib import parse
 from django.utils.translation import ugettext_lazy as _
 
+from oscar.core.compat import user_is_authenticated
+
 
 def staff_member_required(view_func, login_url=None):
     """
@@ -31,7 +33,7 @@ def staff_member_required(view_func, login_url=None):
             return view_func(request, *args, **kwargs)
 
         # If user is not logged in, redirect to login page
-        if not request.user.is_authenticated():
+        if not user_is_authenticated(request.user):
             # If the login url is the same scheme and net location then just
             # use the path as the "next" url.
             path = request.build_absolute_uri()
@@ -104,7 +106,7 @@ def permissions_required(permissions, login_url=None):
 
     def _check_permissions(user):
         outcome = check_permissions(user, permissions)
-        if not outcome and user.is_authenticated():
+        if not outcome and user_is_authenticated(user):
             raise PermissionDenied
         else:
             return outcome
@@ -119,7 +121,7 @@ def login_forbidden(view_func, template_name='login_forbidden.html',
     """
     @wraps(view_func)
     def _checklogin(request, *args, **kwargs):
-        if not request.user.is_authenticated():
+        if not user_is_authenticated(request.user):
             return view_func(request, *args, **kwargs)
         return render(request, template_name, status=status)
 

--- a/tests/_site/urls.py
+++ b/tests/_site/urls.py
@@ -7,8 +7,8 @@ from oscar.app import application
 admin.autodiscover()
 
 urlpatterns = [
-    url(r'^admin/', include(admin.site.urls)),
-    url(r'', include(application.urls)),
+    url(r'^admin/', admin.site.urls),
+    url(r'', application.urls),
     url(r'^i18n/', include('django.conf.urls.i18n')),
 ]
 urlpatterns += staticfiles_urlpatterns()

--- a/tests/functional/customer/wishlists_tests.py
+++ b/tests/functional/customer/wishlists_tests.py
@@ -49,8 +49,8 @@ class TestMoveProductToAnotherWishList(WishListTestMixin, WebTestCase):
                                                                                  'line_pk': line1.pk,
                                                                                  'to_key': self.wishlist2.key})
         self.get(url)
-        self.assertEquals(self.wishlist1.lines.filter(product=self.product).count(), 1)
-        self.assertEquals(self.wishlist2.lines.filter(product=self.product).count(), 1)
+        self.assertEqual(self.wishlist1.lines.filter(product=self.product).count(), 1)
+        self.assertEqual(self.wishlist2.lines.filter(product=self.product).count(), 1)
 
     def test_move_product_to_another_wishlist(self):
         self.wishlist1.add(self.product)
@@ -59,5 +59,5 @@ class TestMoveProductToAnotherWishList(WishListTestMixin, WebTestCase):
                                                                                  'line_pk': line1.pk,
                                                                                  'to_key': self.wishlist2.key})
         self.get(url)
-        self.assertEquals(self.wishlist1.lines.filter(product=self.product).count(), 0)
-        self.assertEquals(self.wishlist2.lines.filter(product=self.product).count(), 1)
+        self.assertEqual(self.wishlist1.lines.filter(product=self.product).count(), 0)
+        self.assertEqual(self.wishlist2.lines.filter(product=self.product).count(), 1)

--- a/tests/functional/dashboard/product_tests.py
+++ b/tests/functional/dashboard/product_tests.py
@@ -184,12 +184,12 @@ class TestProductClass(ProductWebTest):
         # Reloading model instance to re-initiate ProductAttributeContainer
         # with new attributes.
         self.product = Product.objects.get(pk=self.product.id)
-        self.assertEquals(self.product.attr.text, 'test1')
-        self.assertEquals(self.product.attr.integer, 1)
-        self.assertEquals(self.product.attr.float, 1.2)
+        self.assertEqual(self.product.attr.text, 'test1')
+        self.assertEqual(self.product.attr.integer, 1)
+        self.assertEqual(self.product.attr.float, 1.2)
         self.assertTrue(self.product.attr.boolean)
-        self.assertEquals(self.product.attr.richtext, 'longread')
-        self.assertEquals(self.product.attr.date, datetime.date(2016, 10, 12))
+        self.assertEqual(self.product.attr.richtext, 'longread')
+        self.assertEqual(self.product.attr.date, datetime.date(2016, 10, 12))
 
         page = self.get(self.url)
         product_form = page.form
@@ -202,9 +202,9 @@ class TestProductClass(ProductWebTest):
         product_form.submit()
 
         self.product = Product.objects.get(pk=self.product.id)
-        self.assertEquals(self.product.attr.text, 'test2')
-        self.assertEquals(self.product.attr.integer, 2)
-        self.assertEquals(self.product.attr.float, 5.2)
+        self.assertEqual(self.product.attr.text, 'test2')
+        self.assertEqual(self.product.attr.integer, 2)
+        self.assertEqual(self.product.attr.float, 5.2)
         self.assertFalse(self.product.attr.boolean)
-        self.assertEquals(self.product.attr.richtext, 'article')
-        self.assertEquals(self.product.attr.date, datetime.date(2016, 10, 10))
+        self.assertEqual(self.product.attr.richtext, 'article')
+        self.assertEqual(self.product.attr.date, datetime.date(2016, 10, 10))

--- a/tests/functional/dashboard/range_tests.py
+++ b/tests/functional/dashboard/range_tests.py
@@ -85,13 +85,13 @@ class RangeProductViewTest(WebTestCase):
         form['file_upload'] = Upload('new_skus.txt', b'456')
         form.submit().follow()
         all_products = self.range.all_products()
-        self.assertEquals(len(all_products), 1)
+        self.assertEqual(len(all_products), 1)
         self.assertTrue(self.product3 in all_products)
         range_product_file_upload = RangeProductFileUpload.objects.get()
-        self.assertEquals(range_product_file_upload.range, self.range)
-        self.assertEquals(range_product_file_upload.num_new_skus, 1)
-        self.assertEquals(range_product_file_upload.status, RangeProductFileUpload.PROCESSED)
-        self.assertEquals(range_product_file_upload.size, 3)
+        self.assertEqual(range_product_file_upload.range, self.range)
+        self.assertEqual(range_product_file_upload.num_new_skus, 1)
+        self.assertEqual(range_product_file_upload.status, RangeProductFileUpload.PROCESSED)
+        self.assertEqual(range_product_file_upload.size, 3)
 
     def test_dupe_skus_warning(self):
         self.range.add_product(self.product3)
@@ -99,8 +99,8 @@ class RangeProductViewTest(WebTestCase):
         form = range_products_page.forms[0]
         form['query'] = '456'
         response = form.submit()
-        self.assertEquals(list(response.context['messages']), [])
-        self.assertEquals(
+        self.assertEqual(list(response.context['messages']), [])
+        self.assertEqual(
             response.context['form'].errors['query'],
             ['The products with SKUs or UPCs matching 456 are already in this range']
         )
@@ -109,11 +109,11 @@ class RangeProductViewTest(WebTestCase):
         form['query'] = '456, 789'
         response = form.submit().follow()
         messages = list(response.context['messages'])
-        self.assertEquals(len(messages), 2)
-        self.assertEquals(messages[0].level, SUCCESS)
-        self.assertEquals(messages[0].message, '1 product added to range')
-        self.assertEquals(messages[1].level, WARNING)
-        self.assertEquals(
+        self.assertEqual(len(messages), 2)
+        self.assertEqual(messages[0].level, SUCCESS)
+        self.assertEqual(messages[0].message, '1 product added to range')
+        self.assertEqual(messages[1].level, WARNING)
+        self.assertEqual(
             messages[1].message,
             'The products with SKUs or UPCs matching 456 are already in this range'
         )
@@ -123,8 +123,8 @@ class RangeProductViewTest(WebTestCase):
         form = range_products_page.form
         form['query'] = '321'
         response = form.submit()
-        self.assertEquals(list(response.context['messages']), [])
-        self.assertEquals(
+        self.assertEqual(list(response.context['messages']), [])
+        self.assertEqual(
             response.context['form'].errors['query'],
             ['No products exist with a SKU or UPC matching 321']
         )
@@ -132,11 +132,11 @@ class RangeProductViewTest(WebTestCase):
         form['query'] = '456, 321'
         response = form.submit().follow()
         messages = list(response.context['messages'])
-        self.assertEquals(len(messages), 2)
-        self.assertEquals(messages[0].level, SUCCESS)
-        self.assertEquals(messages[0].message, '1 product added to range')
-        self.assertEquals(messages[1].level, WARNING)
-        self.assertEquals(
+        self.assertEqual(len(messages), 2)
+        self.assertEqual(messages[0].level, SUCCESS)
+        self.assertEqual(messages[0].message, '1 product added to range')
+        self.assertEqual(messages[1].level, WARNING)
+        self.assertEqual(
             messages[1].message, 'No product(s) were found with SKU or UPC matching 321'
         )
 
@@ -146,9 +146,9 @@ class RangeProductViewTest(WebTestCase):
         form['query'] = '123123'
         response = form.submit().follow()
         messages = list(response.context['messages'])
-        self.assertEquals(len(messages), 2)
-        self.assertEquals(messages[1].level, WARNING)
-        self.assertEquals(
+        self.assertEqual(len(messages), 2)
+        self.assertEqual(messages[1].level, WARNING)
+        self.assertEqual(
             messages[1].message, 'There are more than one product with SKU 123123'
         )
 
@@ -158,8 +158,8 @@ class RangeProductViewTest(WebTestCase):
         form['file_upload'] = Upload('skus.txt', b'123123')
         response = form.submit().follow()
         messages = list(response.context['messages'])
-        self.assertEquals(len(messages), 2)
-        self.assertEquals(messages[1].level, WARNING)
-        self.assertEquals(
+        self.assertEqual(len(messages), 2)
+        self.assertEqual(messages[1].level, WARNING)
+        self.assertEqual(
             messages[1].message, 'There are more than one product with SKU 123123'
         )

--- a/tests/integration/order/creator_tests.py
+++ b/tests/integration/order/creator_tests.py
@@ -199,7 +199,7 @@ class TestMultiSiteOrderCreation(TestCase):
                     basket=self.basket,
                     order_number='1234')
         order = Order.objects.get(number='1234')
-        self.assertEquals(order.site_id, 1)
+        self.assertEqual(order.site_id, 1)
 
     def test_multi_sites(self):
         site1 = factories.SiteFactory()
@@ -210,11 +210,11 @@ class TestMultiSiteOrderCreation(TestCase):
                     order_number='12345',
                     site=site1)
         order1 = Order.objects.get(number='12345')
-        self.assertEquals(order1.site, site1)
+        self.assertEqual(order1.site, site1)
         add_product(self.basket, D('12.00'))
         place_order(self.creator,
                     basket=self.basket,
                     order_number='12346',
                     site=site2)
         order2 = Order.objects.get(number='12346')
-        self.assertEquals(order2.site, site2)
+        self.assertEqual(order2.site, site2)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -75,7 +75,6 @@ if DJANGO_VERSION < (1, 10):
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
 
         'oscar.apps.basket.middleware.BasketMiddleware',
@@ -86,7 +85,6 @@ else:
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
 
         'oscar.apps.basket.middleware.BasketMiddleware',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,5 +1,6 @@
 import os
 import oscar
+from django import VERSION as DJANGO_VERSION
 
 from oscar.defaults import *  # noqa
 
@@ -68,15 +69,29 @@ TEMPLATES = [
 ]
 
 
-MIDDLEWARE_CLASSES = (
-    'django.middleware.common.CommonMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'oscar.apps.basket.middleware.BasketMiddleware',
-)
+if DJANGO_VERSION < (1, 10):
+    MIDDLEWARE_CLASSES = [
+        'django.middleware.common.CommonMiddleware',
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+
+        'oscar.apps.basket.middleware.BasketMiddleware',
+    ]
+else:
+    MIDDLEWARE = [
+        'django.middleware.common.CommonMiddleware',
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+
+        'oscar.apps.basket.middleware.BasketMiddleware',
+    ]
+
 
 AUTHENTICATION_BACKENDS = (
     'oscar.apps.customer.auth_backends.EmailBackend',

--- a/tests/unit/core/customisation_tests.py
+++ b/tests/unit/core/customisation_tests.py
@@ -62,7 +62,8 @@ class TestForkAppFunction(TestCase):
             filepath = os.path.join(self.tmp_folder, 'order', '%s.py' % module)
             self.assertTrue(os.path.exists(filepath))
 
-            contents = open(filepath).read()
+            with open(filepath) as fh:
+                contents = fh.read()
             self.assertTrue(expected_string in contents)
 
     def test_copies_in_migrations_when_needed(self):


### PR DESCRIPTION
Would be good to get this in before 1.4.

It fixes the following (1500) deprecation warnings:
- RemovedInDjango20Warning: Using user.is_authenticated() and user.is_anonymous() as a method is deprecated. Remove the parentheses to use it as an attribute.
 - ResourceWarning: unclosed file ..
 -  Direct assignment to the forward side of a many-to-many set is deprecated due to the implicit save() that happens. Use offers.set() instead.

It also ignores warnings in django-webtest and sorl, see setup.cfg

The last few should be fixed by #2157 (django-tables2)
