### PR TITLE
Improve image modal rendering in dashboard product list view

### DIFF
--- a/src/oscar/static/oscar/js/oscar/dashboard.js
+++ b/src/oscar/static/oscar/js/oscar/dashboard.js
@@ -363,7 +363,20 @@ var oscar = (function(o, $) {
                     });
                 }
             }
-        }
+        },
+        product_lists: {
+            init: function() {
+                var imageModal = $("#product-image-modal")
+                    thumbnails = $('.sub-image');
+                thumbnails.click(function(e){
+                    e.preventDefault();
+                    var a = $(this);
+                    imageModal.find('h4').text(a.find('img').attr('alt'));
+                    imageModal.find('img').attr('src', a.data('original'));
+                    imageModal.modal();
+                });
+            }
+        },
     };
 
     return o;

--- a/src/oscar/templates/oscar/dashboard/catalogue/product_list.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/product_list.html
@@ -67,9 +67,27 @@
                 {% csrf_token %}
                 {% render_table products %}
             </form>
+            <div class="modal fade" id="product-image-modal" tabindex="-1" role="dialog">
+                <div class="modal-dialog" role="document">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                            <h4 class="modal-title"></h4>
+                        </div>
+                        <div class="modal-body text-center">
+                            <img class="img-responsive center-block">
+                        </div>
+                    </div>
+                </div>
+            </div>
         {% endblock product_list %}
     {% else %}
         <p>{% trans "No products found." %}</p>
     {% endif %}
 
 {% endblock dashboard_content %}
+
+{% block onbodyload %}
+    {{ block.super }}
+    oscar.dashboard.product_lists.init();
+{% endblock onbodyload %}

--- a/src/oscar/templates/oscar/dashboard/catalogue/product_row_image.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/product_row_image.html
@@ -2,24 +2,10 @@
 {% if record.primary_image.original.url %}
     {% with image=record.primary_image %}
         {% thumbnail image.original "70x70" upscale=False as thumb %}
-        <a href="#" data-toggle="modal" data-target="#modal-{{ record.upc|default:"-" }}" class="sub-image">
-            <img src="{{ thumb.url }}" alt="{{ record.get_title }}" height="{{ thumb.height }}" width="{{ thumb.width }}">
+        <a href="#" data-original="{{ image.original.url }}" class="sub-image">
+            <img src="{{ thumb.url }}" alt="{% if image.caption %}{{ image.caption }}{% else %}{{ record.get_title }}{% endif %}" height="{{ thumb.height }}" width="{{ thumb.width }}">
         </a>
         {% endthumbnail %}
-
-        <div class="modal fade" id="modal-{{ record.upc|default:"-" }}" tabindex="-1" role="dialog">
-          <div class="modal-dialog" role="document">
-            <div class="modal-content">
-              <div class="modal-header">
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                <h4 class="modal-title">{% if image.caption %}{{ image.caption }}{% else %}{{ record.get_title }}{% endif %}</h4>
-              </div>
-              <div class="modal-body text-center">
-                <img src="{{ image.original.url }}" class="img-responsive" style="display: inline-block;">
-              </div>
-            </div>
-          </div>
-        </div>
     {% endwith %}
 {% else %}
     —


### PR DESCRIPTION
See #2468.
 
- Ensure that modals work for products regardless of whether they have an UPC.
- Use Javascript to manipulate a single modal object instead of rendering one for each product.