### PR TITLE
Fix handling of unicode formats in Oscar's date/time/datetime widgets.

### DIFF
--- a/src/oscar/forms/widgets.py
+++ b/src/oscar/forms/widgets.py
@@ -142,24 +142,15 @@ def datetime_format_to_js_input_mask(format):
 
 
 class DateTimeWidgetMixin(object):
-    def get_format(self):
-        format = self.format
-        if hasattr(self, 'manual_format'):
-            # For django <= 1.6.5, see
-            # https://code.djangoproject.com/ticket/21173
-            if self.is_localized and not self.manual_format:
-                format = force_text(formats.get_format(self.format_key)[0])
-        else:
-            # For django >= 1.7
-            format = format or formats.get_format(self.format_key)[0]
 
-        return format
+    def get_format(self):
+        return self.format or formats.get_format(self.format_key)[0]
 
     def gett_attrs(self, attrs, format):
         if not attrs:
             attrs = {}
 
-        attrs['data-inputmask'] = "'mask': '{mask}'".format(
+        attrs['data-inputmask'] = u"'mask': '{mask}'".format(
             mask=datetime_format_to_js_input_mask(format))
 
         return attrs
@@ -177,20 +168,20 @@ class TimePickerInput(DateTimeWidgetMixin, forms.TimeInput):
         input = super(TimePickerInput, self).render(
             name, value, self.gett_attrs(attrs, format))
 
-        attrs = {'data-oscarWidget': 'time',
-                 'data-timeFormat':
-                 datetime_format_to_js_time_format(format),
-                 }
+        attrs = {
+            'data-oscarWidget': 'time',
+            'data-timeFormat': datetime_format_to_js_time_format(format),
+        }
 
-        div = format_html('<div class="input-group date"{}>', flatatt(attrs))
-        return mark_safe('<div class="form-inline">'
-                         ' {div}'
-                         '  {input}'
-                         '  <span class="input-group-addon">'
-                         '   <i class="icon-time glyphicon-time"></i>'
-                         '  </span>'
-                         ' </div>'
-                         '</div>'
+        div = format_html(u'<div class="input-group date"{}>', flatatt(attrs))
+        return mark_safe(u'<div class="form-inline">'
+                         u' {div}'
+                         u'  {input}'
+                         u'  <span class="input-group-addon">'
+                         u'   <i class="icon-time glyphicon-time"></i>'
+                         u'  </span>'
+                         u' </div>'
+                         u'</div>'
                          .format(div=div, input=input))
 
 
@@ -206,20 +197,20 @@ class DatePickerInput(DateTimeWidgetMixin, forms.DateInput):
         input = super(DatePickerInput, self).render(
             name, value, self.gett_attrs(attrs, format))
 
-        attrs = {'data-oscarWidget': 'date',
-                 'data-dateFormat':
-                 datetime_format_to_js_date_format(format),
-                 }
+        attrs = {
+            'data-oscarWidget': 'date',
+            'data-dateFormat': datetime_format_to_js_date_format(format),
+        }
 
-        div = format_html('<div class="input-group date"{}>', flatatt(attrs))
-        return mark_safe('<div class="form-inline">'
-                         ' {div}'
-                         '  {input}'
-                         '  <span class="input-group-addon">'
-                         '   <i class="icon-calendar glyphicon-calendar"></i>'
-                         '  </span>'
-                         ' </div>'
-                         '</div>'
+        div = format_html(u'<div class="input-group date"{}>', flatatt(attrs))
+        return mark_safe(u'<div class="form-inline">'
+                         u' {div}'
+                         u'  {input}'
+                         u'  <span class="input-group-addon">'
+                         u'   <i class="icon-calendar glyphicon-calendar"></i>'
+                         u'  </span>'
+                         u' </div>'
+                         u'</div>'
                          .format(div=div, input=input))
 
 
@@ -249,20 +240,20 @@ class DateTimePickerInput(DateTimeWidgetMixin, forms.DateTimeInput):
         input = super(DateTimePickerInput, self).render(
             name, value, self.gett_attrs(attrs, format))
 
-        attrs = {'data-oscarWidget': 'datetime',
-                 'data-datetimeFormat':
-                 datetime_format_to_js_datetime_format(format),
-                 }
+        attrs = {
+            'data-oscarWidget': 'datetime',
+            'data-datetimeFormat': datetime_format_to_js_datetime_format(format),
+        }
 
-        div = format_html('<div class="input-group date"{}>', flatatt(attrs))
-        return mark_safe('<div class="form-inline">'
-                         ' {div}'
-                         '  {input}'
-                         '  <span class="input-group-addon">'
-                         '   <i class="icon-calendar glyphicon-calendar"></i>'
-                         '  </span>'
-                         ' </div>'
-                         '</div>'
+        div = format_html(u'<div class="input-group date"{}>', flatatt(attrs))
+        return mark_safe(u'<div class="form-inline">'
+                         u' {div}'
+                         u'  {input}'
+                         u'  <span class="input-group-addon">'
+                         u'   <i class="icon-calendar glyphicon-calendar"></i>'
+                         u'  </span>'
+                         u' </div>'
+                         u'</div>'
                          .format(div=div, input=input))
 
 

--- a/tests/integration/forms/test_widget.py
+++ b/tests/integration/forms/test_widget.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+import datetime
+
 from django.test import TestCase
 
 from oscar.forms import widgets
@@ -20,3 +23,24 @@ class TestWidgetsDatetimeFormat(TestCase):
         )
         for format_, expected in format_testcases:
             self.assertEqual(widgets.datetime_format_to_js_time_format(format_), expected)
+
+    def test_timepickerinput_format_unicode(self):
+        # Check that the widget can handle unicode formats
+        i = widgets.TimePickerInput(format=u'τ-%H:%M')
+        time = datetime.time(10, 47)
+        html = i.render('time', time)
+        self.assertIn(u'value="τ-10:47"', html)
+
+    def test_datepickerinput_format_unicode(self):
+        # Check that the widget can handle unicode formats
+        i = widgets.DatePickerInput(format=u'δ-%d/%m/%Y')
+        date = datetime.date(2017, 5, 1)
+        html = i.render('date', date)
+        self.assertIn(u'value="δ-01/05/2017"', html)
+
+    def test_datetimepickerinput_format_unicode(self):
+        # Check that the widget can handle unicode formats
+        i = widgets.DateTimePickerInput(format=u'δ-%d/%m/%Y %H:%M')
+        date = datetime.datetime(2017, 5, 1, 10, 57)
+        html = i.render('datetime', date)
+        self.assertIn(u'value="δ-01/05/2017 10:57"', html)


### PR DESCRIPTION
Also remove some Django 1.6 compatibility code.

Fixes #2176.