### PR TITLE
Fix logic for determining 'hurry mode' on alerts. Fixes #2100, #2103.

### DIFF
--- a/docs/source/ref/apps/customer.rst
+++ b/docs/source/ref/apps/customer.rst
@@ -24,3 +24,18 @@ Views
 
 .. automodule:: oscar.apps.customer.views
     :members:
+
+Alerts
+------
+
+The alerts module provides functionality that allows customers to sign up for
+email alerts when out-of-stock products come back in stock. A form for signing
+up is displayed on product detail pages when a product is not in stock.
+
+If the ``OSCAR_EAGER_ALERTS` setting is ``True``, then alerts are sent as soon
+as affected stock records are updated. Alternatively, the management command
+``oscar_send_alerts`` can be used to send alerts periodically.
+
+The context for the alert email body contains a ``hurry`` variable that is set
+to ``True`` if the number of active alerts for a product is greater than the
+quantity of the product available in stock.

--- a/docs/source/releases/v1.5.rst
+++ b/docs/source/releases/v1.5.rst
@@ -55,6 +55,10 @@ Minor changes
    addresses tracked separately: billing address in ``UserAddress.num_orders_as_billing_address`` field
    and shipping address in ``UserAddress.num_order_as_shipping_address`` accordingly.
 
+- Fixed logic for determining "hurry mode" on stock alerts. Hurry mode is now
+  set if the number of alerts for a product exceeds the quantity in stock,
+  rather than the other way around.
+
 .. _incompatible_in_1.5:
 
 Backwards incompatible changes in Oscar 1.5

--- a/src/oscar/apps/customer/alerts/utils.py
+++ b/src/oscar/apps/customer/alerts/utils.py
@@ -66,15 +66,14 @@ def send_product_alerts(product):
     )
 
     # Determine 'hurry mode'
-    num_alerts = alerts.count()
     if num_stockrecords == 1:
         num_in_stock = stockrecords[0].num_in_stock
-        # hurry_mode is false if num_in_stock is None
-        hurry_mode = num_in_stock is not None and num_alerts < num_in_stock
     else:
         result = stockrecords.aggregate(max_in_stock=Max('num_in_stock'))
-        hurry_mode = result['max_in_stock'] is not None and \
-            num_alerts < result['max_in_stock']
+        num_in_stock = result['max_in_stock']
+
+    # hurry_mode is false if num_in_stock is None
+    hurry_mode = num_in_stock is not None and alerts.count() > num_in_stock
 
     # Load templates
     message_tpl = loader.get_template('customer/alerts/message.html')

--- a/src/oscar/templates/oscar/customer/alerts/emails/alert_body.txt
+++ b/src/oscar/templates/oscar/customer/alerts/emails/alert_body.txt
@@ -2,7 +2,7 @@
 {% blocktrans with title=alert.product.get_title|safe path=alert.product.get_absolute_url %}
 We are happy to inform you that our product '{{ title }}' is back in stock:
 http://{{ site }}{{ path }}
-{% endblocktrans %}{% if hurry %}{% blocktrans with product_url=product_url %}
+{% endblocktrans %}{% if hurry %}{% blocktrans %}
 Beware that the amount of items in stock is limited. Be quick or someone might get there first.
 {% endblocktrans %}{% endif %}{% blocktrans with site_name=site.name %}
 With this email we have disabled your alert automatically and you will not


### PR DESCRIPTION
Same as the proposed changes in #2103, with slightly improved code logic and tests.