### PR TITLE
Added hook to allow implementations of strategies that depend on productoptions

### DIFF
--- a/docs/source/releases/v1.6.rst
+++ b/docs/source/releases/v1.6.rst
@@ -44,6 +44,8 @@ Minor changes
  - ``SearchHandler.get_search_form`` method now accepts additional
    keyword arguments, which will be passed on search form class instance
    initiation.
+ - Added ``get_stock_info`` hook to ``oscar.apps.basket.models.Basket``  for
+   implementing strategies that depend on product options.
 
 .. _incompatible_in_1.6:
 

--- a/src/oscar/apps/basket/abstract_models.py
+++ b/src/oscar/apps/basket/abstract_models.py
@@ -165,6 +165,10 @@ class AbstractBasket(models.Model):
         self.lines.all().delete()
         self._lines = None
 
+    def get_stock_info(self, product, options):
+        "Hook for implementing strategies that depend on product options"
+        return self.strategy.fetch_for_product(product)
+
     def add_product(self, product, quantity=1, options=None):
         """
         Add a product to the basket
@@ -188,7 +192,7 @@ class AbstractBasket(models.Model):
 
         # Ensure that all lines are the same currency
         price_currency = self.currency
-        stock_info = self.strategy.fetch_for_product(product)
+        stock_info = self.get_stock_info(product, options)
         if price_currency and stock_info.price.currency != price_currency:
             raise ValueError((
                 "Basket lines must all have the same currency. Proposed "
@@ -365,7 +369,7 @@ class AbstractBasket(models.Model):
                 pass
             except TypeError:
                 # Handle Unavailable products with no known price
-                info = self.strategy.fetch_for_product(line.product)
+                info = self.get_stock_info(line.product, line.attributes.all())
                 if info.availability.is_available_to_buy:
                     raise
                 pass

--- a/src/oscar/apps/basket/abstract_models.py
+++ b/src/oscar/apps/basket/abstract_models.py
@@ -166,7 +166,11 @@ class AbstractBasket(models.Model):
         self._lines = None
 
     def get_stock_info(self, product, options):
-        "Hook for implementing strategies that depend on product options"
+        """
+        Hook for implementing strategies that depend on product options
+        """
+        # The built-in strategies don't use options, so initially disregard
+        # them.
         return self.strategy.fetch_for_product(product)
 
     def add_product(self, product, quantity=1, options=None):


### PR DESCRIPTION
Currently when I need to implement a price strategy that has price
components that are dependent on product options, a rather large part of the
basket code needs to be copy pasted, the whole of ``add_product``. The hook
added here allows me to only override the hook.

Some use cases are: Pens with engravings, the price of engraving depends on
the number of letters. But a lot more things open up when prices can be
assigned based on product configuration.