### PR TITLE
Fix the issue with the quote character in a category name

### DIFF
--- a/src/oscar/apps/catalogue/search_handlers.py
+++ b/src/oscar/apps/catalogue/search_handlers.py
@@ -51,7 +51,7 @@ class SolrProductSearchHandler(SearchHandler):
             # We use 'narrow' API to ensure Solr's 'fq' filtering is used as
             # opposed to filtering using 'q'.
             pattern = ' OR '.join([
-                '"%s"' % c.full_name for c in self.categories])
+                '"%s"' % c.full_name.replace('\"', '\\\"') for c in self.categories])
             sqs = sqs.narrow('category_exact:(%s)' % pattern)
         return sqs
 

--- a/src/oscar/apps/catalogue/search_handlers.py
+++ b/src/oscar/apps/catalogue/search_handlers.py
@@ -51,7 +51,7 @@ class SolrProductSearchHandler(SearchHandler):
             # We use 'narrow' API to ensure Solr's 'fq' filtering is used as
             # opposed to filtering using 'q'.
             pattern = ' OR '.join([
-                '"%s"' % c.full_name.replace('\"', '\\\"') for c in self.categories])
+                '"%s"' % sqs.query.clean(c.full_name) for c in self.categories])
             sqs = sqs.narrow('category_exact:(%s)' % pattern)
         return sqs
 


### PR DESCRIPTION
If a category has a double quote character (") in the name it's impossible to see any products in this category or it's ascenders because the query to solr brokes.