### PR TITLE
Allow `SearchHandler.get_search_form` accept keyword argument for the form class.

### DIFF
--- a/docs/source/releases/v1.6.rst
+++ b/docs/source/releases/v1.6.rst
@@ -41,6 +41,9 @@ Minor changes
    signals.
  - Customer transaction emails reworked on top of mailgun layout and has
    better look.
+ - ``SearchHandler.get_search_form`` method now accepts additional
+   keyword arguments, which will be passed on search form class instance
+   initiation.
 
 .. _incompatible_in_1.6:
 

--- a/src/oscar/apps/search/search_handlers.py
+++ b/src/oscar/apps/search/search_handlers.py
@@ -63,7 +63,7 @@ class SearchHandler(object):
         """
         return search_form.search()
 
-    def get_search_form(self, request_data, search_queryset):
+    def get_search_form(self, request_data, search_queryset, **form_kwargs):
         """
         Return a bound version of Haystack's search form.
         """
@@ -72,6 +72,7 @@ class SearchHandler(object):
             'selected_facets': request_data.getlist("selected_facets"),
             'searchqueryset': search_queryset
         }
+        kwargs.update(**form_kwargs)
         return self.form_class(**kwargs)
 
     def get_search_queryset(self):


### PR DESCRIPTION
Fixed #1619 