### PR TITLE
Attempt to create media directory for MissingProductImage if it doesn't exist

### DIFF
--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -1119,6 +1119,11 @@ class MissingProductImage(object):
         static_file_path = find('oscar/img/%s' % self.name)
         if static_file_path is not None:
             try:
+                # Check that the target directory exists, and attempt to
+                # create it if it doesn't.
+                media_file_dir = os.path.dirname(media_file_path)
+                if not os.path.exists(media_file_dir):
+                    os.makedirs(media_file_dir)
                 os.symlink(static_file_path, media_file_path)
             except OSError:
                 raise ImproperlyConfigured((

--- a/tests/integration/catalogue/test_product_image.py
+++ b/tests/integration/catalogue/test_product_image.py
@@ -1,5 +1,11 @@
-from django.test import TestCase
+import mock
+import os
+import tempfile
 
+from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.test import TestCase, override_settings
+
+from oscar.apps.catalogue.abstract_models import MissingProductImage
 from oscar.test import factories
 
 
@@ -14,3 +20,34 @@ class TestProductImages(TestCase):
 
         for idx, im in enumerate(product.images.all()):
             self.assertEqual(im.display_order, idx)
+
+
+class TestMissingProductImage(StaticLiveServerTestCase):
+
+    TEMP_MEDIA_ROOT = tempfile.mkdtemp()
+
+    @override_settings(MEDIA_ROOT=TEMP_MEDIA_ROOT)
+    @mock.patch('oscar.apps.catalogue.abstract_models.find')
+    def test_symlink_creates_directories(self, mock_find):
+        # Create a fake empty file to symlink
+        img = tempfile.NamedTemporaryFile(delete=False)
+        img.close()
+
+        mock_find.return_value = img.name
+        # Initialise the class with a nested path
+        path = 'image/path.jpg'
+        MissingProductImage(path)
+        # Check that the directory exists
+        image_path = os.path.join(self.TEMP_MEDIA_ROOT, path)
+        self.assertTrue(os.path.exists(image_path))
+
+        # Clean up
+        for f in [image_path, img.name]:
+            os.unlink(f)
+        for d in [os.path.join(self.TEMP_MEDIA_ROOT, 'image'), self.TEMP_MEDIA_ROOT]:
+            os.rmdir(d)
+
+    @mock.patch('oscar.apps.catalogue.abstract_models.MissingProductImage.symlink_missing_image')
+    def test_no_symlink_when_no_media_root(self, mock_symlink):
+        MissingProductImage()
+        self.assertEqual(mock_symlink.call_count, 0)


### PR DESCRIPTION
We try to create the `MEDIA_ROOT` (and any child directories if the path includes them) when symlinking the missing product image.

Fixes #2168.

