### PR TITLE
Fix order of namespace arguments in Application.urls

### DIFF
--- a/src/oscar/core/application.py
+++ b/src/oscar/core/application.py
@@ -12,7 +12,7 @@ class Application(object):
     This is subclassed by each app to provide a customisable container for an
     app's views and permissions.
     """
-    #: Namespace name
+    #: Application namespace name
     name = None
 
     login_url = None
@@ -32,7 +32,11 @@ class Application(object):
     default_permissions = None
 
     def __init__(self, app_name=None, **kwargs):
-        self.app_name = app_name
+        """
+        kwargs:
+            app_name: optionally specify the instance namespace
+        """
+        self.app_name = app_name or self.name
         # Set all kwargs as object attributes
         for key, value in kwargs.items():
             setattr(self, key, value)
@@ -126,7 +130,7 @@ class Application(object):
     @property
     def urls(self):
         # We set the application and instance namespace here
-        return self.get_urls(), self.app_name, self.name
+        return self.get_urls(), self.name, self.app_name
 
 
 class DashboardApplication(Application):

--- a/src/oscar/core/application.py
+++ b/src/oscar/core/application.py
@@ -12,7 +12,7 @@ class Application(object):
     This is subclassed by each app to provide a customisable container for an
     app's views and permissions.
     """
-    #: Application namespace name
+    #: Application name
     name = None
 
     login_url = None


### PR DESCRIPTION
Here the name `Application.name` is the name of the application, where as the `app_name` kwarg is specifying an optional instance namespace. Unsurprisingly given the confusing naming the order returned by `Application.urls` was wrong... it should be application name followed by instance namespace. See: https://docs.djangoproject.com/en/1.11/_modules/django/conf/urls/#url

It would probably be worth dropping this approach of passing a 3-tuple to `url` in the long run as this is undocumented behaviour... and renaming the `app_name` kwarg whilst doing so... but that is a PR for another day.