### PR TITLE
Updated offer.custom module to load models using get_model()

### DIFF
--- a/src/oscar/apps/offer/custom.py
+++ b/src/oscar/apps/offer/custom.py
@@ -1,9 +1,10 @@
 from django.core import exceptions
 from django.db import IntegrityError
 
-from oscar.apps.offer.models import Benefit, Condition
 from oscar.core.loading import get_model
 
+Benefit = get_model('offer', 'Benefit')
+Condition = get_model('offer', 'Condition')
 Range = get_model('offer', 'Range')
 
 


### PR DESCRIPTION
This change ensures that the module can be loaded if models are customized in forked apps.

Fixes #2345