### PR TITLE
Add 'isort:skip' to model imports in forked apps

### DIFF
--- a/src/oscar/core/customisation.py
+++ b/src/oscar/core/customisation.py
@@ -102,7 +102,7 @@ def fork_app(label, folder_path, logger=None):
         logger.info("Creating models.py")
         create_file(
             join(local_app_path, 'models.py'),
-            "from oscar.apps.%s.models import *  # noqa\n" % label)
+            "from oscar.apps.%s.models import *  # noqa isort:skip\n" % label)
 
         migrations_path = 'migrations'
         source = join(oscar_app_path, migrations_path)


### PR DESCRIPTION
Since `from xxx.models import *` must always be after custom model definitions in forked apps, isort should skip that line.