### PR TITLE
refactor proxy_map on conditions and benefits

### DIFF
--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -444,18 +444,28 @@ class AbstractBenefit(models.Model):
         verbose_name = _("Benefit")
         verbose_name_plural = _("Benefits")
 
-    def proxy(self):
-        from oscar.apps.offer import benefits
-
-        klassmap = {
-            self.PERCENTAGE: benefits.PercentageDiscountBenefit,
-            self.FIXED: benefits.AbsoluteDiscountBenefit,
-            self.MULTIBUY: benefits.MultibuyDiscountBenefit,
-            self.FIXED_PRICE: benefits.FixedPriceBenefit,
-            self.SHIPPING_ABSOLUTE: benefits.ShippingAbsoluteDiscountBenefit,
-            self.SHIPPING_FIXED_PRICE: benefits.ShippingFixedPriceBenefit,
-            self.SHIPPING_PERCENTAGE: benefits.ShippingPercentageDiscountBenefit
+    @property
+    def proxy_map(self):
+        return {
+            self.PERCENTAGE: get_class(
+                'offer.benefits', 'PercentageDiscountBenefit'),
+            self.FIXED: get_class(
+                'offer.benefits', 'AbsoluteDiscountBenefit'),
+            self.MULTIBUY: get_class(
+                'offer.benefits', 'MultibuyDiscountBenefit'),
+            self.FIXED_PRICE: get_class(
+                'offer.benefits', 'FixedPriceBenefit'),
+            self.SHIPPING_ABSOLUTE: get_class(
+                'offer.benefits', 'ShippingAbsoluteDiscountBenefit'),
+            self.SHIPPING_FIXED_PRICE: get_class(
+                'offer.benefits', 'ShippingFixedPriceBenefit'),
+            self.SHIPPING_PERCENTAGE: get_class(
+                'offer.benefits', 'ShippingPercentageDiscountBenefit')
         }
+
+    def proxy(self):
+        klassmap = self.proxy_map
+
         # Short-circuit logic if current class is already a proxy class.
         if self.__class__ in klassmap.values():
             return self
@@ -685,17 +695,22 @@ class AbstractCondition(models.Model):
         verbose_name = _("Condition")
         verbose_name_plural = _("Conditions")
 
+    @property
+    def proxy_map(self):
+        return {
+            self.COUNT: get_class(
+                'offer.conditions', 'CountCondition'),
+            self.VALUE: get_class(
+                'offer.conditions', 'ValueCondition'),
+            self.COVERAGE: get_class(
+                'offer.conditions', 'CoverageCondition'),
+        }
+
     def proxy(self):
         """
         Return the proxy model
         """
-        from oscar.apps.offer import conditions
-
-        klassmap = {
-            self.COUNT: conditions.CountCondition,
-            self.VALUE: conditions.ValueCondition,
-            self.COVERAGE: conditions.CoverageCondition
-        }
+        klassmap = self.proxy_map
         # Short-circuit logic if current class is already a proxy class.
         if self.__class__ in klassmap.values():
             return self

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -3,7 +3,6 @@ from django.contrib.auth.models import AnonymousUser
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.sessions.backends.db import SessionStore
 from django.test.client import RequestFactory as BaseRequestFactory
-
 from oscar.core.loading import get_class, get_model
 
 

--- a/tests/integration/offer/test_benefit.py
+++ b/tests/integration/offer/test_benefit.py
@@ -28,17 +28,17 @@ class TestBenefitProxyModels(object):
         This test became necessary because the complex name/description logic
         broke with the python_2_unicode_compatible decorator.
         """
-        for type, __ in Benefit.TYPE_CHOICES:
-            benefit = Benefit(type=type, range=range)
+        for benefit_type, __ in Benefit.TYPE_CHOICES:
+            benefit = Benefit(type=benefit_type, range=range)
             assert all([
                 benefit.name,
                 benefit.description,
                 six.text_type(benefit)])
 
     def test_proxy(self, range):
-        for type, __ in Benefit.TYPE_CHOICES:
+        for benefit_type, __ in Benefit.TYPE_CHOICES:
             benefit = Benefit(
-                type=type, value=10, range=range, max_affected_items=1)
+                type=benefit_type, value=10, range=range, max_affected_items=1)
             proxy = benefit.proxy()
             assert benefit.type == proxy.type
             assert benefit.value == proxy.value

--- a/tests/integration/offer/test_benefit.py
+++ b/tests/integration/offer/test_benefit.py
@@ -1,4 +1,5 @@
-from django.test import TestCase
+import pytest
+
 from django.utils import six
 
 
@@ -6,9 +7,20 @@ from oscar.apps.offer.models import Benefit
 from oscar.test import factories
 
 
-class TestBenefitProxyModels(TestCase):
+@pytest.fixture
+def range():
+    return factories.RangeFactory()
 
-    def test_name_and_description(self):
+
+@pytest.mark.django_db
+class TestBenefitProxyModels(object):
+    """
+
+    https://docs.djangoproject.com/en/1.11/topics/db/models/#proxy-models
+
+    """
+
+    def test_name_and_description(self, range):
         """
         Tests that the benefit proxy classes all return a name and
         description. Unfortunately, the current implementations means
@@ -16,10 +28,19 @@ class TestBenefitProxyModels(TestCase):
         This test became necessary because the complex name/description logic
         broke with the python_2_unicode_compatible decorator.
         """
-        range = factories.RangeFactory()
         for type, __ in Benefit.TYPE_CHOICES:
             benefit = Benefit(type=type, range=range)
-            self.assertTrue(all([
+            assert all([
                 benefit.name,
                 benefit.description,
-                six.text_type(benefit)]))
+                six.text_type(benefit)])
+
+    def test_proxy(self, range):
+        for type, __ in Benefit.TYPE_CHOICES:
+            benefit = Benefit(
+                type=type, value=10, range=range, max_affected_items=1)
+            proxy = benefit.proxy()
+            assert benefit.type == proxy.type
+            assert benefit.value == proxy.value
+            assert benefit.range == proxy.range
+            assert benefit.max_affected_items == proxy.max_affected_items

--- a/tests/integration/offer/test_condition.py
+++ b/tests/integration/offer/test_condition.py
@@ -1,3 +1,4 @@
+import pytest
 from decimal import Decimal as D
 
 import mock
@@ -215,9 +216,15 @@ class TestCoverageCondition(TestCase):
         self.assertEqual(0, self.basket.num_items_without_discount)
 
 
-class TestConditionProxyModels(TestCase):
+@pytest.fixture()
+def range():
+    return factories.RangeFactory()
 
-    def test_name_and_description(self):
+
+@pytest.mark.django_db
+class TestConditionProxyModels(object):
+
+    def test_name_and_description(self, range):
         """
         Tests that the condition proxy classes all return a name and
         description. Unfortunately, the current implementations means
@@ -225,13 +232,20 @@ class TestConditionProxyModels(TestCase):
         This test became necessary because the complex name/description logic
         broke with the python_2_unicode_compatible decorator.
         """
-        range = factories.RangeFactory()
         for type, __ in models.Condition.TYPE_CHOICES:
             condition = models.Condition(type=type, range=range, value=5)
-            self.assertTrue(all([
+            assert all([
                 condition.name,
                 condition.description,
-                six.text_type(condition)]))
+                six.text_type(condition)])
+
+    def test_proxy(self, range):
+        for type, __ in models.Condition.TYPE_CHOICES:
+            condition = models.Condition(type=type, range=range, value=5)
+            proxy = condition.proxy()
+            assert condition.type == proxy.type
+            assert condition.range == proxy.range
+            assert condition.value == proxy.value
 
 
 class TestCustomCondition(TestCase):


### PR DESCRIPTION
- Allow plugin of new conditions and benefits
- Allow usage of custom versions of default conditions and benefits

The current implementation makes it very hard to:
- add a new benefit or condition to the list of proxies
- modify the behavior of a default benefit or condition 

This change seeks to fix both issues