### PR TITLE
Cast PhoneNumber field to unicode before storing in session. Fixes #2421

### DIFF
--- a/src/oscar/apps/checkout/utils.py
+++ b/src/oscar/apps/checkout/utils.py
@@ -165,7 +165,13 @@ class CheckoutSessionData(object):
         """
         Store address fields for a billing address.
         """
-        self._flush_namespace('billing')
+        self._unset('billing', 'new_address_fields')
+        phone_number = address_fields.get('phone_number')
+        if phone_number:
+            # Phone number is stored as a PhoneNumber instance. As we store
+            # strings in the session, we need to serialize it.
+            address_fields = address_fields.copy()
+            address_fields['phone_number'] = phone_number.as_international
         self._set('billing', 'new_address_fields', address_fields)
 
     def bill_to_user_address(self, address):


### PR DESCRIPTION
JSON serializers cannot handle arbitrary python data types (of which the PhoneNumber is one).  To work around this, we cast the phone number to unicode before storing it in the session.  This works ok as the
PhoneNumber field is reconstituted correctly when the string is deserialized.