### PR TITLE
Drop Django 1.10 from test matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,21 +7,15 @@ matrix:
     - python: 2.7
       env: TOXENV=py27-django18
     - python: 2.7
-      env: TOXENV=py27-django110
-    - python: 2.7
       env: TOXENV=py27-django111
     - python: 3.3
       env: TOXENV=py33-django18
     - python: 3.4
       env: TOXENV=py34-django18
     - python: 3.4
-      env: TOXENV=py34-django110
-    - python: 3.4
       env: TOXENV=py34-django111
     - python: 3.5
       env: TOXENV=py35-django18
-    - python: 3.5
-      env: TOXENV=py35-django110
     - python: 3.5
       env: TOXENV=py35-django111
     - python: 3.6

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ sys.path.append(os.path.join(PROJECT_DIR, 'src'))
 from oscar import get_version  # noqa isort:skip
 
 install_requires = [
-    'django>=1.8.8,<1.12',
+    'django>=1.8,<1.12',
     # PIL is required for image fields, Pillow is the "friendly" PIL fork
     'pillow>=3.4.2',
     # We use the ModelFormSetView from django-extra-views for the basket page
@@ -97,7 +97,6 @@ setup(
         'Environment :: Web Environment',
         'Framework :: Django',
         'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
     py{27,33,34,35}-django18
-    py{27,34,35}-django110
     py{27,34,35,36}-django111
     py36-djangomaster
     lint
@@ -14,7 +13,6 @@ extras = test
 pip_pre = true
 deps =
     django18: django>=1.8,<1.9
-    django110: django>=1.10,<1.11
     django111: django>=1.11,<1.12
 
 
@@ -48,7 +46,7 @@ commands =
 basepython = python3.5
 deps =
     -r{toxinidir}/requirements.txt
-    django>=1.10,<1.11
+    django>=1.11,<1.12
 whitelist_externals = make
 commands =
     make build_sandbox


### PR DESCRIPTION
Django 1.10 reached end of life in December 2017.