### PR TITLE
Use default user shipping address to calculate indicative shipping cost on basket summary page.

### DIFF
--- a/docs/source/releases/v1.6.rst
+++ b/docs/source/releases/v1.6.rst
@@ -50,6 +50,10 @@ Minor changes
  - Fixed the page create/update views in the dashboard to correctly validate
    URLs. Invalid characters in URLs will raise a validation error, as will
    URLs longer than 100 characters.
+ - Default shipping method on basket summary page uses default user shipping
+   address in order to calculate indicative shipping cost. Default shipping
+   address definition can be overridden in
+   ``oscar.apps.basket.views.BasketView.get_default_shipping_address`` method.
 
 .. _incompatible_in_1.6:
 

--- a/src/oscar/apps/basket/views.py
+++ b/src/oscar/apps/basket/views.py
@@ -54,10 +54,15 @@ class BasketView(ModelFormSetView):
             basket=self.request.basket, user=self.request.user,
             request=self.request)
 
+    def get_default_shipping_address(self):
+        if user_is_authenticated(self.request.user):
+            return self.request.user.addresses.filter(is_default_for_shipping=True).first()
+        return
+
     def get_default_shipping_method(self, basket):
         return Repository().get_default_shipping_method(
             basket=self.request.basket, user=self.request.user,
-            request=self.request)
+            request=self.request, shipping_addr=self.get_default_shipping_address())
 
     def get_basket_warnings(self, basket):
         """

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -19,7 +19,7 @@ class RequestFactory(BaseRequestFactory):
 
     def request(self, user=None, **request):
         request = super(RequestFactory, self).request(**request)
-        request.user = AnonymousUser()
+        request.user = user or AnonymousUser()
         request.session = SessionStore()
         request._messages = FallbackStorage(request)
 

--- a/tests/integration/basket/test_views.py
+++ b/tests/integration/basket/test_views.py
@@ -1,9 +1,10 @@
 from django.contrib.messages import get_messages
+from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.utils import six
 
 from oscar.apps.basket import views
-from oscar.test.factories import VoucherFactory
+from oscar.test import factories
 from tests.fixtures import RequestFactory
 
 
@@ -20,7 +21,7 @@ class TestVoucherAddView(TestCase):
         return '\n'.join(six.text_type(m.message) for m in get_messages(request))
 
     def test_post_valid(self):
-        voucher = VoucherFactory()
+        voucher = factories.VoucherFactory()
         self.assertTrue(voucher.is_active())
 
         data = {
@@ -39,7 +40,7 @@ class TestVoucherAddView(TestCase):
 
 class TestVoucherRemoveView(TestCase):
     def test_post_valid(self):
-        voucher = VoucherFactory(num_basket_additions=5)
+        voucher = factories.VoucherFactory(num_basket_additions=5)
 
         data = {
             'code': voucher.code
@@ -68,3 +69,23 @@ class TestVoucherRemoveView(TestCase):
         actual = list(get_messages(request))[-1].message
         expected = "No voucher found with id '{}'".format(pk)
         self.assertEqual(actual, expected)
+
+
+class TestBasketSummaryView(TestCase):
+    def setUp(self):
+        self.url = reverse('basket:summary')
+        self.country = factories.CountryFactory()
+        self.user = factories.UserFactory()
+
+    def test_default_shipping_address(self):
+        user_address = factories.UserAddressFactory(
+            country=self.country, user=self.user, is_default_for_shipping=True
+        )
+        request = RequestFactory().get(self.url, user=self.user)
+        view = views.BasketView(request=request)
+        self.assertEquals(view.get_default_shipping_address(), user_address)
+
+    def test_default_shipping_address_for_anonymous_user(self):
+        request = RequestFactory().get(self.url)
+        view = views.BasketView(request=request)
+        self.assertIsNone(view.get_default_shipping_address())


### PR DESCRIPTION
Fixes #827