### PR TITLE
Add make target for test, Makefile-created virtualenv can be python3.5 / python3.6.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ __pycache__
 /docs/build/*
 *.pdf
 TODO
-venv-docs
+venv
 
 # Test files
 .coverage

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ sandbox_image:
 	docker build -t django-oscar-sandbox:latest .
 
 venv:
-	virtualenv --python=$(shell which python3.5) $(VENV)
+	virtualenv --python=$(shell which python3) $(VENV)
 	$(VENV)/bin/pip install -e .[test]
 	$(VENV)/bin/pip install -r docs/requirements.txt
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+VENV = venv
+PYTEST = $(PWD)/$(VENV)/bin/py.test
+
 # These targets are not files
 .PHONY: install sandbox docs coverage lint messages compiledmessages css clean sandbox_image
 
@@ -30,21 +33,22 @@ sandbox: install build_sandbox
 sandbox_image:
 	docker build -t django-oscar-sandbox:latest .
 
-venv-docs:
-	virtualenv --python=$(shell which python3.5) venv-docs
-	venv-docs/bin/pip install -r docs/requirements.txt
+venv:
+	virtualenv --python=$(shell which python3.5) $(VENV)
+	$(VENV)/bin/pip install -e .[test]
+	$(VENV)/bin/pip install -r docs/requirements.txt
 
-docs: venv-docs
-	make -C docs html SPHINXBUILD=$(PWD)/venv-docs/bin/sphinx-build
+docs: venv
+	make -C docs html SPHINXBUILD=$(PWD)/$(VENV)/bin/sphinx-build
 
-test:
-	py.test
+test: venv
+	$(PYTEST)
 
-retest:
-	py.test --lf
+retest: venv
+	$(PYTEST) --lf
 
-coverage:
-	py.test --cov=oscar --cov-report=term-missing
+coverage: venv
+	$(PYTEST) --cov=oscar --cov-report=term-missing
 
 lint:
 	flake8 src/oscar/

--- a/docs/source/internals/contributing/running-tests.rst
+++ b/docs/source/internals/contributing/running-tests.rst
@@ -8,9 +8,19 @@ Running tests
 Oscar uses pytest_ to run the tests.
 .. _pytest: http://pytest.org/latest/
 
+The fast way is::
+
+    $ make test
+
+This will create a virtualenv in `venv`, install the test dependencies and run py.test.
+
+Details
+~~~~~~~
+
 First we create a virtualenv and install the required dependencies::
 
-    $ mkvirtualenv oscar-tests
+    $ virtualenv venv
+    $ source venv/bin/activate
     $ pip install -e .[test]
 
 Then we invoke pytest using ::

--- a/docs/source/internals/contributing/running-tests.rst
+++ b/docs/source/internals/contributing/running-tests.rst
@@ -2,6 +2,14 @@
 Test suite
 ==========
 
+Testing requirements
+--------------------
+
+You'll need:
+
+- A running SQL server (PostgreSQL, or SQLite with `--sqlite` params)
+- python3.5 or python3.6
+
 Running tests
 -------------
 

--- a/docs/source/internals/contributing/writing-documentation.rst
+++ b/docs/source/internals/contributing/writing-documentation.rst
@@ -6,8 +6,9 @@ Directory Structure
 -------------------
 
 The docs are built by calling ``make docs`` from your Oscar directory.
-Note: This requires Python < 3.6, as `transifex-client` doesn't support that yet.
-The ``make docs`` command currently uses `python3.5`.
+Note: This requires Python 3.5 or 3.6, as `transifex-client` only supports these.
+The ``make docs`` command currently uses `python3`,
+so make sure it links to one of these versions.
 
 They live in ``/docs/source``. This directory structure is a
 simplified version of what Django does.


### PR DESCRIPTION
It should now be much easier to run the test (`make test` does everything). You can also still do it like before. The documentation is updated accordingly.

We reuse the docs virtualenv, so we rename that from venv-docs to venv.

Existing documentation was changed to also create a virtualenv (instead of using mkvirtualenv). This ensures you're in the same situation as when using the make command.