### PR TITLE
Fix rendering of options in AdvancedSelect widget for Django > 1.11 (1.5 backport)

### DIFF
--- a/docs/source/releases/v1.5.2.rst
+++ b/docs/source/releases/v1.5.2.rst
@@ -1,0 +1,13 @@
+=========================
+Oscar 1.5.2 release notes
+=========================
+
+:release: tbd
+
+This is Oscar 1.5.2, a bug fix release.
+
+Bug fixes
+=========
+
+* Fixed ``oscar.core.widgets.AdvancedSelect`` widget behaviour with Django 1.11
+  and above.

--- a/src/oscar/forms/widgets.py
+++ b/src/oscar/forms/widgets.py
@@ -270,6 +270,7 @@ class AdvancedSelect(forms.Select):
         super(AdvancedSelect, self).__init__(attrs, choices)
 
     def render_option(self, selected_choices, option_value, option_label):
+        # TODO remove this when Django 1.8 support is dropped
         option_value = force_text(option_value)
         if option_value in self.disabled_values:
             selected_html = mark_safe(' disabled="disabled"')
@@ -284,6 +285,12 @@ class AdvancedSelect(forms.Select):
                            option_value,
                            selected_html,
                            force_text(option_label))
+
+    def create_option(self, name, value, label, selected, index, subindex=None, attrs=None):
+        option = super(AdvancedSelect, self).create_option(name, value, label, selected, index, subindex, attrs)
+        if force_text(value) in self.disabled_values:
+            option['attrs']['disabled'] = True
+        return option
 
 
 class RemoteSelect(forms.Widget):

--- a/tests/integration/core/test_autoslugfield.py
+++ b/tests/integration/core/test_autoslugfield.py
@@ -214,15 +214,15 @@ class AutoSlugFieldTest(TestCase):
         self.assertIn("Migration", result)
 
     def safe_exec(self, string, value=None, context=None):
-        l = {}
+        loc = {}
         g = globals()
         g.update(context)
         try:
-            exec(string, g, l)
+            exec(string, g, loc)
         except Exception as e:
             if value:
                 self.fail("Could not exec %r (from value %r): %s" % (
                     string.strip(), value, e))
             else:
                 self.fail("Could not exec %r: %s" % (string.strip(), e))
-        return l
+        return loc

--- a/tests/integration/forms/test_widget.py
+++ b/tests/integration/forms/test_widget.py
@@ -44,3 +44,22 @@ class TestWidgetsDatetimeFormat(TestCase):
         date = datetime.datetime(2017, 5, 1, 10, 57)
         html = i.render('datetime', date)
         self.assertIn(u'value="δ-01/05/2017 10:57"', html)
+
+
+class AdvancedSelectWidgetTestCase(TestCase):
+
+    def test_widget_disabled_options(self):
+
+        choices = (
+            ('red', 'Red'),
+            ('blue', 'Blue'),
+            ('green', 'Green'),
+        )
+
+        disabled_values = ('red', 'green')
+
+        i = widgets.AdvancedSelect(choices=choices, disabled_values=disabled_values)
+        html = i.render('advselect', [])
+        self.assertInHTML('<option value="blue">Blue</option>', html, count=1)
+        self.assertInHTML('<option value="red" disabled>Red</option>', html, count=1)
+        self.assertInHTML('<option value="green" disabled>Green</option>', html, count=1)


### PR DESCRIPTION
Backport of #2533 to releases/1.5