### PR TITLE
Fix Python 3 string handling in AbstractProductAttributeValue._multi_option_as_text

### DIFF
--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -979,7 +979,7 @@ class AbstractProductAttributeValue(models.Model):
 
     @property
     def _multi_option_as_text(self):
-        return ', '.join(unicode(option) for option in self.value_multi_option.all())
+        return ', '.join(str(option) for option in self.value_multi_option.all())
 
     @property
     def _richtext_as_text(self):

--- a/tests/integration/catalogue/test_attributes.py
+++ b/tests/integration/catalogue/test_attributes.py
@@ -60,3 +60,10 @@ class TestMultiOptionAttributes(TestCase):
         self.attr.save_value(product, None)
         product.refresh_from_db()
         self.assertFalse(hasattr(product.attr, 'sizes'))
+
+    def test_multi_option_value_as_text(self):
+        product = factories.ProductFactory()
+        self.attr.save_value(product, self.options)
+        attr_val = product.attribute_values.get(attribute=self.attr)
+        self.assertEqual(attr_val.value_as_text,
+            ", ".join(o.option for o in self.options))


### PR DESCRIPTION
Also added a test for this method.