### PR TITLE
Remove OSCAR_PROMOTION_MERCHANDISING_BLOCK_TYPES setting.

### DIFF
--- a/docs/source/releases/v1.6.rst
+++ b/docs/source/releases/v1.6.rst
@@ -32,7 +32,8 @@ What's new in Oscar 1.6?
 
 Removal of deprecated features
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
+ - Removed ``OSCAR_PROMOTION_MERCHANDISING_BLOCK_TYPES`` setting since
+   merchandising block promotions, which used it, already removed for a while.
 
 Minor changes
 ~~~~~~~~~~~~~

--- a/src/oscar/defaults.py
+++ b/src/oscar/defaults.py
@@ -52,14 +52,6 @@ OSCAR_DASHBOARD_ITEMS_PER_PAGE = 20
 OSCAR_ALLOW_ANON_CHECKOUT = False
 
 # Promotions
-COUNTDOWN, LIST, SINGLE_PRODUCT, TABBED_BLOCK = (
-    'Countdown', 'List', 'SingleProduct', 'TabbedBlock')
-OSCAR_PROMOTION_MERCHANDISING_BLOCK_TYPES = (
-    (COUNTDOWN, "Vertical list"),
-    (LIST, "Horizontal list"),
-    (TABBED_BLOCK, "Tabbed block"),
-    (SINGLE_PRODUCT, "Single product"),
-)
 OSCAR_PROMOTION_POSITIONS = (('page', 'Page'),
                              ('right', 'Right-hand sidebar'),
                              ('left', 'Left-hand sidebar'))


### PR DESCRIPTION
Merchandising blocks were removed in 4a1bd3aecb3fc34c74457a5ab56abf02bf8ee690, although the setting still remain.