### PR TITLE
Add Django master to travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: python
 
 matrix:
+  fast_finish: true
   include:
     - python: 2.7
       env: TOXENV=py27-django18
@@ -25,11 +26,15 @@ matrix:
       env: TOXENV=py35-django111
     - python: 3.6
       env: TOXENV=py36-django111
+    - python: 3.6
+      env: TOXENV=py36-djangomaster
 
     - python: 3.5
       env: TOXENV=lint
     - python: 3.5
       env: TOXENV=sandbox
+  allow_failures:
+    - env: TOXENV=py36-djangomaster
 
 
 env:

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ test_requires = [
     'coverage==4.4.1',
     'django-webtest==1.9.2',
     'py>=1.4.31',
+    'psycopg2==2.7.3.1',
     'pytest==3.2.1',
     'pytest-cov==2.5.1',
     'pytest-django==3.1.2',

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,29 @@
 [tox]
-envlist = py{27,33,34,35}-django18,py{27,34,35}-django110,py{27,34,35,36}-django111,lint,sandbox
+envlist =
+    py{27,33,34,35}-django18
+    py{27,34,35}-django110
+    py{27,34,35,36}-django111
+    py36-djangomaster
+    lint
+    sandbox
+
 
 [testenv]
 commands = coverage run --parallel -m pytest {posargs}
 extras = test
 pip_pre = true
 deps =
-    -r{toxinidir}/requirements.txt
     django18: django>=1.8,<1.9
     django110: django>=1.10,<1.11
     django111: django>=1.11,<1.12
+
+
+[testenv:py36-djangomaster]
+commands =
+    # Can't specify this in deps - see https://github.com/tox-dev/tox/issues/513
+    pip install https://github.com/django/django/archive/master.tar.gz#egg=django
+    pytest {posargs}
+
 
 [testenv:coverage-report]
 basepython = python3.5


### PR DESCRIPTION
This is to help identify issues that will arise in the next release of Django. Test failure is allowed.