### PR TITLE
Don't mask invalid URL names in dashboard nav access function.

### DIFF
--- a/docs/source/releases/v1.6.rst
+++ b/docs/source/releases/v1.6.rst
@@ -45,7 +45,7 @@ Backwards incompatible changes in Oscar 1.6
  - ``oscar.apps.offer.models.ConditionalOffer`` now has a new flag
    ``exclusive`` to denote that the offer involved can not be combined on the
    same item on the same basket line with another offer.
-   This flag is used by ``oscar.apps.basket.utils.LineOfferConsumer``, a facade 
+   This flag is used by ``oscar.apps.basket.utils.LineOfferConsumer``, a facade
    that supercedes the old ``oscar.apps.basket.models.Line._affected_items`` counter,
    and replaces it with a more finegrained approach. This makes it possible to apply
    two distinct non-exclusive offers on the same basketline items, for example
@@ -55,6 +55,10 @@ Backwards incompatible changes in Oscar 1.6
    are using a customized basketline model, you have to update your methods'
    signatures.
 
+ - Invalid URL names supplied to the ``OSCAR_DASHBOARD_NAVIGATION`` setting
+   are now logged as an exception (previously they were silently ignored).
+   The offending menu item will be skipped during menu rendering.
+   In Oscar 1.8 the exception will be raised without being intercepted.
 
 Dependency changes
 ------------------

--- a/tests/integration/dashboard/test_nav.py
+++ b/tests/integration/dashboard/test_nav.py
@@ -1,27 +1,35 @@
 from django.test import TestCase
+
 from oscar.apps.dashboard.menu import get_nodes
-from oscar.core.compat import get_user_model
+from oscar.apps.dashboard.nav import default_access_fn
+from oscar.test.factories import UserFactory
 
 
-User = get_user_model()
-
-
-class TestCategory(TestCase):
+class DashboardAccessFunctionTestCase(TestCase):
 
     def setUp(self):
-        self.staff_user = User.objects.create_user('staff', 'staff@example.com',
-                                                   'pw1')
-        self.staff_user.is_staff = True
-        self.staff_user.save()
-        self.non_staff_user = User.objects.create_user('nostaff',
-                                                       'nostaff@example.com',
-                                                       'pw2')
-        self.non_staff_user.save()
+        self.staff_user = UserFactory(is_staff=True)
+        self.non_staff_user = UserFactory()
+
+    def test_default_access_fn_no_url_name(self):
+        self.assertTrue(default_access_fn(self.staff_user, None))
+
+    def test_default_access_fn_staff(self):
+        self.assertTrue(default_access_fn(self.staff_user, 'dashboard:index'))
+
+    def test_default_access_fn_non_staff_user(self):
+        self.assertFalse(default_access_fn(self.non_staff_user, 'dashboard:index'))
+
+    def test_default_access_fn_invalid_url_name(self):
+        self.assertFalse(default_access_fn(self.staff_user, 'invalid_module:index'))
+
+
+class DashboardNavTestCase(TestCase):
 
     def test_staff_user_has_menu(self):
-        menu = get_nodes(self.staff_user)
+        menu = get_nodes(UserFactory(is_staff=True))
         self.assertTrue(menu)
 
     def test_non_staff_user_has_empty_menu(self):
-        menu = get_nodes(self.non_staff_user)
+        menu = get_nodes(UserFactory())
         self.assertEqual(menu, [])


### PR DESCRIPTION
If a `url_name` is invalid, then we should allow the exception to propagate instead of silently discarding that menu item. Currently the exception is silently discarded which makes it very difficult to debug an invalid configuration of `OSCAR_DASHBOARD_NAVIGATION`.