### PR TITLE
New blocks to allow easy adding of new tab panes to Dashboard

### DIFF
--- a/src/oscar/templates/oscar/dashboard/catalogue/attribute_option_group_form.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/attribute_option_group_form.html
@@ -64,69 +64,69 @@
             <div class="col-md-9">
                 <div class="tab-content">
                     {% block tab_content%}
-                    {% block attribute_option_group_details %}
-                        <div class="tab-pane active" id="attribute_option_group_details">
-                            <div class="table-header">
-                                <h3>{% trans "Attribute Option Group details" %}</h3>
-                            </div>
-                            <div class="well attribute-option-group-details">
+                        {% block attribute_option_group_details %}
+                            <div class="tab-pane active" id="attribute_option_group_details">
+                                <div class="table-header">
+                                    <h3>{% trans "Attribute Option Group details" %}</h3>
+                                </div>
+                                <div class="well attribute-option-group-details">
 
-                                {% comment %}
-                                    If the AttributeOptionGroup form has field_errors, partials/form_fields.html
-                                    will render an error message.
-                                    This means that there'll be 2 error messages,
-                                    one from the partial and one from the view. Perhaps there should be
-                                    an option allowing hiding of the error message in the template.
-                                    For now we copy paste what we need from the template.
-                                {% endcomment %}
+                                    {% comment %}
+                                        If the AttributeOptionGroup form has field_errors, partials/form_fields.html
+                                        will render an error message.
+                                        This means that there'll be 2 error messages,
+                                        one from the partial and one from the view. Perhaps there should be
+                                        an option allowing hiding of the error message in the template.
+                                        For now we copy paste what we need from the template.
+                                    {% endcomment %}
 
-                                {% if form.non_field_errors %}
-                                    {% for error in form.non_field_errors %}
-                                        <div class="alert alert-error control-group error">
-                                            <span class="error-block"><i class="icon-exclamation-sign"></i> {{ error }}</span>
-                                        </div>
-                                    {% endfor %}
-                                {% endif %}
-
-                                {% for field in form %}
-                                    {% include 'dashboard/partials/form_field.html' with field=field %}
-                                {% endfor %}
-                            </div>
-                        </div>
-                    {% endblock %}
-
-                    {% block attribute_options %}
-                        <div class="tab-pane" id="attribute_options">
-                            <div class="table-header">
-                                <h3>{% trans "Attribute Options" %}</h3>
-                            </div>
-                            <div class="attribute-options">
-                                <table class="table table-striped table-bordered">
-                                    {{ attribute_option_formset.management_form }}
-                                    {{ attribute_option_formset.non_form_errors }}
-                                    <col width="50%">
-                                    <col width="50%">
-                                    <thead>
-                                        <tr>
-                                            <th>{% trans "Option" %}</th>
-                                            <th>{% trans "Delete?" %}</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {% for attribute_option_form in attribute_option_formset %}
-                                            <tr>
-                                                {% for hidden_field in attribute_option_form.hidden_fields %}
-                                                    {{ hidden_field }}
-                                                {% endfor %}
-                                                <td>{% include 'dashboard/partials/form_field.html' with field=attribute_option_form.option nolabel=True %}</td>
-                                                <td>{% include 'dashboard/partials/form_field.html' with field=attribute_option_form.DELETE nolabel=True %}</td>
-                                            </tr>
+                                    {% if form.non_field_errors %}
+                                        {% for error in form.non_field_errors %}
+                                            <div class="alert alert-error control-group error">
+                                                <span class="error-block"><i class="icon-exclamation-sign"></i> {{ error }}</span>
+                                            </div>
                                         {% endfor %}
-                                    </tbody>
-                                </table>
+                                    {% endif %}
+
+                                    {% for field in form %}
+                                        {% include 'dashboard/partials/form_field.html' with field=field %}
+                                    {% endfor %}
+                                </div>
                             </div>
-                        </div>
-                    {% endblock %}
+                        {% endblock %}
+
+                        {% block attribute_options %}
+                            <div class="tab-pane" id="attribute_options">
+                                <div class="table-header">
+                                    <h3>{% trans "Attribute Options" %}</h3>
+                                </div>
+                                <div class="attribute-options">
+                                    <table class="table table-striped table-bordered">
+                                        {{ attribute_option_formset.management_form }}
+                                        {{ attribute_option_formset.non_form_errors }}
+                                        <col width="50%">
+                                        <col width="50%">
+                                        <thead>
+                                            <tr>
+                                                <th>{% trans "Option" %}</th>
+                                                <th>{% trans "Delete?" %}</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% for attribute_option_form in attribute_option_formset %}
+                                                <tr>
+                                                    {% for hidden_field in attribute_option_form.hidden_fields %}
+                                                        {{ hidden_field }}
+                                                    {% endfor %}
+                                                    <td>{% include 'dashboard/partials/form_field.html' with field=attribute_option_form.option nolabel=True %}</td>
+                                                    <td>{% include 'dashboard/partials/form_field.html' with field=attribute_option_form.DELETE nolabel=True %}</td>
+                                                </tr>
+                                            {% endfor %}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        {% endblock %}
                     {%endblock tab_content%}
                 </div>
             </div>

--- a/src/oscar/templates/oscar/dashboard/catalogue/attribute_option_group_form.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/attribute_option_group_form.html
@@ -63,7 +63,7 @@
 
             <div class="col-md-9">
                 <div class="tab-content">
-                    {% block tab_content%}
+                    {% block tab_content %}
                         {% block attribute_option_group_details %}
                             <div class="tab-pane active" id="attribute_option_group_details">
                                 <div class="table-header">
@@ -127,7 +127,7 @@
                                 </div>
                             </div>
                         {% endblock %}
-                    {%endblock tab_content%}
+                    {% endblock tab_content %}
                 </div>
             </div>
         </div>

--- a/src/oscar/templates/oscar/dashboard/catalogue/attribute_option_group_form.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/attribute_option_group_form.html
@@ -63,6 +63,7 @@
 
             <div class="col-md-9">
                 <div class="tab-content">
+                    {% block tab_content%}
                     {% block attribute_option_group_details %}
                         <div class="tab-pane active" id="attribute_option_group_details">
                             <div class="table-header">
@@ -126,6 +127,7 @@
                             </div>
                         </div>
                     {% endblock %}
+                    {%endblock tab_content%}
                 </div>
             </div>
         </div>

--- a/src/oscar/templates/oscar/dashboard/catalogue/product_class_form.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/product_class_form.html
@@ -47,6 +47,7 @@
 
             <div class="col-md-9">
                 <div class="tab-content">
+                    {% block tab_content%}
                     {% block product_class_details %}
                         <div class="tab-pane active" id="product_class_details">
                             <div class="table-header">
@@ -121,6 +122,7 @@
                             </div>
                         </div>
                     {% endblock %}
+                    {%endblock tab_content%}
                 </div>
             </div>
         </div>

--- a/src/oscar/templates/oscar/dashboard/catalogue/product_class_form.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/product_class_form.html
@@ -47,7 +47,7 @@
 
             <div class="col-md-9">
                 <div class="tab-content">
-                    {% block tab_content%}
+                    {% block tab_content %}
                         {% block product_class_details %}
                             <div class="tab-pane active" id="product_class_details">
                                 <div class="table-header">
@@ -122,7 +122,7 @@
                                 </div>
                             </div>
                         {% endblock %}
-                    {%endblock tab_content%}
+                    {% endblock tab_content %}
                 </div>
             </div>
         </div>

--- a/src/oscar/templates/oscar/dashboard/catalogue/product_class_form.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/product_class_form.html
@@ -48,80 +48,80 @@
             <div class="col-md-9">
                 <div class="tab-content">
                     {% block tab_content%}
-                    {% block product_class_details %}
-                        <div class="tab-pane active" id="product_class_details">
-                            <div class="table-header">
-                                <h3>{% trans "Product Class details" %}</h3>
-                            </div>
-                            <div class="well product-class-details">
+                        {% block product_class_details %}
+                            <div class="tab-pane active" id="product_class_details">
+                                <div class="table-header">
+                                    <h3>{% trans "Product Class details" %}</h3>
+                                </div>
+                                <div class="well product-class-details">
 
-                                {% comment %}
-                                    If the ProductClass form has field_errors, partials/form_fields.html
-                                    will render an error message.
-                                    This means that there'll be 2 error messages,
-                                    one from the partial and one from the view. Perhaps there should be
-                                    an option allowing hiding of the error message in the template.
-                                    For now we copy paste what we need from the template.
-                                {% endcomment %}
+                                    {% comment %}
+                                        If the ProductClass form has field_errors, partials/form_fields.html
+                                        will render an error message.
+                                        This means that there'll be 2 error messages,
+                                        one from the partial and one from the view. Perhaps there should be
+                                        an option allowing hiding of the error message in the template.
+                                        For now we copy paste what we need from the template.
+                                    {% endcomment %}
 
-                                {% if form.non_field_errors %}
-                                    {% for error in form.non_field_errors %}
-                                        <div class="alert alert-error control-group error">
-                                            <span class="error-block"><i class="icon-exclamation-sign"></i> {{ error }}</span>
-                                        </div>
-                                    {% endfor %}
-                                {% endif %}
-
-                                {% for field in form %}
-                                    {% include 'dashboard/partials/form_field.html' with field=field %}
-                                {% endfor %}
-                            </div>
-                        </div>
-                    {% endblock %}
-
-                    {% block product_attributes %}
-                        <div class="tab-pane" id="product_attributes">
-                            <div class="table-header">
-                                <h3>{% trans "Product attributes" %}</h3>
-                            </div>
-                            <div class="product-attributes">
-                                <table class="table table-striped table-bordered">
-                                    {{ attributes_formset.management_form }}
-                                    {{ attributes_formset.non_form_errors }}
-                                    <col width="20%">
-                                    <col width="20%">
-                                    <col width="20%">
-                                    <thead>
-                                        <tr>
-                                            <th>{% trans "Name" %}</th>
-                                            <th>{% trans "Code" %}</th>
-                                            <th>{% trans "Type" %}</th>
-                                            <th>{% trans "Required" %}</th>
-                                            <th>{% trans "Delete?" %}</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {% for attribute_form in attributes_formset %}
-                                            <tr>
-                                                {% for hidden_field in attribute_form.hidden_fields %}
-                                                 {{ hidden_field }}
-                                                {% endfor %}
-                                                <td>{% include 'dashboard/partials/form_field.html' with field=attribute_form.name nolabel=True %}</td>
-                                                <td>{% include 'dashboard/partials/form_field.html' with field=attribute_form.code nolabel=True %}</td>
-                                                <td>
-                                                    {% include 'dashboard/partials/form_field.html' with field=attribute_form.type nolabel=True %}
-
-                                                    {% include 'dashboard/partials/form_field.html' with field=attribute_form.option_group nolabel=True %}
-                                                </td>
-                                                <td>{% include 'dashboard/partials/form_field.html' with field=attribute_form.required nolabel=True %}</td>
-                                                <td>{% include 'dashboard/partials/form_field.html' with field=attribute_form.DELETE nolabel=True %}</td>
-                                            </tr>
+                                    {% if form.non_field_errors %}
+                                        {% for error in form.non_field_errors %}
+                                            <div class="alert alert-error control-group error">
+                                                <span class="error-block"><i class="icon-exclamation-sign"></i> {{ error }}</span>
+                                            </div>
                                         {% endfor %}
-                                    </tbody>
-                                </table>
+                                    {% endif %}
+
+                                    {% for field in form %}
+                                        {% include 'dashboard/partials/form_field.html' with field=field %}
+                                    {% endfor %}
+                                </div>
                             </div>
-                        </div>
-                    {% endblock %}
+                        {% endblock %}
+
+                        {% block product_attributes %}
+                            <div class="tab-pane" id="product_attributes">
+                                <div class="table-header">
+                                    <h3>{% trans "Product attributes" %}</h3>
+                                </div>
+                                <div class="product-attributes">
+                                    <table class="table table-striped table-bordered">
+                                        {{ attributes_formset.management_form }}
+                                        {{ attributes_formset.non_form_errors }}
+                                        <col width="20%">
+                                        <col width="20%">
+                                        <col width="20%">
+                                        <thead>
+                                            <tr>
+                                                <th>{% trans "Name" %}</th>
+                                                <th>{% trans "Code" %}</th>
+                                                <th>{% trans "Type" %}</th>
+                                                <th>{% trans "Required" %}</th>
+                                                <th>{% trans "Delete?" %}</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% for attribute_form in attributes_formset %}
+                                                <tr>
+                                                    {% for hidden_field in attribute_form.hidden_fields %}
+                                                     {{ hidden_field }}
+                                                    {% endfor %}
+                                                    <td>{% include 'dashboard/partials/form_field.html' with field=attribute_form.name nolabel=True %}</td>
+                                                    <td>{% include 'dashboard/partials/form_field.html' with field=attribute_form.code nolabel=True %}</td>
+                                                    <td>
+                                                        {% include 'dashboard/partials/form_field.html' with field=attribute_form.type nolabel=True %}
+
+                                                        {% include 'dashboard/partials/form_field.html' with field=attribute_form.option_group nolabel=True %}
+                                                    </td>
+                                                    <td>{% include 'dashboard/partials/form_field.html' with field=attribute_form.required nolabel=True %}</td>
+                                                    <td>{% include 'dashboard/partials/form_field.html' with field=attribute_form.DELETE nolabel=True %}</td>
+                                                </tr>
+                                            {% endfor %}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        {% endblock %}
                     {%endblock tab_content%}
                 </div>
             </div>

--- a/src/oscar/templates/oscar/dashboard/catalogue/product_update.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/product_update.html
@@ -94,6 +94,7 @@
 
             <div class="col-md-9">
                 <div class="tab-content">
+                    {% block tab_content%}
                     {% block product_details %}
                         <div class="tab-pane active" id="product_details">
                             <div class="table-header">
@@ -308,6 +309,7 @@
                             {% endblock recommended_products_content %}
                         </div>
                     {% endblock recommended_products %}
+                    {%endblock tab_content%}
                 </div>
             </div>
         </div>

--- a/src/oscar/templates/oscar/dashboard/catalogue/product_update.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/product_update.html
@@ -95,220 +95,220 @@
             <div class="col-md-9">
                 <div class="tab-content">
                     {% block tab_content%}
-                    {% block product_details %}
-                        <div class="tab-pane active" id="product_details">
-                            <div class="table-header">
-                                <h3>{% trans "Product details" %}</h3>
-                            </div>
-                            <div class="well product-details">
-                                {% block product_details_content %}
-                                    <span class="error-block">{{ form.non_field_errors }}</span>
-                                    {% for field in form.hidden_fields %}
-                                        {{ field }}
-                                    {% endfor %}
-
-                                    {% for field in form.visible_fields %}
-                                        {% if 'attr' not in field.id_for_label %}
-                                            {% include 'dashboard/partials/form_field.html' with field=field %}
-                                        {% endif %}
-                                    {% endfor %}
-                                {% endblock product_details_content %}
-                            </div>
-                        </div>
-                    {% endblock product_details %}
-
-                    {% block product_categories %}
-                        <div class="tab-pane" id="product_category">
-                            {% block product_categories_content %}
-                                <table class="table table-striped table-bordered form-inline">
-                                    <caption>{% trans "Category" %}</caption>
-                                    {{ category_formset.management_form }}
-                                    {{ category_formset.non_form_errors }}
-                                    {% for category_form in category_formset %}
-                                        <tr>
-                                            <td>
-                                                {% include "dashboard/partials/form_fields_inline.html" with form=category_form %}
-                                            </td>
-                                        </tr>
-                                    {% endfor %}
-                                </table>
-                            {% endblock product_categories_content %}
-                        </div>
-                    {% endblock product_categories %}
-
-                    {% block product_attributes %}
-                        <div class="tab-pane" id="product_attributes">
-                            {% block product_attributes_content %}
-                                <table class="table table-striped table-bordered">
-                                    <caption>
-                                        {% trans "Attributes" %}
-                                        <span class="label label-success">
-                                            {% trans "Product Type:" %} {{ product_class }}
-                                        </span>
-                                    </caption>
-                                    {% for field in form %}
-                                        {% if 'attr' in field.id_for_label %}
-                                            <tr>
-                                                <td>
-                                                    {% include "dashboard/partials/form_field.html" %}
-                                                </td>
-                                            </tr>
-                                        {% endif %}
-                                    {% endfor %}
-                                </table>
-                            {% endblock product_attributes_content %}
-                        </div>
-                    {% endblock product_attributes %}
-
-                    {% block product_images %}
-                        <div class="tab-pane" id="product_images">
-                            {% block product_images_content %}
+                        {% block product_details %}
+                            <div class="tab-pane active" id="product_details">
                                 <div class="table-header">
-                                    <h3>{% trans "Upload, change or remove images" %}</h3>
+                                    <h3>{% trans "Product details" %}</h3>
                                 </div>
-                                <div class="well">
-                                    {{ image_formset.management_form }}
-                                    {{ image_formset.non_form_errors }}
-                                    <ol class='upload-image'>
-                                        {% for image_form in image_formset %}
-                                            {% include "dashboard/partials/product_images.html" with form=image_form %}
+                                <div class="well product-details">
+                                    {% block product_details_content %}
+                                        <span class="error-block">{{ form.non_field_errors }}</span>
+                                        {% for field in form.hidden_fields %}
+                                            {{ field }}
                                         {% endfor %}
-                                    </ol>
-                                </div>
-                            {% endblock product_images_content %}
-                        </div>
-                    {% endblock product_images %}
 
-                    {% block stockrecords %}
-                        <div class="tab-pane" id="product_stock">
-                            {% block stockrecords_content %}
-                                <table class="table table-striped table-bordered">
-                                    <caption>{% trans "Stock and pricing" %}</caption>
-                                    {{ stockrecord_formset.management_form }}
-                                    {{ stockrecord_formset.non_form_errors }}
-                                    <thead>
-                                        <tr>
-                                            <th>{% trans "Partner" %}</th>
-                                            <th>{% trans "SKU" %}</th>
-                                            {% if product_class.track_stock %}
-                                                <th>{% trans "Num in stock" %}</th>
-                                                <th>{% trans "Num allocated" %}</th>
-                                                <th>{% trans "Low stock threshold" %}</th>
+                                        {% for field in form.visible_fields %}
+                                            {% if 'attr' not in field.id_for_label %}
+                                                {% include 'dashboard/partials/form_field.html' with field=field %}
                                             {% endif %}
-                                            <th>{% trans "Currency" %}</th>
-                                            <th>{% trans "Cost price" %}</th>
-                                            <th>{% trans "Price (excl tax)" %}</th>
-                                            <th>{% trans "Retail price" %}</th>
-                                            <th>{% trans "Delete?" %}</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {% for stockrecord_form in stockrecord_formset %}
-                                            {% if stockrecord_form.non_field_errors %}
+                                        {% endfor %}
+                                    {% endblock product_details_content %}
+                                </div>
+                            </div>
+                        {% endblock product_details %}
+
+                        {% block product_categories %}
+                            <div class="tab-pane" id="product_category">
+                                {% block product_categories_content %}
+                                    <table class="table table-striped table-bordered form-inline">
+                                        <caption>{% trans "Category" %}</caption>
+                                        {{ category_formset.management_form }}
+                                        {{ category_formset.non_form_errors }}
+                                        {% for category_form in category_formset %}
                                             <tr>
-                                                <td colspan="{% if product_class.track_stock %}10{% else %}7{% endif %}">
-                                                    {% for error in stockrecord_form.non_field_errors  %}
-                                                        <span class="error-block errorlist"><i class="icon-exclamation-sign"></i> {{ error }}</span>
-                                                    {% endfor %}
-                                                </td>
-                                            </tr>
-                                            {% endif %}
-                                            <tr>
-                                                <td>{% include "dashboard/partials/form_field.html" with field=stockrecord_form.partner nolabel=True %}</td>
-                                                <td>{% include "dashboard/partials/form_field.html" with field=stockrecord_form.partner_sku nolabel=True %}</td>
-                                                {% if product_class.track_stock %}
-                                                    <td>{% include "dashboard/partials/form_field.html" with field=stockrecord_form.num_in_stock nolabel=True %}</td>
-                                                    <td>{{ stockrecord_form.instance.num_allocated|default:"-" }}</td>
-                                                    <td>{% include "dashboard/partials/form_field.html" with field=stockrecord_form.low_stock_threshold nolabel=True %}</td>
-                                                {% endif %}
-                                                <td>{% include "dashboard/partials/form_field.html" with field=stockrecord_form.price_currency nolabel=True %}</td>
-                                                <td>{% include "dashboard/partials/form_field.html" with field=stockrecord_form.cost_price nolabel=True %}</td>
-                                                <td>{% include "dashboard/partials/form_field.html" with field=stockrecord_form.price_excl_tax nolabel=True %}</td>
-                                                <td>{% include "dashboard/partials/form_field.html" with field=stockrecord_form.price_retail nolabel=True %}</td>
                                                 <td>
-                                                    {% include "dashboard/partials/form_field.html" with field=stockrecord_form.id nolabel=True %}
-                                                    {% include "dashboard/partials/form_field.html" with field=stockrecord_form.DELETE nolabel=True %}
+                                                    {% include "dashboard/partials/form_fields_inline.html" with form=category_form %}
                                                 </td>
                                             </tr>
                                         {% endfor %}
-                                    </tbody>
-                                </table>
-                            {% endblock stockrecords_content %}
-                        </div>
-                    {% endblock stockrecords %}
+                                    </table>
+                                {% endblock product_categories_content %}
+                            </div>
+                        {% endblock product_categories %}
 
-                    {% block child_products %}
-                        {% with children=product.children.all %}
-                            <div class="tab-pane" id="child_products">
-                                {% block child_products_content %}
-                                    <table class='table table-striped table-bordered'>
+                        {% block product_attributes %}
+                            <div class="tab-pane" id="product_attributes">
+                                {% block product_attributes_content %}
+                                    <table class="table table-striped table-bordered">
                                         <caption>
-                                            {% trans "Variants" %}
-                                            <button class="btn btn-primary pull-right{% if not product.can_be_parent %} disabled{% endif %}" name="action" type="submit" value="create-child" data-loading-text="{% trans 'Adding...' %}">
-                                                <i class="icon-plus"></i>
-                                                {% trans "Add variant" %}
-                                            </button>
+                                            {% trans "Attributes" %}
+                                            <span class="label label-success">
+                                                {% trans "Product Type:" %} {{ product_class }}
+                                            </span>
                                         </caption>
-                                        {% if children %}
-                                            <tr>
-                                                <th>{% trans "Title" %}</th>
-                                                <th>{% trans "Attributes" %}</th>
-                                                <th>{% trans "Stock records" %}</th>
-                                                <th>&nbsp;</th>
-                                            </tr>
-                                            {% for child in children %}
+                                        {% for field in form %}
+                                            {% if 'attr' in field.id_for_label %}
                                                 <tr>
-                                                    <td>{{ child.get_title }}</td>
-                                                    <td>{{ child.attribute_summary }}</td>
-                                                    <td>{{ child.stockrecords.count }}</td>
                                                     <td>
-                                                        <a href="{% url 'dashboard:catalogue-product' pk=child.id %}" class="btn btn-primary">
-                                                            {% trans "Edit" %}
-                                                        </a>
-                                                        <a href="{% url 'dashboard:catalogue-product-delete' pk=child.id %}" class="btn btn-danger">
-                                                            {% trans "Delete" %}
-                                                        </a>
+                                                        {% include "dashboard/partials/form_field.html" %}
+                                                    </td>
+                                                </tr>
+                                            {% endif %}
+                                        {% endfor %}
+                                    </table>
+                                {% endblock product_attributes_content %}
+                            </div>
+                        {% endblock product_attributes %}
+
+                        {% block product_images %}
+                            <div class="tab-pane" id="product_images">
+                                {% block product_images_content %}
+                                    <div class="table-header">
+                                        <h3>{% trans "Upload, change or remove images" %}</h3>
+                                    </div>
+                                    <div class="well">
+                                        {{ image_formset.management_form }}
+                                        {{ image_formset.non_form_errors }}
+                                        <ol class='upload-image'>
+                                            {% for image_form in image_formset %}
+                                                {% include "dashboard/partials/product_images.html" with form=image_form %}
+                                            {% endfor %}
+                                        </ol>
+                                    </div>
+                                {% endblock product_images_content %}
+                            </div>
+                        {% endblock product_images %}
+
+                        {% block stockrecords %}
+                            <div class="tab-pane" id="product_stock">
+                                {% block stockrecords_content %}
+                                    <table class="table table-striped table-bordered">
+                                        <caption>{% trans "Stock and pricing" %}</caption>
+                                        {{ stockrecord_formset.management_form }}
+                                        {{ stockrecord_formset.non_form_errors }}
+                                        <thead>
+                                            <tr>
+                                                <th>{% trans "Partner" %}</th>
+                                                <th>{% trans "SKU" %}</th>
+                                                {% if product_class.track_stock %}
+                                                    <th>{% trans "Num in stock" %}</th>
+                                                    <th>{% trans "Num allocated" %}</th>
+                                                    <th>{% trans "Low stock threshold" %}</th>
+                                                {% endif %}
+                                                <th>{% trans "Currency" %}</th>
+                                                <th>{% trans "Cost price" %}</th>
+                                                <th>{% trans "Price (excl tax)" %}</th>
+                                                <th>{% trans "Retail price" %}</th>
+                                                <th>{% trans "Delete?" %}</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% for stockrecord_form in stockrecord_formset %}
+                                                {% if stockrecord_form.non_field_errors %}
+                                                <tr>
+                                                    <td colspan="{% if product_class.track_stock %}10{% else %}7{% endif %}">
+                                                        {% for error in stockrecord_form.non_field_errors  %}
+                                                            <span class="error-block errorlist"><i class="icon-exclamation-sign"></i> {{ error }}</span>
+                                                        {% endfor %}
+                                                    </td>
+                                                </tr>
+                                                {% endif %}
+                                                <tr>
+                                                    <td>{% include "dashboard/partials/form_field.html" with field=stockrecord_form.partner nolabel=True %}</td>
+                                                    <td>{% include "dashboard/partials/form_field.html" with field=stockrecord_form.partner_sku nolabel=True %}</td>
+                                                    {% if product_class.track_stock %}
+                                                        <td>{% include "dashboard/partials/form_field.html" with field=stockrecord_form.num_in_stock nolabel=True %}</td>
+                                                        <td>{{ stockrecord_form.instance.num_allocated|default:"-" }}</td>
+                                                        <td>{% include "dashboard/partials/form_field.html" with field=stockrecord_form.low_stock_threshold nolabel=True %}</td>
+                                                    {% endif %}
+                                                    <td>{% include "dashboard/partials/form_field.html" with field=stockrecord_form.price_currency nolabel=True %}</td>
+                                                    <td>{% include "dashboard/partials/form_field.html" with field=stockrecord_form.cost_price nolabel=True %}</td>
+                                                    <td>{% include "dashboard/partials/form_field.html" with field=stockrecord_form.price_excl_tax nolabel=True %}</td>
+                                                    <td>{% include "dashboard/partials/form_field.html" with field=stockrecord_form.price_retail nolabel=True %}</td>
+                                                    <td>
+                                                        {% include "dashboard/partials/form_field.html" with field=stockrecord_form.id nolabel=True %}
+                                                        {% include "dashboard/partials/form_field.html" with field=stockrecord_form.DELETE nolabel=True %}
                                                     </td>
                                                 </tr>
                                             {% endfor %}
-                                        {% else %}
-                                            <tr>
-                                                <td colspan="3">
-                                                    {% if product.can_be_parent %}
-                                                        {% trans 'This product does not have any variants.' %}
-                                                    {% else %}
-                                                        {% trans "One can't add variants to this product at this point." %}
-                                                        {% if product.has_stockrecords %}
-                                                            {% trans 'This is likely because this product still has stock records.' %}
+                                        </tbody>
+                                    </table>
+                                {% endblock stockrecords_content %}
+                            </div>
+                        {% endblock stockrecords %}
+
+                        {% block child_products %}
+                            {% with children=product.children.all %}
+                                <div class="tab-pane" id="child_products">
+                                    {% block child_products_content %}
+                                        <table class='table table-striped table-bordered'>
+                                            <caption>
+                                                {% trans "Variants" %}
+                                                <button class="btn btn-primary pull-right{% if not product.can_be_parent %} disabled{% endif %}" name="action" type="submit" value="create-child" data-loading-text="{% trans 'Adding...' %}">
+                                                    <i class="icon-plus"></i>
+                                                    {% trans "Add variant" %}
+                                                </button>
+                                            </caption>
+                                            {% if children %}
+                                                <tr>
+                                                    <th>{% trans "Title" %}</th>
+                                                    <th>{% trans "Attributes" %}</th>
+                                                    <th>{% trans "Stock records" %}</th>
+                                                    <th>&nbsp;</th>
+                                                </tr>
+                                                {% for child in children %}
+                                                    <tr>
+                                                        <td>{{ child.get_title }}</td>
+                                                        <td>{{ child.attribute_summary }}</td>
+                                                        <td>{{ child.stockrecords.count }}</td>
+                                                        <td>
+                                                            <a href="{% url 'dashboard:catalogue-product' pk=child.id %}" class="btn btn-primary">
+                                                                {% trans "Edit" %}
+                                                            </a>
+                                                            <a href="{% url 'dashboard:catalogue-product-delete' pk=child.id %}" class="btn btn-danger">
+                                                                {% trans "Delete" %}
+                                                            </a>
+                                                        </td>
+                                                    </tr>
+                                                {% endfor %}
+                                            {% else %}
+                                                <tr>
+                                                    <td colspan="3">
+                                                        {% if product.can_be_parent %}
+                                                            {% trans 'This product does not have any variants.' %}
+                                                        {% else %}
+                                                            {% trans "One can't add variants to this product at this point." %}
+                                                            {% if product.has_stockrecords %}
+                                                                {% trans 'This is likely because this product still has stock records.' %}
+                                                            {% endif %}
                                                         {% endif %}
-                                                    {% endif %}
+                                                    </td>
+                                                </tr>
+                                            {% endif %}
+                                        </table>
+                                    {% endblock child_products_content %}
+                                </div>
+                            {% endwith %}
+                        {% endblock child_products %}
+
+                        {% block recommended_products %}
+                            <div class="tab-pane" id="product_recommended">
+                                {% block recommended_products_content %}
+                                    <table class="table table-striped table-bordered form-inline">
+                                        <caption>{% trans "Recommended products" %}</caption>
+                                        {{ recommended_formset.management_form }}
+                                        {{ recommended_formset.non_form_errors }}
+                                        {% for recommended_form in recommended_formset %}
+                                            <tr>
+                                                <td>
+                                                    {% include "dashboard/partials/form_fields_inline.html" with form=recommended_form %}
                                                 </td>
                                             </tr>
-                                        {% endif %}
+                                        {% endfor %}
                                     </table>
-                                {% endblock child_products_content %}
+                                {% endblock recommended_products_content %}
                             </div>
-                        {% endwith %}
-                    {% endblock child_products %}
-
-                    {% block recommended_products %}
-                        <div class="tab-pane" id="product_recommended">
-                            {% block recommended_products_content %}
-                                <table class="table table-striped table-bordered form-inline">
-                                    <caption>{% trans "Recommended products" %}</caption>
-                                    {{ recommended_formset.management_form }}
-                                    {{ recommended_formset.non_form_errors }}
-                                    {% for recommended_form in recommended_formset %}
-                                        <tr>
-                                            <td>
-                                                {% include "dashboard/partials/form_fields_inline.html" with form=recommended_form %}
-                                            </td>
-                                        </tr>
-                                    {% endfor %}
-                                </table>
-                            {% endblock recommended_products_content %}
-                        </div>
-                    {% endblock recommended_products %}
+                        {% endblock recommended_products %}
                     {%endblock tab_content%}
                 </div>
             </div>

--- a/src/oscar/templates/oscar/dashboard/catalogue/product_update.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/product_update.html
@@ -94,7 +94,7 @@
 
             <div class="col-md-9">
                 <div class="tab-content">
-                    {% block tab_content%}
+                    {% block tab_content %}
                         {% block product_details %}
                             <div class="tab-pane active" id="product_details">
                                 <div class="table-header">
@@ -309,7 +309,7 @@
                                 {% endblock recommended_products_content %}
                             </div>
                         {% endblock recommended_products %}
-                    {%endblock tab_content%}
+                    {% endblock tab_content %}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Adding new panes to Dashboard (for product/ product class) is easy for 'tabs' block but adding the new panes needs a new block inside the <div class='tab-content'> so that templates that inherit and extend to add new tabs can simply use

{% block tab_content%}
{{block.super}}
{# our new tabs html here #}
{%endblock%}

It is a very minor improvement but a convenience.