### PR TITLE
Fixed race condition handling logic in RegisterUserMixin

### DIFF
--- a/src/oscar/apps/customer/mixins.py
+++ b/src/oscar/apps/customer/mixins.py
@@ -74,10 +74,14 @@ class RegisterUserMixin(object):
             # ignore capitalisation when looking up an email address.
             # We might otherwise accidentally mark unrelated users as inactive
             users = User.objects.filter(email=user.email)
-            user = users[0]
             for u in users[1:]:
                 u.is_active = False
                 u.save()
+                
+            # Try again to authenticate
+            user = authenticate(
+                username=user.email,
+                password=form.cleaned_data['password1'])
 
         auth_login(self.request, user)
 


### PR DESCRIPTION
A user must be authenticated (or have a backend set) before you can log them in with `auth.login()`. Currently in `RegisterUserMixin`'s race condition handling logic, this doesn't happen, which means you end up with another exception and the point of catching the first exception is lost.

Changed this to re-authenticate the user after cleaning up the duplicates.