### PR TITLE
Exclude test utils from coverage reports.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,5 @@
 [run]
 source = oscar
-omit = *migrations*
+omit =
+    *migrations*
+    */oscar/test/*


### PR DESCRIPTION
Currently the contents of `oscar/test/` are included in coverage analysis which is a bit weird, and incorrectly inflates the "real" coverage metrics.