### PR TITLE
Fix site notifications generated by send_product_alerts.

### DIFF
--- a/src/oscar/apps/customer/alerts/utils.py
+++ b/src/oscar/apps/customer/alerts/utils.py
@@ -148,8 +148,13 @@ def send_product_alerts(product):   # noqa C901 too complex
         if alert.user:
             # Send a site notification
             num_notifications += 1
+            subj_tpl = loader.get_template('customer/alerts/message_subject.html')
             message_tpl = loader.get_template('customer/alerts/message.html')
-            services.notify_user(alert.user, message_tpl.render(ctx))
+            services.notify_user(
+                alert.user,
+                subj_tpl.render(ctx).strip(),
+                body=message_tpl.render(ctx).strip()
+            )
 
         # Build message and add to list
         if use_deprecated_templates:

--- a/src/oscar/apps/customer/notifications/services.py
+++ b/src/oscar/apps/customer/notifications/services.py
@@ -3,16 +3,16 @@ from oscar.core.loading import get_model
 Notification = get_model('customer', 'Notification')
 
 
-def notify_user(user, msg, **kwargs):
+def notify_user(user, subject, **kwargs):
     """
     Send a simple notification to a user
     """
-    Notification.objects.create(recipient=user, subject=msg, **kwargs)
+    Notification.objects.create(recipient=user, subject=subject, **kwargs)
 
 
-def notify_users(users, msg, **kwargs):
+def notify_users(users, subject, **kwargs):
     """
     Send a simple notification to an iterable of users
     """
     for user in users:
-        notify_user(user, msg, **kwargs)
+        notify_user(user, subject, **kwargs)

--- a/src/oscar/templates/oscar/customer/alerts/message_subject.html
+++ b/src/oscar/templates/oscar/customer/alerts/message_subject.html
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% blocktrans with title=alert.product.get_title|truncatechars:200 %}
+{{ title }} is back in stock
+{% endblocktrans %}

--- a/tests/integration/customer/test_notification.py
+++ b/tests/integration/customer/test_notification.py
@@ -34,17 +34,25 @@ class TestANotification(TestCase):
         self.assertEqual(Notification.ARCHIVE, self.notification.location)
 
 
-class TestAServiceExistsTo(TestCase):
+class NotificationServiceTestCase(TestCase):
 
     def test_notify_a_single_user(self):
         user = UserFactory()
-        services.notify_user(user, "Hello you!")
-        self.assertEqual(1, Notification.objects.filter(
-            recipient=user).count())
+        subj = "Hello you!"
+        body = "This is the notification body."
+
+        services.notify_user(user, subj, body=body)
+        user_notification = Notification.objects.get(recipient=user)
+        self.assertEqual(user_notification.subject, subj)
+        self.assertEqual(user_notification.body, body)
 
     def test_notify_a_set_of_users(self):
-        users = [UserFactory() for i in range(3)]
-        services.notify_users(User.objects.all(), "Hello everybody!")
+        users = UserFactory.create_batch(3)
+        subj = "Hello everyone!"
+        body = "This is the notification body."
+
+        services.notify_users(User.objects.all(), subj, body=body)
         for user in users:
-            self.assertEqual(1, Notification.objects.filter(
-                recipient=user).count())
+            user_notification = Notification.objects.get(recipient=user)
+            self.assertEqual(user_notification.subject, subj)
+            self.assertEqual(user_notification.body, body)


### PR DESCRIPTION
Notification subjects have a max length of 255 characters, which can easily be exceeded by long product names. Change the alert logic to provide a short notification subject and put the longer content in the notification body.

This patch also modifies the notification utils to make it obvious that the positional argument is a notification subject, not a body.