### PR TITLE
Fixing custom condition choosing

### DIFF
--- a/src/oscar/apps/dashboard/offers/forms.py
+++ b/src/oscar/apps/dashboard/offers/forms.py
@@ -86,10 +86,11 @@ class ConditionForm(forms.ModelForm):
                 _("Please either choose a range, type and value OR "
                   "select a custom condition"))
 
-        if not data['custom_condition']:
-            if not data.get('range', None):
+        if data['custom_condition']:
+            if data.get('range', None) or data.get('type', None) or data.get('value', None):
                 raise forms.ValidationError(
-                    _("A range is required"))
+                    _("No other options can be set if you are using a "
+                      "custom condition"))
 
         return data
 


### PR DESCRIPTION
When custom conditions are available, form demands a range, but no range should be attached to the custom condition. Also no another fields filled should be. Current commit fixes the bug, which appears when you try to save ConditionalOffer instance with custom condition.