### PR TITLE
Switch to using Django's password validation framework in Django >=1.9

### DIFF
--- a/docs/source/releases/v1.5.rst
+++ b/docs/source/releases/v1.5.rst
@@ -29,6 +29,8 @@ What's new in Oscar 1.5?
 ------------------------
  - Support for Django 1.11 (:issue:`2221`)
  - Google Analytics tracking code has been migrated to Universal Analytics.
+ - Passwords are validated using the validators defined in
+   ``AUTH_PASSWORD_VALIDATORS`` for Django 1.9 and above.
 
 
 Removal of deprecated features

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -287,6 +287,18 @@ AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
 )
 
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        'OPTIONS': {
+            'min_length': 9,
+        }
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+    },
+]
+
 LOGIN_REDIRECT_URL = '/'
 APPEND_SLASH = True
 

--- a/src/oscar/apps/customer/forms.py
+++ b/src/oscar/apps/customer/forms.py
@@ -15,7 +15,7 @@ from oscar.apps.customer.utils import get_password_reset_url, normalise_email
 from oscar.core.compat import (
     existing_user_fields, get_user_model, user_is_authenticated)
 from oscar.core.loading import get_class, get_model, get_profile_class
-from oscar.core.validators import password_validators
+from oscar.core.validators import validate_password
 from oscar.forms import widgets
 
 Dispatcher = get_class('customer.utils', 'Dispatcher')
@@ -79,17 +79,21 @@ class PasswordResetForm(auth_forms.PasswordResetForm):
 
 
 class SetPasswordForm(auth_forms.SetPasswordForm):
-    def __init__(self, *args, **kwargs):
-        super(SetPasswordForm, self).__init__(*args, **kwargs)
-        # Enforce password validations for the new password
-        self.fields['new_password1'].validators += password_validators
+
+    def clean_new_password2(self):
+        new_password2 = super(SetPasswordForm, self).clean_new_password2()
+        # For backward compatibility with Django 1.8
+        validate_password(new_password2, self.user)
+        return new_password2
 
 
 class PasswordChangeForm(auth_forms.PasswordChangeForm):
-    def __init__(self, *args, **kwargs):
-        super(PasswordChangeForm, self).__init__(*args, **kwargs)
-        # Enforce password validations for the new password
-        self.fields['new_password1'].validators += password_validators
+
+    def clean_new_password2(self):
+        new_password2 = super(PasswordChangeForm, self).clean_new_password2()
+        # For backward compatibility with Django 1.8
+        validate_password(new_password2, self.user)
+        return new_password2
 
 
 class EmailAuthenticationForm(AuthenticationForm):
@@ -135,8 +139,7 @@ class ConfirmPasswordForm(forms.Form):
 class EmailUserCreationForm(forms.ModelForm):
     email = forms.EmailField(label=_('Email address'))
     password1 = forms.CharField(
-        label=_('Password'), widget=forms.PasswordInput,
-        validators=password_validators)
+        label=_('Password'), widget=forms.PasswordInput)
     password2 = forms.CharField(
         label=_('Confirm password'), widget=forms.PasswordInput)
     redirect_url = forms.CharField(
@@ -166,6 +169,7 @@ class EmailUserCreationForm(forms.ModelForm):
         if password1 != password2:
             raise forms.ValidationError(
                 _("The two password fields didn't match."))
+        validate_password(password2, self.instance)
         return password2
 
     def clean_redirect_url(self):

--- a/src/oscar/apps/dashboard/partners/forms.py
+++ b/src/oscar/apps/dashboard/partners/forms.py
@@ -6,7 +6,7 @@ from django.utils.translation import pgettext_lazy
 from oscar.apps.customer.forms import EmailUserCreationForm
 from oscar.core.compat import existing_user_fields, get_user_model
 from oscar.core.loading import get_model
-from oscar.core.validators import password_validators
+from oscar.core.validators import validate_password
 
 User = get_user_model()
 Partner = get_model('partner', 'Partner')
@@ -76,8 +76,7 @@ class ExistingUserForm(forms.ModelForm):
     password1 = forms.CharField(
         label=_('Password'),
         widget=forms.PasswordInput,
-        required=False,
-        validators=password_validators)
+        required=False)
     password2 = forms.CharField(
         required=False,
         label=_('Confirm Password'),
@@ -90,6 +89,7 @@ class ExistingUserForm(forms.ModelForm):
         if password1 != password2:
             raise forms.ValidationError(
                 _("The two password fields didn't match."))
+        validate_password(password, self.instance)
         return password2
 
     def __init__(self, *args, **kwargs):

--- a/src/oscar/core/validators.py
+++ b/src/oscar/core/validators.py
@@ -1,5 +1,6 @@
 import keyword
 
+from django.conf import settings
 from django.core import validators
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import resolve
@@ -98,7 +99,7 @@ def non_python_keyword(value):
 
 
 class CommonPasswordValidator(validators.BaseValidator):
-    # See http://www.smartplanet.com/blog/business-brains/top-20-most-common-passwords-of-all-time-revealed-8216123456-8216princess-8216qwerty/4519  # noqa
+
     forbidden_passwords = [
         'password',
         '1234',
@@ -152,8 +153,38 @@ class CommonPasswordValidator(validators.BaseValidator):
             return self.forbidden_passwords
 
 
-# List all requirements for password, site wide
-password_validators = [
-    validators.MinLengthValidator(6),
-    CommonPasswordValidator(),
-]
+# Shim for backwards compatibility with Django 1.8. This can be removed when
+# support for Django 1.8 is dropped.
+def validate_password(password, user=None):
+    try:
+        # Django 1.9 and above
+        from django.contrib.auth import password_validation
+        # If AUTH_PASSWORD_VALIDATORS is empty, then supply validators
+        # equivalent to what Oscar used to do itself (deprecated).
+        if settings.AUTH_PASSWORD_VALIDATORS:
+            password_validators = None
+        else:
+            password_validators = [
+                password_validation.MinimumLengthValidator(min_length=6),
+                password_validation.CommonPasswordValidator(),
+            ]
+        return password_validation.validate_password(password, user=user,
+                                        password_validators=password_validators)
+    except ImportError:
+        # Django 1.8 - use our custom validators. Note that these are Field
+        # validators and have a different signature to the password validators
+        # used above.
+        password_validators = [
+            validators.MinLengthValidator(6),
+            CommonPasswordValidator(),
+        ]
+
+        errors = []
+        for validator in password_validators:
+            try:
+                validator(password)
+            except ValidationError as error:
+                errors.append(error)
+
+        if errors:
+            raise ValidationError(errors)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -101,6 +101,21 @@ AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
 )
 
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        'OPTIONS': {
+            'min_length': 6,
+        }
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+    },
+]
+
 HAYSTACK_CONNECTIONS = {'default': {'ENGINE': 'haystack.backends.simple_backend.SimpleEngine'}}
 PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher']
 ROOT_URLCONF = 'tests._site.urls'


### PR DESCRIPTION
Django 1.9 introduced the `AUTH_PASSWORD_VALIDATORS` setting which allows for more flexible password validation. Switch to using that when it is available, with a fallback to Oscar's previous behaviour in Django 1.8 or when this setting is empty.