### PR TITLE
Fix EmailBackend.authenticate() signature for Django 1.11.

### DIFF
--- a/docs/source/releases/v1.5.rst
+++ b/docs/source/releases/v1.5.rst
@@ -44,6 +44,8 @@ These methods/modules have been removed:
    alternative.
  - ``oscar.test.decorators`` module.
  - ``oscar.core.utils.compose`` function.
+ - ``oscar.apps.customer.auth_backends.Emailbackend``. Use
+   ``oscar.apps.customer.auth_backends.EmailBackend`` instead.
 
 
 .. _silk: https://github.com/django-silk/silk

--- a/tests/integration/customer/test_auth_backend.py
+++ b/tests/integration/customer/test_auth_backend.py
@@ -1,0 +1,26 @@
+import unittest
+
+import django
+from django.test import TestCase
+
+from oscar.apps.customer.auth_backends import EmailBackend
+from oscar.test.factories import UserFactory
+
+
+class AuthBackendTestCase(TestCase):
+
+    def setUp(self):
+        self.user = UserFactory(email='foo@example.com', is_staff=True)
+        self.user.set_password('letmein')
+        self.user.save()
+        self.backend = EmailBackend()
+
+    @unittest.skipUnless(django.VERSION < (1, 11), "for Django <1.11 only")
+    def test_authentication_method_signature_pre_django_1_11(self):
+        auth_result = self.backend.authenticate('foo@example.com', 'letmein')
+        self.assertEqual(auth_result, self.user)
+
+    @unittest.skipUnless(django.VERSION >= (1, 11), "for Django >=1.11 only")
+    def test_authentication_method_signature_post_django_1_11(self):
+        auth_result = self.backend.authenticate(None, 'foo@example.com', 'letmein')
+        self.assertEqual(auth_result, self.user)


### PR DESCRIPTION
In Django 1.11, `authenticate` is passed a required `request` argument, which means the current method fails. This patch modifies the method signature if we're using Django 1.11. 

While I was at it I also removed the `Emailbackend` (lower case b) class which was deprecated in Oscar 1.0.