### PR TITLE
Deprecate unused StockRecord and order.Line model fields

### DIFF
--- a/docs/source/releases/v1.6.rst
+++ b/docs/source/releases/v1.6.rst
@@ -89,3 +89,11 @@ The following features have been deprecated in this release:
 
 * ``StockRecord.price_excl_tax`` will be renamed into ``StockRecord.price`` in
   Oscar 2.0. Please see :issue:`1962` for more details.
+
+* The ``StockRecord.price_retail`` and ``StockRecord.cost_price`` fields are
+  deprecated and will be removed in Oscar 2.0.
+
+* The ``order.Line.est_dispatch_date``,  ``order.Line.line_price_incl_tax``,
+  ``order.Line.unit_retail_price``, ``order.Line.unit_cost_price`` and
+  ``order.Line.line_price_excl_tax`` fields are deprecated and will be removed
+  in Oscar 2.0.

--- a/src/oscar/apps/order/abstract_models.py
+++ b/src/oscar/apps/order/abstract_models.py
@@ -480,8 +480,10 @@ class AbstractLine(models.Model):
 
     # Price information (these fields are actually redundant as the information
     # can be calculated from the LinePrice models
+    # Deprecated - will be removed in Oscar 2.0
     line_price_incl_tax = models.DecimalField(
         _("Price (inc. tax)"), decimal_places=2, max_digits=12)
+    # Deprecated - will be removed in Oscar 2.0
     line_price_excl_tax = models.DecimalField(
         _("Price (excl. tax)"), decimal_places=2, max_digits=12)
 
@@ -493,8 +495,7 @@ class AbstractLine(models.Model):
         _("Price before discounts (excl. tax)"),
         decimal_places=2, max_digits=12)
 
-    # Cost price (the price charged by the fulfilment partner for this
-    # product).
+    # Deprecated - will be removed in Oscar 2.0
     unit_cost_price = models.DecimalField(
         _("Unit Cost Price"), decimal_places=2, max_digits=12, blank=True,
         null=True)
@@ -505,7 +506,7 @@ class AbstractLine(models.Model):
     unit_price_excl_tax = models.DecimalField(
         _("Unit Price (excl. tax)"), decimal_places=2, max_digits=12,
         blank=True, null=True)
-    # Retail price at time of purchase
+    # Deprecated - will be removed in Oscar 2.0
     unit_retail_price = models.DecimalField(
         _("Unit Retail Price"), decimal_places=2, max_digits=12,
         blank=True, null=True)
@@ -514,7 +515,7 @@ class AbstractLine(models.Model):
     # own business processes.
     status = models.CharField(_("Status"), max_length=255, blank=True)
 
-    # Estimated dispatch date - should be set at order time
+    # Deprecated - will be removed in Oscar 2.0
     est_dispatch_date = models.DateField(
         _("Estimated Dispatch Date"), blank=True, null=True)
 

--- a/src/oscar/apps/partner/abstract_models.py
+++ b/src/oscar/apps/partner/abstract_models.py
@@ -121,16 +121,12 @@ class AbstractStockRecord(models.Model):
         _("Price (excl. tax)"), decimal_places=2, max_digits=12,
         blank=True, null=True)
 
-    #: Retail price for this item.  This is simply the recommended price from
-    #: the manufacturer.  If this is used, it is for display purposes only.
-    #: This prices is the NOT the price charged to the customer.
+    # Deprecated - will be removed in Oscar 2.0
     price_retail = models.DecimalField(
         _("Price (retail)"), decimal_places=2, max_digits=12,
         blank=True, null=True)
 
-    #: Cost price is the price charged by the fulfilment partner.  It is not
-    #: used (by default) in any price calculations but is often used in
-    #: reporting so merchants can report on their profit margin.
+    # Deprecated - will be removed in Oscar 2.0
     cost_price = models.DecimalField(
         _("Cost Price"), decimal_places=2, max_digits=12,
         blank=True, null=True)

--- a/src/oscar/apps/partner/admin.py
+++ b/src/oscar/apps/partner/admin.py
@@ -7,8 +7,7 @@ StockRecord = get_model('partner', 'StockRecord')
 
 
 class StockRecordAdmin(admin.ModelAdmin):
-    list_display = ('product', 'partner', 'partner_sku', 'price_excl_tax',
-                    'cost_price', 'num_in_stock')
+    list_display = ('product', 'partner', 'partner_sku', 'price_excl_tax', 'num_in_stock')
     list_filter = ('partner',)
 
 


### PR DESCRIPTION
- `StockRecord.price_retail`
- `StockRecord.cost_price`
- `order.Line.est_dispatch_date`
- `order.Line.line_price_incl_tax`
- `order.Line.line_price_excl_tax`

These fields are not used in Oscar core. Refs #1968.