### PR TITLE
Add ability to add many phone number fields

### DIFF
--- a/src/oscar/apps/address/forms.py
+++ b/src/oscar/apps/address/forms.py
@@ -2,7 +2,7 @@ from django import forms
 from django.conf import settings
 
 from oscar.core.loading import get_model
-from oscar.views.generic import PhoneNumberMixin
+from oscar.forms.mixins import PhoneNumberMixin
 
 UserAddress = get_model('address', 'useraddress')
 

--- a/src/oscar/apps/checkout/forms.py
+++ b/src/oscar/apps/checkout/forms.py
@@ -6,7 +6,7 @@ from oscar.apps.address.forms import AbstractAddressForm
 from oscar.apps.customer.utils import normalise_email
 from oscar.core.compat import get_user_model
 from oscar.core.loading import get_model
-from oscar.views.generic import PhoneNumberMixin
+from oscar.forms.mixins import PhoneNumberMixin
 
 User = get_user_model()
 Country = get_model('address', 'Country')

--- a/src/oscar/apps/dashboard/orders/forms.py
+++ b/src/oscar/apps/dashboard/orders/forms.py
@@ -7,8 +7,8 @@ from django.utils.translation import pgettext_lazy
 
 from oscar.apps.address.forms import AbstractAddressForm
 from oscar.core.loading import get_model
+from oscar.forms.mixins import PhoneNumberMixin
 from oscar.forms.widgets import DatePickerInput
-from oscar.views.generic import PhoneNumberMixin
 
 Order = get_model('order', 'Order')
 OrderNote = get_model('order', 'OrderNote')

--- a/src/oscar/apps/payment/forms.py
+++ b/src/oscar/apps/payment/forms.py
@@ -8,7 +8,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from oscar.apps.address.forms import AbstractAddressForm
 from oscar.core.loading import get_model
-from oscar.views.generic import PhoneNumberMixin
+from oscar.forms.mixins import PhoneNumberMixin
 
 from . import bankcards
 

--- a/src/oscar/forms/mixins.py
+++ b/src/oscar/forms/mixins.py
@@ -1,0 +1,107 @@
+import phonenumbers
+from django import forms
+from django.core import validators
+from django.utils.translation import ugettext_lazy as _
+from phonenumber_field.phonenumber import PhoneNumber
+
+
+class PhoneNumberMixin(object):
+    """Validation mixin for forms with a phone numbers, and optionally a country.
+
+    It tries to validate the phone numbers, and on failure tries to validate
+    them using a hint (the country provided), and treating it as a local number.
+
+    """
+    country = None
+    region_code = None
+    # Since this mixin will be used with `ModelForms`, names of phone numbers
+    # fields should match names of related Model's fields
+    phone_numbers_fields = {
+        'phone_number': {
+            'required': False,
+            'help_text': '',
+            'max_length': 32,
+            'label': _('Phone number')
+        },
+    }
+
+    def __init__(self, *args, **kwargs):
+        super(PhoneNumberMixin, self).__init__(*args, **kwargs)
+
+        # We can't use the PhoneNumberField here since we want validate the
+        # phonenumber based on the selected country as a fallback when a local
+        # number is entered. We add the fields in the init since on Python 2
+        # using forms.Form as base class results in errors when using this
+        # class as mixin.
+
+        # If the model field already exists, copy existing properties from it
+        for field_name, field_kwargs in self.phone_numbers_fields.items():
+            for key in field_kwargs:
+                try:
+                    field_kwargs[key] = getattr(self.fields[field_name], key)
+                except (KeyError, AttributeError):
+                    pass
+
+            self.fields[field_name] = forms.CharField(**field_kwargs)
+
+    def get_country(self):
+        # If the form data contains valid country information, we use that.
+        if hasattr(self, 'cleaned_data') and 'country' in self.cleaned_data:
+            return self.cleaned_data['country']
+        # Oscar hides the field if there's only one country. Then (and only
+        # then!) we can consider a country on the model instance.
+        elif 'country' not in self.fields and hasattr(self.instance, 'country'):
+            return self.instance.country
+
+    def set_country_and_region_code(self):
+        # Try hinting with the shipping country if we can determine one.
+        self.country = self.get_country()
+        if self.country:
+            self.region_code = self.country.iso_3166_1_a2
+
+    def clean_phone_number_field(self, field_name):
+        number = self.cleaned_data[field_name]
+
+        # Empty
+        if number in validators.EMPTY_VALUES:
+            return ''
+
+        # Check for an international phone format
+        try:
+            phone_number = PhoneNumber.from_string(number)
+        except phonenumbers.NumberParseException:
+
+            if not self.region_code:
+                # There is no shipping country, not a valid international number
+                self.add_error(
+                    field_name,
+                    _(u'This is not a valid international phone format.'))
+                return number
+
+            # The PhoneNumber class does not allow specifying
+            # the region. So we drop down to the underlying phonenumbers
+            # library, which luckily allows parsing into a PhoneNumber
+            # instance.
+            try:
+                phone_number = PhoneNumber.from_string(number,
+                                                       region=self.region_code)
+                if not phone_number.is_valid():
+                    self.add_error(
+                        field_name,
+                        _(u'This is not a valid local phone format for %s.')
+                        % self.country)
+            except phonenumbers.NumberParseException:
+                # Not a valid local or international phone number
+                self.add_error(
+                    field_name,
+                    _(u'This is not a valid local or international phone format.'))
+                return number
+
+        return phone_number
+
+    def clean(self):
+        self.set_country_and_region_code()
+        cleaned_data = super(PhoneNumberMixin, self).clean()
+        for field_name in self.phone_numbers_fields:
+            cleaned_data[field_name] = self.clean_phone_number_field(field_name)
+        return cleaned_data

--- a/src/oscar/views/generic.py
+++ b/src/oscar/views/generic.py
@@ -1,10 +1,6 @@
 import json
 
-import phonenumbers
-from django import forms
 from django.contrib import messages
-from django.core import validators
-from django.core.exceptions import ValidationError
 from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.utils import six
@@ -12,7 +8,6 @@ from django.utils.encoding import smart_str
 from django.utils.six.moves import map
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic.base import View
-from phonenumber_field.phonenumber import PhoneNumber
 
 from oscar.core.utils import safe_referrer
 
@@ -145,87 +140,3 @@ class ObjectLookupView(View):
             'results': [self.format_object(obj) for obj in qs],
             'more': more,
         }), content_type='application/json')
-
-
-class PhoneNumberMixin(object):
-    """Validation mixin for forms with a phone number, and optionally a country.
-
-    It tries to validate the phone number, and on failure tries to validate it
-    using a hint (the country provided), and treating it as a local number.
-
-    """
-
-    def __init__(self, *args, **kwargs):
-        super(PhoneNumberMixin, self).__init__(*args, **kwargs)
-
-        # We can't use the PhoneNumberField here since we want validate the
-        # phonenumber based on the selected country as a fallback when a local
-        # number is entered. We add the field in the init since on Python 2
-        # using forms.Form as base class results in errors when using this
-        # class as mixin.
-        field_kwargs = {
-            'required': False,
-            'help_text': '',
-            'max_length': 32,
-            'label': _('Phone number'),
-        }
-
-        # If the model field already exists, copy existing properties from it
-        for key in field_kwargs:
-            try:
-                field_kwargs[key] = getattr(self.fields['phone_number'], key)
-            except (KeyError, AttributeError):
-                pass
-
-        self.fields['phone_number'] = forms.CharField(**field_kwargs)
-
-    def get_country(self):
-        # If the form data contains valid country information, we use that.
-        if hasattr(self, 'cleaned_data') and 'country' in self.cleaned_data:
-            return self.cleaned_data['country']
-        # Oscar hides the field if there's only one country. Then (and only
-        # then!) can we consider a country on the model instance.
-        elif 'country' not in self.fields and hasattr(self.instance, 'country'):
-            return self.instance.country
-
-    def get_region_code(self, country):
-        return country.iso_3166_1_a2
-
-    def clean_phone_number(self):
-        number = self.cleaned_data['phone_number']
-
-        # empty
-        if number in validators.EMPTY_VALUES:
-            return ''
-
-        # Check for an international phone format
-        try:
-            phone_number = PhoneNumber.from_string(number)
-        except phonenumbers.NumberParseException:
-            # Try hinting with the shipping country if we can determine one
-            country = self.get_country()
-            region_code = self.get_region_code(country) if country else None
-
-            if not region_code:
-                # There is no shipping country, not a valid international
-                # number
-                raise ValidationError(
-                    _(u'This is not a valid international phone format.'))
-
-            # The PhoneNumber class does not allow specifying
-            # the region. So we drop down to the underlying phonenumbers
-            # library, which luckily allows parsing into a PhoneNumber
-            # instance
-            try:
-                phone_number = PhoneNumber.from_string(number, region=region_code)
-                if not phone_number.is_valid():
-                    raise ValidationError(
-                        _(u'This is not a valid local phone format for %s.')
-                        % country)
-            except phonenumbers.NumberParseException:
-                # Not a valid local or international phone number
-                raise ValidationError(
-                    _(u'This is not a valid local or international phone'
-                      u' format.'))
-
-        return phone_number

--- a/tests/integration/core/test_mixins.py
+++ b/tests/integration/core/test_mixins.py
@@ -2,7 +2,7 @@ from django import forms
 from django.test import TestCase
 
 from oscar.apps.address.models import UserAddress
-from oscar.views.generic import PhoneNumberMixin
+from oscar.forms.mixins import PhoneNumberMixin
 
 
 class PhoneNumberMixinTestCase(TestCase):
@@ -15,6 +15,38 @@ class PhoneNumberMixinTestCase(TestCase):
         form = TestForm()
         self.assertIn('phone_number', form.fields)
 
+    def test_mixin_adds_all_phone_number_fields(self):
+
+        class TestForm(PhoneNumberMixin, forms.Form):
+            phone_numbers_fields = {
+                'phone_number': {
+                    'required': False,
+                    'help_text': '',
+                    'max_length': 32,
+                    'label': 'Phone number'
+                },
+                'another_phone_number': {
+                    'required': False,
+                    'help_text': 'Another phone number help text',
+                    'max_length': 32,
+                    'label': 'Another phone number'
+                },
+                'one_more_phone_number': {
+                    'required': False,
+                    'help_text': '',
+                    'max_length': 32,
+                    'label': 'One more phone number'
+                },
+            }
+
+        form = TestForm()
+        self.assertIn('phone_number', form.fields)
+        self.assertIn('another_phone_number', form.fields)
+        self.assertIn('one_more_phone_number', form.fields)
+
+        field = form.fields['another_phone_number']
+        self.assertEqual(field.help_text, 'Another phone number help text')
+
     def test_mixin_retains_existing_field_properties(self):
 
         class TestForm(PhoneNumberMixin, forms.ModelForm):
@@ -23,10 +55,10 @@ class PhoneNumberMixinTestCase(TestCase):
                 model = UserAddress
                 fields = ['country', 'phone_number']
                 # Override default label and help text
-                labels = {"phone_number": "Special number"}
-                help_texts = {"phone_number": "Special help text"}
+                labels = {'phone_number': 'Special number'}
+                help_texts = {'phone_number': 'Special help text'}
 
         form = TestForm()
         field = form.fields['phone_number']
-        self.assertEqual(field.label, "Special number")
-        self.assertEqual(field.help_text, "Special help text")
+        self.assertEqual(field.label, 'Special number')
+        self.assertEqual(field.help_text, 'Special help text')

--- a/tests/unit/checkout/test_checkout_session_data.py
+++ b/tests/unit/checkout/test_checkout_session_data.py
@@ -32,7 +32,6 @@ def get_address_fields():
 
     form = ShippingAddressForm(data)
     form.is_valid()
-    form.clean()
     address_fields = dict(
         (k, v) for (k, v) in form.instance.__dict__.items()
         if not k.startswith('_'))


### PR DESCRIPTION
With this change phone numbers (any qty) can be added as `ModelForm`
property `phone_numbers_fields` - dict where "keys" are names of
phone numbers fields and "values" are attributes of fields.

* `PhoneNumberMixin` slightly reworked and moved from `oscar.views.generic` to `oscar.forms.mixins`
* Couple tests added (based on previous tests)

Refs #1500