### PR TITLE
Mark notifications as read only when the detail view is visited

### DIFF
--- a/src/oscar/apps/customer/notifications/views.py
+++ b/src/oscar/apps/customer/notifications/views.py
@@ -39,13 +39,7 @@ class InboxView(NotificationListView):
         for obj in qs:
             if not obj.is_read:
                 setattr(obj, 'is_new', True)
-        # ...but then mark everything as read.
-        self.mark_as_read(qs)
         return qs
-
-    def mark_as_read(self, queryset):
-        unread = queryset.filter(date_read=None)
-        unread.update(date_read=now())
 
 
 class ArchiveView(NotificationListView):
@@ -62,6 +56,13 @@ class DetailView(PageTitleMixin, generic.DetailView):
     template_name = 'customer/notifications/detail.html'
     context_object_name = 'notification'
     active_tab = 'notifications'
+
+    def get_object(self, queryset=None):
+        obj = super(DetailView, self).get_object()
+        if not obj.date_read:
+            obj.date_read = now()
+            obj.save()
+        return obj
 
     def get_page_title(self):
         """Append subject to page title"""

--- a/src/oscar/apps/customer/notifications/views.py
+++ b/src/oscar/apps/customer/notifications/views.py
@@ -32,14 +32,9 @@ class InboxView(NotificationListView):
     list_type = 'inbox'
 
     def get_queryset(self):
-        qs = self.model._default_manager.filter(
+        return self.model._default_manager.filter(
             recipient=self.request.user,
             location=self.model.INBOX)
-        # Mark unread notifications so they can be rendered differently...
-        for obj in qs:
-            if not obj.is_read:
-                setattr(obj, 'is_new', True)
-        return qs
 
 
 class ArchiveView(NotificationListView):

--- a/src/oscar/templates/oscar/customer/notifications/list.html
+++ b/src/oscar/templates/oscar/customer/notifications/list.html
@@ -18,24 +18,24 @@
                     {% for notification in notifications %}
                         <tr>
                             <td>
-                                <input type="checkbox" name="selected_notification" 
+                                <input type="checkbox" name="selected_notification"
                                 value="{{ notification.id }}"/>
                             </td>
                             <td>
-                                {% if notification.is_new %}
-                                    <i class="icon-envelope"></i>
-                                {% else %}
+                                {% if notification.is_read %}
                                     <i class="icon-inbox"></i>
+                                {% else %}
+                                    <i class="icon-envelope"></i>
                                 {% endif %}
                             </td>
                             <td>
-                                {% if notification.is_new %}
-                                    <strong>{{ notification.subject|safe }}</strong>
-                                {% else %}
+                                {% if notification.is_read %}
                                     {{ notification.subject|safe }} 
+                                {% else %}
+                                    <strong>{{ notification.subject|safe }}</strong>
                                 {% endif %}
                                 <br/>
-                                <em>{{ notification.date_sent }}</em> 
+                                <em>{{ notification.date_sent }}</em>
                             </td>
                             <td>
                                 <a href="{% url 'customer:notifications-detail' pk=notification.pk %}" class="btn btn-info btn-sm">{% trans 'View' %}</a>
@@ -48,7 +48,7 @@
                     {% endfor %}
                 </tbody>
             </table>
-            {% trans "With selected items:" %} 
+            {% trans "With selected items:" %}
             {% if list_type == 'inbox' %}
                 <button type="submit" class="btn btn-success" name="action" value="archive" data-loading-text="{% trans 'Archiving...' %}">{% trans "Archive" context 'verb' %}</button>
             {% endif %}

--- a/src/oscar/templates/oscar/customer/notifications/list.html
+++ b/src/oscar/templates/oscar/customer/notifications/list.html
@@ -25,11 +25,16 @@
                                 {% if notification.is_new %}
                                     <i class="icon-envelope"></i>
                                 {% else %}
-                                    <i class="icon-envelope"></i>
+                                    <i class="icon-inbox"></i>
                                 {% endif %}
                             </td>
                             <td>
-                                {{ notification.subject|safe }} <br/>
+                                {% if notification.is_new %}
+                                    <strong>{{ notification.subject|safe }}</strong>
+                                {% else %}
+                                    {{ notification.subject|safe }} 
+                                {% endif %}
+                                <br/>
                                 <em>{{ notification.date_sent }}</em> 
                             </td>
                             <td>

--- a/src/oscar/templates/oscar/partials/nav_accounts.html
+++ b/src/oscar/templates/oscar/partials/nav_accounts.html
@@ -40,7 +40,7 @@
                             <a href="{% url 'customer:notifications-inbox' %}">
                                 <i class="icon-user"></i>
                                 {% trans "Account" %}
-                                <span class="label label-important">{{ num_unread_notifications }}</span>
+                                <span class="label label-warning">{{ num_unread_notifications }}</span>
                             </a>
                         {% else %}
                             <a href="{% url 'customer:summary' %}"><i class="icon-user"></i> {% trans "Account" %}</a>

--- a/tests/functional/customer/test_notification.py
+++ b/tests/functional/customer/test_notification.py
@@ -1,6 +1,9 @@
 from oscar.test.testcases import WebTestCase
 from oscar.apps.customer.notifications import services
 from oscar.test.factories import UserFactory
+from django.utils.six.moves import http_client
+from django.core.urlresolvers import reverse
+from oscar.apps.customer.models import Notification
 
 
 class TestAUserWithUnreadNotifications(WebTestCase):
@@ -11,5 +14,18 @@ class TestAUserWithUnreadNotifications(WebTestCase):
 
     def test_can_see_them_in_page_header(self):
         homepage = self.app.get('/', user=self.user)
-        self.assertTrue('num_unread_notifications' in homepage.context)
         self.assertEqual(1, homepage.context['num_unread_notifications'])
+
+    def test_notification_list_view_shows_user_notifications(self):
+        response = self.app.get(reverse('customer:notifications-inbox'), user=self.user)
+        self.assertEqual(1, len(response.context['notifications']))
+        self.assertEqual(False, response.context['notifications'][0].is_read)
+
+    def test_notification_marked_as_read(self):
+        n = Notification.objects.first()
+        path = reverse('customer:notifications-detail', kwargs={'pk': n.id})
+        response = self.app.get(path, user=self.user)
+        # notification should be marked as read
+        self.assertEqual(http_client.OK, response.status_code)
+        n.refresh_from_db()
+        self.assertTrue(n.is_read)


### PR DESCRIPTION
Currently notifications are marked as read as soon as you visit the list view, which is not what a user would expect.

This is a rebase of #2570.

Will update the release notes separately - there are several other things we need to add which we can do in one go.