### PR TITLE
Disable submit buttons upon form submission instead of click

### DIFF
--- a/src/oscar/static/oscar/js/oscar/ui.js
+++ b/src/oscar/static/oscar/js/oscar/ui.js
@@ -75,10 +75,10 @@ var oscar = (function(o, $) {
             // Do not disable if button is inside a form with invalid fields.
             // This uses a delegated event so that it keeps working for forms that are reloaded
             // via AJAX: https://api.jquery.com/on/#direct-and-delegated-events
-            $(document.body).on('click', '[data-loading-text]', function(){
-                var form = $(this).parents("form");
-                if (!form || $(":invalid", form).length == 0)
-                    $(this).button('loading');
+            $(document.body).on('submit', 'form', function(){
+                var form = $(this);
+                if ($(":invalid", form).length == 0)
+                    $(this).find('button[data-loading-text]').button('loading');
             });
             // stuff for star rating on review page
             // show clickable stars instead of a select dropdown for product rating


### PR DESCRIPTION
There is a problem with disabling form submit buttons in Chrome. Since buttons become disabled upon 'click' event, form submission is prevented. The solution is to only disable submit buttons on form submit event.

See http://stackoverflow.com/questions/20157321/disabling-a-submit-button-when-clicking-on-it-will-prevent-the-form-from-being for example.