### PR TITLE
Updated tinymce version

### DIFF
--- a/src/oscar/templates/oscar/dashboard/layout.html
+++ b/src/oscar/templates/oscar/dashboard/layout.html
@@ -142,8 +142,8 @@
     <script src="{% static "oscar/js/oscar/dashboard.js" %}" type="text/javascript" charset="utf-8"></script>
 
     {# We don't use a fallback for tinyMCE as it dynamically loads several other files #}
-    <script src="//cdn.tinymce.com/4/tinymce.min.js" type="text/javascript" charset="utf-8"></script>
-    <script src="//cdn.tinymce.com/4/jquery.tinymce.min.js" type="text/javascript" charset="utf-8"></script>
+    <script src="//cdn.tinymce.com/4.3/tinymce.min.js" type="text/javascript" charset="utf-8"></script>
+    <script src="//cdn.tinymce.com/4.3/jquery.tinymce.min.js" type="text/javascript" charset="utf-8"></script>
 
 {% endblock %}
 


### PR DESCRIPTION
I encountered a bug in oscar's current tinymce version on safari and chrome. The one described here http://stackoverflow.com/questions/16450499/form-with-tinymce-textarea-having-html5-required-attribute-cannot-submit

tl;dr: A required textfield will be hidden via tinymce in the dashboard. Chrome tries to focus it. But it can't. Even if there is text inside. 

I tested the 4.3 Version of tinymce (latest one available on cdn.tinymce.com, current version is 4.5.x.) 