### PR TITLE
Fix label classes for voucher dashboard view. Fixes #2249.

### DIFF
--- a/src/oscar/templates/oscar/dashboard/vouchers/voucher_list.html
+++ b/src/oscar/templates/oscar/dashboard/vouchers/voucher_list.html
@@ -63,13 +63,13 @@
                         <tr>
                             <td><a href="{% url 'dashboard:voucher-stats' voucher.id %}">{{ voucher.name }}</a></td>
                             <td>
-                                <span class="label label-inverse">{{ voucher.code }}</span>
+                                <span class="label label-default">{{ voucher.code }}</span>
                             </td>
                             <td>
                                 {% if voucher.is_active %}
                                     <span class="label label-success">{% trans "Active" %}</span>
                                 {% else %}
-                                    <span class="label">{% trans "Inactive" %}</span>
+                                    <span class="label label-default">{% trans "Inactive" %}</span>
                                 {% endif %}
                             </td>
                             <td>{{ voucher.num_basket_additions }}</td>


### PR DESCRIPTION
`label-inverse` was dropped in Bootstrap 3, and an explicit `label-default` is required for the default style.