### PR TITLE
Exclude analytics receiver race condition exceptions from coverage reports

### DIFF
--- a/src/oscar/apps/analytics/receivers.py
+++ b/src/oscar/apps/analytics/receivers.py
@@ -38,7 +38,7 @@ def _update_counter(model, field_name, filter_kwargs, increment=1):
         if not affected:
             filter_kwargs[field_name] = increment
             model.objects.create(**filter_kwargs)
-    except IntegrityError:
+    except IntegrityError:      # pragma: no cover
         # get_or_create has a race condition (we should use upsert in supported)
         # databases. For now just ignore these errors
         logger.error(
@@ -68,7 +68,7 @@ def _record_user_order(user, order):
                 num_order_items=order.num_items,
                 total_spent=order.total_incl_tax,
                 date_last_order=order.date_placed)
-    except IntegrityError:
+    except IntegrityError:      # pragma: no cover
         logger.error(
             "IntegrityError in analytics when recording a user order.")
 


### PR DESCRIPTION
Otherwise we keep getting "unexpected coverage changes" whenever this code triggers in tests.

The underlying issue is that there is a race condition as noted in the comments.