### PR TITLE
Deprecate `StockRecord.price_excl_tax` field name.

### DIFF
--- a/docs/source/releases/v1.6.rst
+++ b/docs/source/releases/v1.6.rst
@@ -75,3 +75,14 @@ Backwards incompatible changes in Oscar 1.6
 
 Dependency changes
 ------------------
+
+
+.. _deprecated_features_in_1.6:
+
+Deprecated features
+~~~~~~~~~~~~~~~~~~~
+
+The following features have been deprecated in this release:
+
+* ``StockRecord.price_excl_tax`` will be renamed into ``StockRecord.price`` in
+  Oscar 2.0. Please see :issue:`1962` for more details.

--- a/src/oscar/apps/partner/abstract_models.py
+++ b/src/oscar/apps/partner/abstract_models.py
@@ -115,7 +115,8 @@ class AbstractStockRecord(models.Model):
     # appropriate method.  We don't store tax here as its calculation is highly
     # domain-specific.  It is NULLable because some items don't have a fixed
     # price but require a runtime calculation (possible from an external
-    # service).
+    # service). Current field name `price_excl_tax` is deprecated and will be
+    # renamed into `price` in Oscar 2.0.
     price_excl_tax = models.DecimalField(
         _("Price (excl. tax)"), decimal_places=2, max_digits=12,
         blank=True, null=True)


### PR DESCRIPTION
Refs #1962