### PR TITLE
Enforce user_can_authenticate check before authenticating users in EmailBackend

### DIFF
--- a/docs/source/releases/v1.6.rst
+++ b/docs/source/releases/v1.6.rst
@@ -42,6 +42,9 @@ Minor changes
 Backwards incompatible changes in Oscar 1.6
 -------------------------------------------
 
+ - ``oscar.apps.customer.auth_backends.EmailBackend`` now rejects inactive users
+   (where ``User.is_active`` is ``False``).
+
  - ``oscar.apps.offer.models.ConditionalOffer`` now has a new flag
    ``exclusive`` to denote that the offer involved can not be combined on the
    same item on the same basket line with another offer.

--- a/src/oscar/apps/customer/auth_backends.py
+++ b/src/oscar/apps/customer/auth_backends.py
@@ -41,7 +41,7 @@ class EmailBackend(ModelBackend):
         # We make a case-insensitive match when looking for emails.
         matching_users = User.objects.filter(email__iexact=clean_email)
         authenticated_users = [
-            user for user in matching_users if user.check_password(password)]
+            user for user in matching_users if (user.check_password(password) and self.user_can_authenticate(user))]
         if len(authenticated_users) == 1:
             # Happy path
             return authenticated_users[0]
@@ -62,3 +62,9 @@ class EmailBackend(ModelBackend):
     else:
         def authenticate(self, *args, **kwargs):
             return self._authenticate(*args, **kwargs)
+
+    if django.VERSION < (1, 10):
+        def user_can_authenticate(self, user):
+            # user_can_authenticate was introduced in Django 1.10. Prior to that
+            # inactive users could log in. That behaviour is retained for Django < 1.10.
+            return True

--- a/tests/integration/customer/test_auth_backend.py
+++ b/tests/integration/customer/test_auth_backend.py
@@ -24,3 +24,10 @@ class AuthBackendTestCase(TestCase):
     def test_authentication_method_signature_post_django_1_11(self):
         auth_result = self.backend.authenticate(None, 'foo@example.com', 'letmein')
         self.assertEqual(auth_result, self.user)
+
+    def test_inactive_users_cannot_authenticate(self):
+        self.user.is_active = False
+        self.user.save()
+
+        auth_result = self.backend.authenticate(None, 'foo@example.com', 'letmein')
+        self.assertIsNone(auth_result)


### PR DESCRIPTION
The `EmailBackend` that we currently ship will let inactive users (`is_active=False`) log in, which is not at all the behaviour that you would expect. 

Django's `ModelBackend` provides a `can_authenticate_user` method that we should be using to filter active users. If the user model has no `is_active` field then this has no effect.