### PR TITLE
Use a python2 virtualenv for building docs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ __pycache__
 /docs/build/*
 *.pdf
 TODO
+venv-docs
 
 # Test files
 .coverage

--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,10 @@ docs:
 	cd docs && make html
 
 test:
-	py.test 
+	py.test
 
 retest:
-	py.test --lf 
+	py.test --lf
 
 coverage:
 	py.test --cov=oscar --cov-report=term-missing
@@ -70,7 +70,7 @@ clean:
 	rm -rf nosetests.xml coverage.xml htmlcov *.egg-info *.pdf dist violations.txt
 
 todo:
-	# Look for areas of the code that need updating when some event has taken place (like 
+	# Look for areas of the code that need updating when some event has taken place (like
 	# Oscar dropping support for a Django version)
 	-grep -rnH TODO *.txt
 	-grep -rnH TODO src/oscar/apps/

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,12 @@ sandbox: install build_sandbox
 sandbox_image:
 	docker build -t django-oscar-sandbox:latest .
 
-docs:
-	cd docs && make html
+venv-docs:
+	virtualenv --python=$(shell which python3.5) venv-docs
+	venv-docs/bin/pip install -r docs/requirements.txt
+
+docs: venv-docs
+	make -C docs html SPHINXBUILD=$(PWD)/venv-docs/bin/sphinx-build
 
 test:
 	py.test

--- a/docs/source/internals/contributing/writing-documentation.rst
+++ b/docs/source/internals/contributing/writing-documentation.rst
@@ -6,6 +6,9 @@ Directory Structure
 -------------------
 
 The docs are built by calling ``make docs`` from your Oscar directory.
+Note: This requires Python < 3.6, as `transifex-client` doesn't support that yet.
+The ``make docs`` command currently uses `python3.5`.
+
 They live in ``/docs/source``. This directory structure is a
 simplified version of what Django does.
 


### PR DESCRIPTION
While updating documentation in #2571, i noticed that our `make docs` requires sphinx installed, but installing the docs requirements in a python3 virtualenv fails. 

To facilitate simple docs-generation, let's have the Makefile create the proper (python2) virtualenv. 

This has the added advantage of not interfering with the virtualenv you use for testing.