### PR TITLE
Add a css class to set the ProductSelect widget width 

### DIFF
--- a/src/oscar/apps/dashboard/catalogue/forms.py
+++ b/src/oscar/apps/dashboard/catalogue/forms.py
@@ -323,10 +323,6 @@ class ProductRecommendationForm(forms.ModelForm):
             'recommendation': ProductSelect,
         }
 
-    def __init__(self, *args, **kwargs):
-        super(ProductRecommendationForm, self).__init__(*args, **kwargs)
-        self.fields['recommendation'].widget.attrs['class'] = "select2"
-
 
 class ProductClassForm(forms.ModelForm):
 

--- a/src/oscar/apps/dashboard/catalogue/widgets.py
+++ b/src/oscar/apps/dashboard/catalogue/widgets.py
@@ -8,6 +8,10 @@ class ProductSelect(RemoteSelect):
     # AjaxSelect(data_url=...) for overridability and backwards compatibility
     lookup_url = reverse_lazy('dashboard:catalogue-product-lookup')
 
+    def __init__(self, *args, **kwargs):
+        super(ProductSelect, self).__init__(*args, **kwargs)
+        self.attrs['class'] = 'select2 product-select'
+
 
 class ProductSelectMultiple(MultipleRemoteSelect):
     # Implemented as separate class instead of just calling

--- a/src/oscar/apps/dashboard/promotions/forms.py
+++ b/src/oscar/apps/dashboard/promotions/forms.py
@@ -37,10 +37,6 @@ class SingleProductForm(forms.ModelForm):
         fields = ['name', 'product', 'description']
         widgets = {'product': ProductSelect}
 
-    def __init__(self, *args, **kwargs):
-        super(SingleProductForm, self).__init__(*args, **kwargs)
-        self.fields['product'].widget.attrs['class'] = "select2 input-xlarge"
-
 
 class HandPickedProductListForm(forms.ModelForm):
     class Meta:
@@ -55,10 +51,6 @@ class OrderedProductForm(forms.ModelForm):
         widgets = {
             'product': ProductSelect,
         }
-
-    def __init__(self, *args, **kwargs):
-        super(OrderedProductForm, self).__init__(*args, **kwargs)
-        self.fields['product'].widget.attrs['class'] = "select2 input-xlarge"
 
 
 class PagePromotionForm(forms.ModelForm):

--- a/src/oscar/static/oscar/css/dashboard.css
+++ b/src/oscar/static/oscar/css/dashboard.css
@@ -3419,6 +3419,9 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 .navbar-form .control-group {
   margin-right: 10px;
 }
+.navbar-form .product-select {
+  width: 270px;
+}
 .navbar-form .help-block,
 .navbar-form .error-block {
   display: inline-block;
@@ -5659,6 +5662,9 @@ form.flat {
 }
 .form-inline .control-group {
   margin-right: 10px;
+}
+.form-inline .product-select {
+  width: 270px;
 }
 .create-page .form-horizontal input[type=text],
 .create-page .form-stacked input[type=text],

--- a/src/oscar/static/oscar/less/dashboard/forms.less
+++ b/src/oscar/static/oscar/less/dashboard/forms.less
@@ -48,6 +48,9 @@ form.flat {
   .control-group {
     margin-right: 10px;
   }
+  .product-select{
+    width: 270px;
+  }
 }
 
 .create-page {


### PR DESCRIPTION
Previously this was using bootstrap2's `input-xlarge` to set the widget's width, but this is no longer available in bootstrap3 and therefore the product select widget is too small.