### PR TITLE
Fix rendering of options in AdvancedSelect widget for Django >= 1.11.

### DIFF
--- a/src/oscar/forms/widgets.py
+++ b/src/oscar/forms/widgets.py
@@ -270,6 +270,7 @@ class AdvancedSelect(forms.Select):
         super(AdvancedSelect, self).__init__(attrs, choices)
 
     def render_option(self, selected_choices, option_value, option_label):
+        # TODO remove this when Django 1.8 support is dropped
         option_value = force_text(option_value)
         if option_value in self.disabled_values:
             selected_html = mark_safe(' disabled="disabled"')
@@ -284,6 +285,12 @@ class AdvancedSelect(forms.Select):
                            option_value,
                            selected_html,
                            force_text(option_label))
+
+    def create_option(self, name, value, label, selected, index, subindex=None, attrs=None):
+        option = super(AdvancedSelect, self).create_option(name, value, label, selected, index, subindex, attrs)
+        if force_text(value) in self.disabled_values:
+            option['attrs']['disabled'] = True
+        return option
 
 
 class RemoteSelect(forms.Widget):

--- a/tests/integration/forms/test_widget.py
+++ b/tests/integration/forms/test_widget.py
@@ -44,3 +44,22 @@ class TestWidgetsDatetimeFormat(TestCase):
         date = datetime.datetime(2017, 5, 1, 10, 57)
         html = i.render('datetime', date)
         self.assertIn(u'value="δ-01/05/2017 10:57"', html)
+
+
+class AdvancedSelectWidgetTestCase(TestCase):
+
+    def test_widget_disabled_options(self):
+
+        choices = (
+            ('red', 'Red'),
+            ('blue', 'Blue'),
+            ('green', 'Green'),
+        )
+
+        disabled_values = ('red', 'green')
+
+        i = widgets.AdvancedSelect(choices=choices, disabled_values=disabled_values)
+        html = i.render('advselect', [])
+        self.assertInHTML('<option value="blue">Blue</option>', html, count=1)
+        self.assertInHTML('<option value="red" disabled>Red</option>', html, count=1)
+        self.assertInHTML('<option value="green" disabled>Green</option>', html, count=1)


### PR DESCRIPTION
Fixes #2526.

The `render_option()` method needs to be removed when we drop Django 1.8 support. Will do that separately in #2508 once this is merged.