### PR TITLE
Update supported Django/Python versions and tox configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ matrix:
     - python: 2.7
       env: TOXENV=py27-django18
     - python: 2.7
-      env: TOXENV=py27-django19
-    - python: 2.7
       env: TOXENV=py27-django110
     - python: 2.7
       env: TOXENV=py27-django111
@@ -16,25 +14,15 @@ matrix:
     - python: 3.4
       env: TOXENV=py34-django18
     - python: 3.4
-      env: TOXENV=py34-django19
-    - python: 3.4
       env: TOXENV=py34-django110
     - python: 3.4
       env: TOXENV=py34-django111
     - python: 3.5
       env: TOXENV=py35-django18
     - python: 3.5
-      env: TOXENV=py35-django19
-    - python: 3.5
       env: TOXENV=py35-django110
     - python: 3.5
       env: TOXENV=py35-django111
-    - python: 3.6
-      env: TOXENV=py36-django18
-    - python: 3.6
-      env: TOXENV=py36-django19
-    - python: 3.6
-      env: TOXENV=py36-django110
     - python: 3.6
       env: TOXENV=py36-django111
 

--- a/docs/source/releases/v1.5.rst
+++ b/docs/source/releases/v1.5.rst
@@ -19,8 +19,8 @@ Table of contents:
 Compatibility
 -------------
 
-Oscar 1.5 is compatible with Django 1.8, 1.9, 1.10  and 1.11 as well as Python 2.7,
-3.3, 3.4, 3.5 and 3.6.
+Oscar 1.5 is compatible with Django 1.8, 1.10 and 1.11 as well as Python 2.7,
+3.3, 3.4, 3.5 and 3.6. Support for Django 1.9 is dropped in this version.
 
 
 .. _new_in_1.5:

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,8 @@ setup(
         'Environment :: Web Environment',
         'Framework :: Django',
         'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.9',
+        'Framework :: Django :: 1.10',
+        'Framework :: Django :: 1.11',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: Unix',
@@ -105,6 +106,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Libraries :: Application Frameworks']
 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,13 @@
 [tox]
-envlist = py{27,34,35,36}-django{18,19,110,111},py33-django18,lint,sandbox
+envlist = py{27,33,34,35}-django18,py{27,34,35}-django110,py{27,34,35,36}-django111,lint,sandbox
 
 [testenv]
 commands = coverage run --parallel -m pytest {posargs}
 extras = test
 pip_pre = true
-deps = 
+deps =
     -r{toxinidir}/requirements.txt
     django18: django>=1.8,<1.9
-    django19: django>=1.9,<1.10
     django110: django>=1.10,<1.11
     django111: django>=1.11,<1.12
 
@@ -24,16 +23,16 @@ commands =
 [testenv:lint]
 basepython = python3.5
 deps = flake8
-commands = 
+commands =
     flake8 src tests setup.py
     isort -q --recursive --diff src/ tests/
 
 
 [testenv:sandbox]
 basepython = python3.5
-deps = 
+deps =
     -r{toxinidir}/requirements.txt
     django>=1.10,<1.11
 whitelist_externals = make
-commands = 
+commands =
     make build_sandbox


### PR DESCRIPTION
- Drop support for Django 1.9 (EOL)
- Drop support for Python 3.6 with Django 1.8 to 1.10 (these versions of Django don't officially support Python 3.6)