### PR TITLE
Add a OSCAR_CSV_INCLUDE_BOM setting which optionally adds a BOM to UTF-8 CSV output

### DIFF
--- a/docs/source/ref/settings.rst
+++ b/docs/source/ref/settings.rst
@@ -139,7 +139,7 @@ Default::
                                  ('right', 'Right-hand sidebar'),
                                  ('left', 'Left-hand sidebar'))
 
-The choice of display locations available when editing a promotion. Only 
+The choice of display locations available when editing a promotion. Only
 useful when using a new set of templates.
 
 ``OSCAR_PROMOTION_MERCHANDISING_BLOCK_TYPES``
@@ -203,7 +203,7 @@ Default: ``{}``
 The pipeline defines the statuses that an order or line item can have and what
 transitions are allowed in any given status. The pipeline is defined as a
 dictionary where the keys are the available statuses. Allowed transitions are
-defined as iterable values for the corresponding status. 
+defined as iterable values for the corresponding status.
 
 A sample pipeline (as used in the Oscar sandbox) might look like this::
 
@@ -444,7 +444,7 @@ Slug settings
 Default: ``{}``
 
 A dictionary to map strings to more readable versions for including in URL
-slugs.  This mapping is appled before the slugify function.  
+slugs.  This mapping is appled before the slugify function.
 This is useful when names contain characters which would normally be
 stripped.  For instance::
 
@@ -517,3 +517,13 @@ transactions.
 ------------------
 
 Allows to use raw LESS styles directly. Refer to :ref:`less-css` document for more details.
+
+
+``OSCAR_CSV_INCLUDE_BOM``
+-------------------------
+
+Default: ``False``
+
+A flag to control whether Oscar's CSV writer should prepend a byte order mark
+(BOM) to CSV files that are encoded in UTF-8. Useful for compatibility with some
+CSV readers, Microsoft Excel in particular.

--- a/tests/integration/core/test_compat.py
+++ b/tests/integration/core/test_compat.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
+import codecs
+import csv
 import datetime
+import os
 from tempfile import NamedTemporaryFile
 from django.utils import six
+from django.utils.encoding import smart_text
 from django.utils.six.moves import cStringIO
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from oscar.core.compat import UnicodeCSVWriter, existing_user_fields
 
@@ -43,6 +47,63 @@ class TestUnicodeCSVWriter(TestCase):
             s = u'ünįcodē'
             rows = [[s, unicodeobj(s), 123, datetime.date.today()], ]
             writer.writerows(rows)
+
+    def test_csv_write_output(self):
+        tmp_file = NamedTemporaryFile(delete=False)
+        with UnicodeCSVWriter(filename=tmp_file.name) as writer:
+            s = u'ünįcodē'
+            row = [s, 123, 'foo-bar']
+            writer.writerows([row])
+
+        with open(tmp_file.name, 'r') as read_file:
+            content = smart_text(read_file.read(), encoding='utf-8').strip()
+            self.assertEqual(content, u'ünįcodē,123,foo-bar')
+
+        # Clean up
+        os.unlink(tmp_file.name)
+
+    @override_settings(OSCAR_CSV_INCLUDE_BOM=True)
+    def test_bom_write_with_open_file(self):
+        csv_file = NamedTemporaryFile(delete=False)
+        with open(csv_file.name, 'w') as open_file:
+            writer = UnicodeCSVWriter(open_file=open_file, encoding="utf-8")
+            s = u'ünįcodē'
+            row = [s, 123, datetime.date.today()]
+            writer.writerows([row])
+
+        with open(csv_file.name, 'rb') as read_file:
+            self.assertTrue(read_file.read().startswith(codecs.BOM_UTF8))
+
+        # Clean up
+        os.unlink(csv_file.name)
+
+    @override_settings(OSCAR_CSV_INCLUDE_BOM=True)
+    def test_bom_write_with_filename(self):
+        csv_file = NamedTemporaryFile(delete=False)
+        with UnicodeCSVWriter(filename=csv_file.name, encoding="utf-8") as writer:
+            s = u'ünįcodē'
+            row = [s, 123, datetime.date.today()]
+            writer.writerows([row])
+
+        with open(csv_file.name, 'rb') as read_file:
+            self.assertTrue(read_file.read().startswith(codecs.BOM_UTF8))
+
+        # Clean up
+        os.unlink(csv_file.name)
+
+    @override_settings(OSCAR_CSV_INCLUDE_BOM=True)
+    def test_bom_not_written_for_other_encodings(self):
+        csv_file = NamedTemporaryFile(delete=False)
+        with UnicodeCSVWriter(filename=csv_file.name, encoding="ascii") as writer:
+            s = 'boring ascii'
+            row = [s, 123, datetime.date.today()]
+            writer.writerows([row])
+
+        with open(csv_file.name, 'rb') as read_file:
+            self.assertFalse(read_file.read().startswith(codecs.BOM_UTF8))
+
+        # Clean up
+        os.unlink(csv_file.name)
 
 
 class TestPython3Compatibility(TestCase):


### PR DESCRIPTION
This is a reimplementation of #2300, but with a few modifications:

- Support for both Python 2 and 3
- Works with both contexts (`open_file` and `filename`)
- Addition of BOM is controlled by a new setting (defaults to `False`). This is necessary because adding the BOM changes the readability of the resulting CSV files. Python 2 itself cannot read these files correctly.

I have tested this on Excel for Windows, and the resulting CSV files are correctly imported when the BOM is enabled.