### PR TITLE
Remove the verify_exists argument from ExtendedUrlField

### DIFF
--- a/docs/source/releases/v1.5.rst
+++ b/docs/source/releases/v1.5.rst
@@ -136,6 +136,9 @@ Backwards incompatible changes in Oscar 1.5
  - Offer ``Applicator`` is now loaded from the ``offer.applicator`` module, instead of ``offer.utils``.
    Old path is deprecated and won't be supported in the next Oscar versions.
 
+ - ``oscar.forms.fields.ExtendedURLField`` no longer accepts a ``verify_exists``
+   argument.
+
 
 Dependency changes
 ------------------

--- a/src/oscar/apps/dashboard/promotions/forms.py
+++ b/src/oscar/apps/dashboard/promotions/forms.py
@@ -62,7 +62,7 @@ class OrderedProductForm(forms.ModelForm):
 
 
 class PagePromotionForm(forms.ModelForm):
-    page_url = ExtendedURLField(label=_("URL"), verify_exists=True)
+    page_url = ExtendedURLField(label=_("URL"))
     position = forms.CharField(
         widget=forms.Select(choices=settings.OSCAR_PROMOTION_POSITIONS),
         label=_("Position"),

--- a/src/oscar/apps/promotions/migrations/0001_initial.py
+++ b/src/oscar/apps/promotions/migrations/0001_initial.py
@@ -137,7 +137,7 @@ class Migration(migrations.Migration):
                 ('display_order', models.PositiveIntegerField(default=0, verbose_name='Display Order')),
                 ('clicks', models.PositiveIntegerField(default=0, verbose_name='Clicks')),
                 ('date_created', models.DateTimeField(auto_now_add=True, verbose_name='Date Created')),
-                ('page_url', oscar.models.fields.ExtendedURLField(max_length=128, verify_exists=True, db_index=True, verbose_name='Page URL')),
+                ('page_url', oscar.models.fields.ExtendedURLField(max_length=128, db_index=True, verbose_name='Page URL')),
                 ('content_type', models.ForeignKey(to='contenttypes.ContentType', on_delete=models.CASCADE)),
             ],
             options={

--- a/src/oscar/apps/promotions/models.py
+++ b/src/oscar/apps/promotions/models.py
@@ -46,7 +46,7 @@ class PagePromotion(LinkedPromotion):
     A promotion embedded on a particular page.
     """
     page_url = ExtendedURLField(
-        _('Page URL'), max_length=128, db_index=True, verify_exists=True)
+        _('Page URL'), max_length=128, db_index=True)
 
     def __str__(self):
         return u"%s on %s" % (self.content_object, self.page_url)

--- a/src/oscar/core/validators.py
+++ b/src/oscar/core/validators.py
@@ -12,19 +12,15 @@ from oscar.core.loading import get_model
 class ExtendedURLValidator(validators.URLValidator):
 
     def __init__(self, *args, **kwargs):
-        # 'verify_exists' has been removed in Django 1.5 and so we no longer
-        # pass it up to the core validator class
         self.is_local_url = False
-        verify_exists = kwargs.pop('verify_exists', False)
         super(ExtendedURLValidator, self).__init__(*args, **kwargs)
-        self.verify_exists = verify_exists
 
     def __call__(self, value):
         try:
             super(ExtendedURLValidator, self).__call__(value)
         except ValidationError:
-            # The parent validator will raise an exception if the URL does not
-            # exist and so we test here to see if the value is a local URL.
+            # The parent validator will raise an exception if the URL is not a
+            # valid absolute URL so we test here to see if it is a local URL.
             if value:
                 self.validate_local_url(value)
             else:
@@ -65,12 +61,12 @@ class URLDoesNotExistValidator(ExtendedURLValidator):
 
     def __call__(self, value):
         """
-        Validate that the URLdoes not already exist.
+        Validate that the URL does not already exist.
 
         The URL will be verified first and raises ``ValidationError`` when
-        it is invalid. A valid URL is checked for existance and raises
-        ``ValidationError`` if the URL already exists. Setting attribute
-        ``verify_exists`` has no impact on validation.
+        it is invalid. A valid URL is checked for existence and raises
+        ``ValidationError`` if the URL already exists.
+
         This validation uses two calls to ExtendedURLValidator which can
         be slow. Be aware of this, when you use it.
 

--- a/src/oscar/forms/fields.py
+++ b/src/oscar/forms/fields.py
@@ -14,21 +14,9 @@ class ExtendedURLField(fields.URLField):
     # URLS are allowed for ExtendedURLField, we must set it to TextInput
     widget = TextInput
 
-    def __init__(self, max_length=None, min_length=None, verify_exists=None,
-                 *args, **kwargs):
-        # We don't pass on verify_exists as it has been deprecated in Django
-        # 1.4
-        super(fields.URLField, self).__init__(
-            max_length, min_length, *args, **kwargs)
-        # Even though it is deprecated, we still pass on 'verify_exists' as
-        # Oscar's ExtendedURLValidator uses it to determine whether to test
-        # local URLs.
-        if verify_exists is not None:
-            validator = validators.ExtendedURLValidator(
-                verify_exists=verify_exists)
-        else:
-            validator = validators.ExtendedURLValidator()
-        self.validators.append(validator)
+    def __init__(self, max_length=None, min_length=None, *args, **kwargs):
+        super(fields.URLField, self).__init__(*args, **kwargs)
+        self.validators.append(validators.ExtendedURLValidator())
 
     def to_python(self, value):
         # We need to avoid having 'http' inserted at the start of

--- a/src/oscar/models/fields/__init__.py
+++ b/src/oscar/models/fields/__init__.py
@@ -32,27 +32,16 @@ class Creator(object):
 class ExtendedURLField(CharField):
     description = _("URL")
 
-    def __init__(self, verbose_name=None, name=None,
-                 verify_exists=None, **kwargs):
+    def __init__(self, *args, **kwargs):
         kwargs['max_length'] = kwargs.get('max_length', 200)
-        CharField.__init__(self, verbose_name, name, **kwargs)
-        # 'verify_exists' was deprecated in Django 1.4. To ensure backwards
-        # compatibility, it is still accepted here, but only passed
-        # on to the parent class if it was specified.
-        self.verify_exists = verify_exists
-        if verify_exists is not None:
-            validator = validators.ExtendedURLValidator(
-                verify_exists=verify_exists)
-        else:
-            validator = validators.ExtendedURLValidator()
-        self.validators.append(validator)
+        CharField.__init__(self, *args, **kwargs)
+        self.validators.append(validators.ExtendedURLValidator())
 
     def formfield(self, **kwargs):
         # As with CharField, this will cause URL validation to be performed
         # twice.
         defaults = {
             'form_class': fields.ExtendedURLField,
-            'verify_exists': self.verify_exists
         }
         defaults.update(kwargs)
         return super(ExtendedURLField, self).formfield(**defaults)
@@ -62,9 +51,6 @@ class ExtendedURLField(CharField):
         deconstruct() is needed by Django's migration framework
         """
         name, path, args, kwargs = super(ExtendedURLField, self).deconstruct()
-        # Add verify_exists to kwargs if it's not the default value.
-        if self.verify_exists is not None:
-            kwargs['verify_exists'] = self.verify_exists
         # We have a default value for max_length; remove it in that case
         if self.max_length == 200:
             del kwargs['max_length']

--- a/tests/integration/core/test_validator.py
+++ b/tests/integration/core/test_validator.py
@@ -6,13 +6,10 @@ from oscar.core.validators import ExtendedURLValidator
 from oscar.core.validators import URLDoesNotExistValidator
 
 
-class TestExtendedURLValidatorWithVerifications(TestCase):
-    """
-    ExtendedURLValidator with verify_exists=True
-    """
+class TestExtendedURLValidator(TestCase):
 
     def setUp(self):
-        self.validator = ExtendedURLValidator(verify_exists=True)
+        self.validator = ExtendedURLValidator()
 
     def test_validates_local_url(self):
         try:
@@ -52,10 +49,7 @@ class TestExtendedURLValidatorWithVerifications(TestCase):
                       'unexpectedly!')
 
 
-class TestExtendedURLValidatorWithoutVerifyExists(TestCase):
-    """
-    ExtendedURLValidator with verify_exists=False
-    """
+class TestURLDoesNotExistValidator(TestCase):
 
     def setUp(self):
         self.validator = URLDoesNotExistValidator()

--- a/tests/integration/forms/test_field.py
+++ b/tests/integration/forms/test_field.py
@@ -6,5 +6,5 @@ class TestExtendedURLField(TestCase):
     """ExtendedURLField"""
 
     def test_validates_local_urls(self):
-        field = fields.ExtendedURLField(verify_exists=True)
+        field = fields.ExtendedURLField()
         field.clean('/')


### PR DESCRIPTION
This was removed from the parent class way back in Django 1.4, and was not being used at all here - there was just a load of redundant code passing the argument around. I think it's safe to drop it completely.