### PR TITLE
Fix handling of required phone_number in address form

### DIFF
--- a/src/oscar/views/generic.py
+++ b/src/oscar/views/generic.py
@@ -163,14 +163,17 @@ class PhoneNumberMixin(object):
         # number is entered. We add the field in the init since on Python 2
         # using forms.Form as base class results in errors when using this
         # class as mixin.
-        self.fields['phone_number'] = forms.CharField(max_length=32, required=False)
 
-        # Copy the help_text from the model field if it is available
+        # If the model field already exists, copy some properties from it
         try:
-            self.fields['phone_number'].help_text = (
-                self._meta.model._meta.get_field('phone_number').help_text)
-        except (AttributeError, FieldDoesNotExist):
-            pass
+            number_required = self.fields['phone_number'].required
+            number_help_text = self.fields['phone_number'].help_text
+        except KeyError:
+            number_required = False
+            number_help_text = ''
+
+        self.fields['phone_number'] = forms.CharField(
+            max_length=32, required=number_required, help_text=number_help_text)
 
     def get_country(self):
         # If the form data contains valid country information, we use that.

--- a/tests/integration/checkout/test_forms.py
+++ b/tests/integration/checkout/test_forms.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from oscar.apps.address.models import Country
 from oscar.apps.checkout.forms import ShippingAddressForm
@@ -24,6 +25,22 @@ class TestShippingAddressForm(TestCase):
     def test_keeps_country_field(self):
         CountryFactory(iso_3166_1_a2='DE', is_shipping_country=True)
         self.assertTrue('country' in ShippingAddressForm().fields)
+
+    @override_settings(OSCAR_REQUIRED_ADDRESS_FIELDS=('last_name', 'postcode'))
+    def test_required_fields_validated(self):
+        form = ShippingAddressForm()
+        self.assertTrue(form.fields['last_name'].required)
+        self.assertTrue(form.fields['postcode'].required)
+        self.assertFalse(form.fields['first_name'].required)
+        self.assertFalse(form.fields['line2'].required)
+        self.assertFalse(form.fields['line3'].required)
+        self.assertFalse(form.fields['line4'].required)
+
+    @override_settings(OSCAR_REQUIRED_ADDRESS_FIELDS=('phone_number',))
+    def test_required_phone_number_validated(self):
+        # This needs a separate test because of the logic in PhoneNumberMixin
+        form = ShippingAddressForm()
+        self.assertTrue(form.fields['phone_number'].required)
 
     # Tests where the country field is hidden
 


### PR DESCRIPTION
The changes made in the [switch to django-phonenumber-field](https://github.com/django-oscar/django-oscar/commit/8266000b8e6266379f0aba424b4d56a471cbb30c#commitcomment-20876167) resulted in the `required` attribute of the `phone_number` field being reset to `False` regardless of whether it was in `OSCAR_REQUIRED_ADDRESS_FIELDS`.

This patch fixes that to preserve that and also simplifies the preservation of the help text using the same approach.