### PR TITLE
Rename PhoneNumberMixin.phone_numbers_fields to phone_number_fields and add to docs.

### DIFF
--- a/docs/source/ref/core.rst
+++ b/docs/source/ref/core.rst
@@ -15,7 +15,7 @@ core functionality.
 .. automodule:: oscar.core.loading
     :members: get_classes, get_class
 
-URL patterns and views 
+URL patterns and views
 ----------------------
 
 Oscar's app organise their URLs and associated views using a "Application"
@@ -28,7 +28,7 @@ Oscar projects to subclass and customised URLs and views.
 Prices
 ------
 
-Oscar uses a custom price object for easier tax handling.  
+Oscar uses a custom price object for easier tax handling.
 
 .. automodule:: oscar.core.prices
     :members: Price
@@ -39,4 +39,11 @@ Custom model fields
 Oscar uses a few custom model fields.
 
 .. automodule:: oscar.models.fields
-    :members: 
+    :members:
+
+
+Form helpers
+------------
+
+.. automodule:: oscar.forms.mixins
+    :members:

--- a/src/oscar/forms/mixins.py
+++ b/src/oscar/forms/mixins.py
@@ -11,12 +11,15 @@ class PhoneNumberMixin(object):
     It tries to validate the phone numbers, and on failure tries to validate
     them using a hint (the country provided), and treating it as a local number.
 
+    Specify which fields to treat as phone numbers by specifying them in
+    `phone_number_fields`, a dictionary of fields names and default kwargs
+    for instantiation of the field.
     """
     country = None
     region_code = None
-    # Since this mixin will be used with `ModelForms`, names of phone numbers
-    # fields should match names of related Model's fields
-    phone_numbers_fields = {
+    # Since this mixin will be used with `ModelForms`, names of phone number
+    # fields should match names of the related Model field
+    phone_number_fields = {
         'phone_number': {
             'required': False,
             'help_text': '',
@@ -35,7 +38,7 @@ class PhoneNumberMixin(object):
         # class as mixin.
 
         # If the model field already exists, copy existing properties from it
-        for field_name, field_kwargs in self.phone_numbers_fields.items():
+        for field_name, field_kwargs in self.phone_number_fields.items():
             for key in field_kwargs:
                 try:
                     field_kwargs[key] = getattr(self.fields[field_name], key)
@@ -102,6 +105,6 @@ class PhoneNumberMixin(object):
     def clean(self):
         self.set_country_and_region_code()
         cleaned_data = super(PhoneNumberMixin, self).clean()
-        for field_name in self.phone_numbers_fields:
+        for field_name in self.phone_number_fields:
             cleaned_data[field_name] = self.clean_phone_number_field(field_name)
         return cleaned_data

--- a/tests/integration/checkout/test_forms.py
+++ b/tests/integration/checkout/test_forms.py
@@ -8,7 +8,7 @@ from oscar.test.factories import CountryFactory
 
 
 class AnotherShippingAddressForm(ShippingAddressForm):
-    phone_numbers_fields = {
+    phone_number_fields = {
         'phone_number': {
             'required': False,
             'help_text': '',

--- a/tests/integration/core/test_mixins.py
+++ b/tests/integration/core/test_mixins.py
@@ -18,7 +18,7 @@ class PhoneNumberMixinTestCase(TestCase):
     def test_mixin_adds_all_phone_number_fields(self):
 
         class TestForm(PhoneNumberMixin, forms.Form):
-            phone_numbers_fields = {
+            phone_number_fields = {
                 'phone_number': {
                     'required': False,
                     'help_text': '',


### PR DESCRIPTION
`phone_number_fields` is more correct grammatically. Also added to the dosctring for the class, and display it in the documentation, to explain how to use this feature.

This was added only recently, and hasn't been released, so it's safe to rename.