### PR TITLE
Only send analytics transaction events on the first load of the checkout thank you page.

### DIFF
--- a/src/oscar/apps/checkout/views.py
+++ b/src/oscar/apps/checkout/views.py
@@ -677,3 +677,16 @@ class ThankYouView(generic.DetailView):
                 raise http.Http404(_("No order found"))
 
         return order
+
+    def get_context_data(self, *args, **kwargs):
+        ctx = super(ThankYouView, self).get_context_data(*args, **kwargs)
+        # Remember whether this view has been loaded.
+        # Only send tracking information on the first load.
+        key = 'order_{}_thankyou_viewed'.format(ctx['order'].pk)
+        if not self.request.session.get(key, False):
+            self.request.session[key] = True
+            ctx['send_analytics_event'] = True
+        else:
+            ctx['send_analytics_event'] = False
+
+        return ctx

--- a/src/oscar/templates/oscar/checkout/thank_you.html
+++ b/src/oscar/templates/oscar/checkout/thank_you.html
@@ -322,5 +322,7 @@
 {% endblock content %}
 
 {% block tracking %}
-    {% include "partials/google_analytics_transaction.html" %}
+    {% if send_analytics_event %}
+        {% include "partials/google_analytics_transaction.html" %}
+    {% endif %}
 {% endblock %}

--- a/tests/integration/checkout/test_views.py
+++ b/tests/integration/checkout/test_views.py
@@ -1,0 +1,24 @@
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from oscar.test.factories import OrderFactory
+
+
+class ThankYouViewTestCase(TestCase):
+
+    @override_settings(OSCAR_ALLOW_ANON_CHECKOUT=True)
+    def test_analytics_event_triggered_only_on_first_view(self):
+        order = OrderFactory()
+        session = self.client.session
+        # Put the order ID in the session, mimicking a completed order,
+        # so that we can reach the thank you page.
+        session['checkout_order_id'] = order.pk
+        session.save()
+
+        r1 = self.client.get(reverse('checkout:thank-you'))
+        self.assertTrue(r1.context['send_analytics_event'])
+
+        # Request the view a second time
+        r2 = self.client.get(reverse('checkout:thank-you'))
+        self.assertFalse(r2.context['send_analytics_event'])


### PR DESCRIPTION
Subsequent views of the page (for the same order) should not trigger an event.

Fixes #2413.