### PR TITLE
Make ConditionalOffer.priority editable from dashboard. Fixes #2494.

### DIFF
--- a/src/oscar/apps/dashboard/offers/forms.py
+++ b/src/oscar/apps/dashboard/offers/forms.py
@@ -37,7 +37,7 @@ class RestrictionsForm(forms.ModelForm):
         fields = ('start_datetime', 'end_datetime',
                   'max_basket_applications', 'max_user_applications',
                   'max_global_applications', 'max_discount',
-                  'exclusive')
+                  'priority', 'exclusive')
 
     def clean(self):
         cleaned_data = super(RestrictionsForm, self).clean()

--- a/src/oscar/templates/oscar/dashboard/offers/offer_list.html
+++ b/src/oscar/templates/oscar/dashboard/offers/offer_list.html
@@ -46,6 +46,7 @@
                     <th>{% anchor 'name' _('Offer name') %}</th>
                     <th>{% anchor 'start_date' _('Start date') %}</th>
                     <th>{% anchor 'end_date' _('End date') %}</th>
+                    <th>{% trans "Priority" %}</th>
                     <th>{% trans "Incentive" %}</th>
                     <th>{% trans "Condition" %}</th>
                     <th>{% trans "Is available?" %}</th>
@@ -59,6 +60,7 @@
                         <td><a href="{% url 'dashboard:offer-detail' pk=offer.pk %}">{{ offer.name }}</a></td>
                         <td>{{ offer.start_date|default:"-" }}</td>
                         <td>{{ offer.end_date|default:"-" }}</td>
+                        <td>{{ offer.priority }}</td>
                         <td>{{ offer.benefit.description|safe }}</td>
                         <td>{{ offer.condition.description|safe }}</td>
                         <td>{% if offer.is_available %}

--- a/tests/functional/dashboard/test_offer.py
+++ b/tests/functional/dashboard/test_offer.py
@@ -121,8 +121,8 @@ class TestAnAdmin(testcases.WebTestCase):
         form = detail_page.forms['status_form']
         form.submit('suspend')
 
-        reloaded_offer = models.ConditionalOffer.objects.get(pk=offer.pk)
-        self.assertTrue(reloaded_offer.is_suspended)
+        offer.refresh_from_db()
+        self.assertTrue(offer.is_suspended)
 
     def test_can_reinstate_a_suspended_offer(self):
         # Create a suspended offer
@@ -135,5 +135,14 @@ class TestAnAdmin(testcases.WebTestCase):
         form = detail_page.forms['status_form']
         form.submit('unsuspend')
 
-        reloaded_offer = models.ConditionalOffer.objects.get(pk=offer.pk)
-        self.assertFalse(reloaded_offer.is_suspended)
+        offer.refresh_from_db()
+        self.assertFalse(offer.is_suspended)
+
+    def test_can_change_offer_priority(self):
+        offer = factories.create_offer()
+        restrictions_page = self.get(reverse('dashboard:offer-restrictions', kwargs={'pk': offer.pk}))
+        restrictions_page.form['priority'] = '12'
+        restrictions_page.form.submit()
+        offer.refresh_from_db()
+
+        self.assertEqual(offer.priority, 12)


### PR DESCRIPTION
The priority isn't strictly a "restriction", but this seems like the most sensible form to add it to.

This also adds the priority to the list view - important to let you see the order in which offers will be applied.