### PR TITLE
Make it easy to only override the formtag

### DIFF
--- a/src/oscar/templates/oscar/dashboard/catalogue/product_update.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/product_update.html
@@ -33,7 +33,10 @@
 {% block headertext %}{{ title }}{% endblock %}
 
 {% block dashboard_content %}
-    <form action="{% if request.GET.urlencode %}?{{ request.GET.urlencode }}{% endif %}" method="post" class="form-stacked wysiwyg fixed-actions" enctype="multipart/form-data" data-behaviour="affix-nav-errors" autocomplete="off">
+    {% block form %}
+        <form action="{% if request.GET.urlencode %}?{{ request.GET.urlencode }}{% endif %}" method="post" class="form-stacked wysiwyg fixed-actions" enctype="multipart/form-data" data-behaviour="affix-nav-errors" autocomplete="off">
+    {% endblock %}
+
         {% csrf_token %}
 
         {% if parent %}


### PR DESCRIPTION
In the product create/update dashboard view you would like to disable html5 client side validation
for example. This way you only need to override the form block.