### PR TITLE
Fixed string formatting bug in VoucherRemoveView

### DIFF
--- a/src/oscar/apps/basket/views.py
+++ b/src/oscar/apps/basket/views.py
@@ -398,7 +398,7 @@ class VoucherRemoveView(View):
             voucher = request.basket.vouchers.get(id=voucher_id)
         except ObjectDoesNotExist:
             messages.error(
-                request, _("No voucher found with id '%d'") % voucher_id)
+                request, _("No voucher found with id '%s'") % voucher_id)
         else:
             request.basket.vouchers.remove(voucher)
             self.remove_signal.send(

--- a/tests/integration/basket/test_views.py
+++ b/tests/integration/basket/test_views.py
@@ -38,7 +38,6 @@ class TestVoucherAddView(TestCase):
 
 
 class TestVoucherRemoveView(TestCase):
-
     def test_post_valid(self):
         voucher = VoucherFactory(num_basket_additions=5)
 
@@ -55,3 +54,17 @@ class TestVoucherRemoveView(TestCase):
 
         voucher = voucher.__class__.objects.get(pk=voucher.pk)
         self.assertEqual(voucher.num_basket_additions, 4)
+
+    def test_post_with_missing_voucher(self):
+        """ If the voucher is missing, verify the view queues a message and redirects. """
+        pk = '12345'
+        view = views.VoucherRemoveView.as_view()
+        request = RequestFactory().post('/')
+        request.basket.save()
+        response = view(request, pk=pk)
+
+        self.assertEqual(response.status_code, 302)
+
+        actual = list(get_messages(request))[-1].message
+        expected = "No voucher found with id '{}'".format(pk)
+        self.assertEqual(actual, expected)


### PR DESCRIPTION
The pk kwarg on views is a string type. The message format string was expecting a numeric value. This updates that format string to expect a string value, which will always display correctly.