### PR TITLE
When the query is empty, send emptystring as query

### DIFF
--- a/src/oscar/templates/oscar/catalogue/browse.html
+++ b/src/oscar/templates/oscar/catalogue/browse.html
@@ -64,7 +64,7 @@
         {% for value in selected_facets %}
             <input type="hidden" name="selected_facets" value="{{ value }}" />
         {% endfor %}
-        <input type="hidden" name="q" value="{% firstof search_form.q.value %}" />
+        <input type="hidden" name="q" value="{{ search_form.q.value|default_if_none:"" }}" />
 
         {% if paginator.count %}
             {% if paginator.num_pages > 1 %}

--- a/src/oscar/templates/oscar/catalogue/browse.html
+++ b/src/oscar/templates/oscar/catalogue/browse.html
@@ -64,7 +64,7 @@
         {% for value in selected_facets %}
             <input type="hidden" name="selected_facets" value="{{ value }}" />
         {% endfor %}
-        <input type="hidden" name="q" value="{{ search_form.q.value }}" />
+        <input type="hidden" name="q" value="{% firstof search_form.q.value %}" />
 
         {% if paginator.count %}
             {% if paginator.num_pages > 1 %}


### PR DESCRIPTION
Currently the form sends "None" as the query string.