### PR TITLE
Update the currency filter to support the same params as babel.numbers.format_currency

### DIFF
--- a/docs/source/ref/settings.rst
+++ b/docs/source/ref/settings.rst
@@ -368,6 +368,29 @@ the ``format_currency`` function from the `Babel library`_.
 
 .. _`Babel library`: http://babel.pocoo.org/docs/api/numbers/#babel.numbers.format_currency
 
+``OSCAR_CURRENCY_DIGITS``
+-------------------------
+
+Default: ``True``
+
+This can be used show or hide the digits, overriding the default for the given
+currency. The value will be passed to the ``format_currency`` function from the
+`Babel library`_.
+
+.. _`Babel library`: http://babel.pocoo.org/docs/api/numbers/#babel.numbers.format_currency
+
+``OSCAR_CURRENCY_FORMAT_TYPE``
+-------------------------
+
+Default: ``standard``
+
+This can be used choose an alternate format for a currency where available. The
+value will be passed to the ``format_currency`` function from the
+`Babel library`_.
+
+.. _`Babel library`: http://babel.pocoo.org/docs/api/numbers/#babel.numbers.format_currency
+
+
 Upload/media settings
 =====================
 

--- a/docs/source/ref/settings.rst
+++ b/docs/source/ref/settings.rst
@@ -363,33 +363,19 @@ This will be used by the currency templatetag.
 
 Default: ``None``
 
-This can be used to customise currency formatting. The value will be passed to
-the ``format_currency`` function from the `Babel library`_.
+Dictionary with arguments for the ``format_currency`` function from the `Babel library`_.
+Contains next options: `format`, `format_type`, `currency_digits`.
+For example::
 
-.. _`Babel library`: http://babel.pocoo.org/docs/api/numbers/#babel.numbers.format_currency
+    OSCAR_CURRENCY_FORMAT = {
+        'USD': {
+            'currency_digits': False,
+            'currency_digits': "accounting",
+        },
+        'EUR': { .. }
+    }
 
-``OSCAR_CURRENCY_DIGITS``
--------------------------
-
-Default: ``True``
-
-This can be used show or hide the digits, overriding the default for the given
-currency. The value will be passed to the ``format_currency`` function from the
-`Babel library`_.
-
-.. _`Babel library`: http://babel.pocoo.org/docs/api/numbers/#babel.numbers.format_currency
-
-``OSCAR_CURRENCY_FORMAT_TYPE``
--------------------------
-
-Default: ``standard``
-
-This can be used choose an alternate format for a currency where available. The
-value will be passed to the ``format_currency`` function from the
-`Babel library`_.
-
-.. _`Babel library`: http://babel.pocoo.org/docs/api/numbers/#babel.numbers.format_currency
-
+.. _`Babel library`: http://babel.pocoo.org/en/latest/api/numbers.html#babel.numbers.format_currency
 
 Upload/media settings
 =====================

--- a/docs/source/releases/v1.5.rst
+++ b/docs/source/releases/v1.5.rst
@@ -73,17 +73,15 @@ Backwards incompatible changes in Oscar 1.5
   - ``OrderedProductFormSet`` moved to ``oscar.apps.dashboard.promotions.formsets``;
   - ``LineFormset`` moved to ``oscar.apps.wishlists.formsets``.
 
-.. _incompatible_in_1.5:
-
-Backwards incompatible changes in Oscar 1.5
--------------------------------------------
-
-- `SimpleAddToBasketForm` doesn't override the quantity field any
+- ``SimpleAddToBasketForm`` doesn't override the quantity field any
   more. Instead, it just hides the field declared by AddToBasketForm
-  and sets the quantity to one. This means `SimpleAddToBasketForm`
+  and sets the quantity to one. This means ``SimpleAddToBasketForm``
   doesn't need to be overridden for most cases, but please check
   things still work as expected for you if you have customized it.
 
+- ``OSCAR_CURRENCY_FORMAT`` setting changed to dictionary form in order to support multi-currency for
+  currency formatting. You can set `format`, `format_type` and `currency_digits` in it.
+  Please refer to documentation for an example.
 
 Dependency changes
 ------------------

--- a/src/oscar/templatetags/currency_filters.py
+++ b/src/oscar/templatetags/currency_filters.py
@@ -21,8 +21,11 @@ def currency(value, currency=None):
     # Using Babel's currency formatting
     # http://babel.pocoo.org/en/latest/api/numbers.html#babel.numbers.format_currency
     kwargs = {
-        'currency': currency if currency else settings.OSCAR_DEFAULT_CURRENCY,
+        'currency': (currency if not currency is None else
+            settings.OSCAR_DEFAULT_CURRENCY),
         'format': getattr(settings, 'OSCAR_CURRENCY_FORMAT', None),
         'locale': to_locale(get_language() or settings.LANGUAGE_CODE),
+        'currency_digits': getattr(settings, 'OSCAR_CURRENCY_DIGITS', True),
+        'format_type': getattr(settings, 'OSCAR_CURRENCY_FORMAT_TYPE', 'standard'),
     }
     return format_currency(value, **kwargs)

--- a/src/oscar/templatetags/currency_filters.py
+++ b/src/oscar/templatetags/currency_filters.py
@@ -20,12 +20,13 @@ def currency(value, currency=None):
         return u""
     # Using Babel's currency formatting
     # http://babel.pocoo.org/en/latest/api/numbers.html#babel.numbers.format_currency
+    OSCAR_CURRENCY_FORMAT = getattr(settings, 'OSCAR_CURRENCY_FORMAT', None)
     kwargs = {
-        'currency': (currency if not currency is None else
-            settings.OSCAR_DEFAULT_CURRENCY),
-        'format': getattr(settings, 'OSCAR_CURRENCY_FORMAT', None),
-        'locale': to_locale(get_language() or settings.LANGUAGE_CODE),
-        'currency_digits': getattr(settings, 'OSCAR_CURRENCY_DIGITS', True),
-        'format_type': getattr(settings, 'OSCAR_CURRENCY_FORMAT_TYPE', 'standard'),
+        'currency': currency or settings.OSCAR_DEFAULT_CURRENCY,
+        'locale': to_locale(get_language() or settings.LANGUAGE_CODE)
     }
+    if isinstance(OSCAR_CURRENCY_FORMAT, dict):
+        kwargs.update(OSCAR_CURRENCY_FORMAT.get(currency, {}))
+    else:
+        kwargs['format'] = OSCAR_CURRENCY_FORMAT
     return format_currency(value, **kwargs)

--- a/tests/integration/templatetags/test_currency_filters.py
+++ b/tests/integration/templatetags/test_currency_filters.py
@@ -4,6 +4,7 @@ from decimal import Decimal as D
 from django import template
 from django.test import TestCase
 from django.utils import translation
+from django.test.utils import override_settings
 
 
 def render(template_string, ctx):
@@ -40,3 +41,42 @@ class TestCurrencyFilter(TestCase):
             self.template.render(template.Context({
                 'price': D('10.23'),
             }))
+
+    @override_settings(OSCAR_CURRENCY_FORMAT={
+        'AUD': {
+            'currency_digits': False,
+            'format_type': "accounting",
+        },
+        'USD': {
+            'format': '$#,##'
+        },
+        'EUR': {
+            'currency_digits': True,
+            'format': u'#,## \u20ac'
+        }
+    })
+    def test_formatting_settings(self):
+        template1 = template.Template(
+            "{% load currency_filters %}"
+            "{{ price|currency:'AUD' }}"
+        )
+        out1 = template1.render(template.Context({
+            'price': D('10.23'),
+        }))
+        self.assertEquals(out1, u'A$10.23')
+        template2 = template.Template(
+            "{% load currency_filters %}"
+            "{{ price|currency:'USD' }}"
+        )
+        out2 = template2.render(template.Context({
+            'price': D('10.23'),
+        }))
+        self.assertEquals(out2, u'$10.23')
+        template3 = template.Template(
+            "{% load currency_filters %}"
+            "{{ price|currency:'EUR' }}"
+        )
+        out3 = template3.render(template.Context({
+            'price': D('10.23'),
+        }))
+        self.assertEquals(out3, u'10.23 €')


### PR DESCRIPTION
Updated version of PR #2057 with multi-currency support.