### PR TITLE
Fix handling of free products when calculating basket totals in Python 3

### DIFF
--- a/src/oscar/apps/basket/abstract_models.py
+++ b/src/oscar/apps/basket/abstract_models.py
@@ -802,14 +802,14 @@ class AbstractLine(models.Model):
 
     @property
     def line_price_excl_tax(self):
-        if self.unit_price_excl_tax:
+        if self.unit_price_excl_tax is not None:
             return self.quantity * self.unit_price_excl_tax
 
     @property
     def line_price_excl_tax_incl_discounts(self):
-        if self._discount_excl_tax and self.line_price_excl_tax:
+        if self._discount_excl_tax and self.line_price_excl_tax is not None:
             return self.line_price_excl_tax - self._discount_excl_tax
-        if self._discount_incl_tax and self.line_price_incl_tax:
+        if self._discount_incl_tax and self.line_price_incl_tax is not None:
             # This is a tricky situation.  We know the discount as calculated
             # against tax inclusive prices but we need to guess how much of the
             # discount applies to tax-exclusive prices.  We do this by
@@ -823,7 +823,7 @@ class AbstractLine(models.Model):
         # We use whichever discount value is set.  If the discount value was
         # calculated against the tax-exclusive prices, then the line price
         # including tax
-        if self.line_price_incl_tax:
+        if self.line_price_incl_tax is not None:
             return self.line_price_incl_tax - self.discount_value
 
     @property
@@ -833,7 +833,7 @@ class AbstractLine(models.Model):
 
     @property
     def line_price_incl_tax(self):
-        if self.unit_price_incl_tax:
+        if self.unit_price_incl_tax is not None:
             return self.quantity * self.unit_price_incl_tax
 
     @property

--- a/tests/integration/basket/test_models.py
+++ b/tests/integration/basket/test_models.py
@@ -170,6 +170,19 @@ class TestANonEmptyBasket(TestCase):
         self.basket.add(product, 1)
         self.assertEqual(self.basket.total_excl_tax, 105)
 
+    def test_totals_for_free_products(self):
+        basket = Basket()
+        basket.strategy = strategy.Default()
+        # Add a zero-priced product to the basket
+        product = factories.create_product()
+        factories.create_stockrecord(
+            product, price_excl_tax=D('0.00'), num_in_stock=10)
+        basket.add(product, 1)
+
+        self.assertEqual(basket.lines.count(), 1)
+        self.assertEqual(basket.total_excl_tax, 0)
+        self.assertEqual(basket.total_incl_tax, 0)
+
     def test_basket_prices_calculation_for_unavailable_pricing(self):
         new_product = factories.create_product()
         factories.create_stockrecord(


### PR DESCRIPTION
In Python 2, adding None to the basket total worked, but in Python 3 this raises a `TypeError`. This fixes the handling of totals to distinguish between a zero price and a non-existent price.

You can reproduce the bug in the sandbox - try adding this product to cart: https://latest.oscarcommerce.com/en-gb/catalogue/wayuu-bag_262/