### PR TITLE
Update date/time picker widgets to use template-based rendering.

### DIFF
--- a/docs/source/releases/v1.6.rst
+++ b/docs/source/releases/v1.6.rst
@@ -35,8 +35,6 @@ Removal of deprecated features
 
  - Removed the redundant ``OSCAR_PROMOTION_MERCHANDISING_BLOCK_TYPES`` setting.
 
- - Removed the redundant ``OSCAR_PROMOTION_MERCHANDISING_BLOCK_TYPES`` setting.
-
 Minor changes
 ~~~~~~~~~~~~~
  - The majority of the Oscar class imports now use dynamic loading, instead of
@@ -87,6 +85,9 @@ Minor changes
 
  - The Google Analytics tracking code provided by Oscar now uses ``gtag.js`` API
    instead of the deprecated ``analytics.js``.
+
+ - Oscar's ``TimePickerInput``, ``DatePickerInput`` and ``DateTimePickerInput``
+   now use templates for rendering.
 
 .. _incompatible_in_1.6:
 

--- a/src/oscar/forms/widgets.py
+++ b/src/oscar/forms/widgets.py
@@ -8,7 +8,6 @@ from django.forms.widgets import FileInput
 from django.template.loader import render_to_string
 from django.utils import formats, six
 from django.utils.encoding import force_text
-from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.six.moves import filter, map
 
@@ -139,16 +138,15 @@ def datetime_format_to_js_input_mask(format):
 
 class DateTimeWidgetMixin(object):
 
+    template_name = 'oscar/forms/widgets/date_time_picker.html'
+
     def get_format(self):
         return self.format or formats.get_format(self.format_key)[0]
 
-    def gett_attrs(self, attrs, format):
-        if not attrs:
-            attrs = {}
-
+    def build_attrs(self, base_attrs, extra_attrs=None):
+        attrs = super(DateTimeWidgetMixin, self).build_attrs(base_attrs, extra_attrs)
         attrs['data-inputmask'] = u"'mask': '{mask}'".format(
-            mask=datetime_format_to_js_input_mask(format))
-
+            mask=datetime_format_to_js_input_mask(self.get_format()))
         return attrs
 
 
@@ -159,26 +157,14 @@ class TimePickerInput(DateTimeWidgetMixin, forms.TimeInput):
     """
     format_key = 'TIME_INPUT_FORMATS'
 
-    def render(self, name, value, attrs=None, renderer=None):
-        format = self.get_format()
-        input = super(TimePickerInput, self).render(
-            name, value, self.gett_attrs(attrs, format))
-
-        attrs = {
+    def get_context(self, name, value, attrs):
+        ctx = super(TimePickerInput, self).get_context(name, value, attrs)
+        ctx['div_attrs'] = {
             'data-oscarWidget': 'time',
-            'data-timeFormat': datetime_format_to_js_time_format(format),
+            'data-timeFormat': datetime_format_to_js_time_format(self.get_format()),
         }
-
-        div = format_html(u'<div class="input-group date"{}>', flatatt(attrs))
-        return mark_safe(u'<div class="form-inline">'
-                         u' {div}'
-                         u'  {input}'
-                         u'  <span class="input-group-addon">'
-                         u'   <i class="icon-time glyphicon-time"></i>'
-                         u'  </span>'
-                         u' </div>'
-                         u'</div>'
-                         .format(div=div, input=input))
+        ctx['icon_classes'] = 'icon-time glyphicon-time'
+        return ctx
 
 
 class DatePickerInput(DateTimeWidgetMixin, forms.DateInput):
@@ -188,26 +174,14 @@ class DatePickerInput(DateTimeWidgetMixin, forms.DateInput):
     """
     format_key = 'DATE_INPUT_FORMATS'
 
-    def render(self, name, value, attrs=None, renderer=None):
-        format = self.get_format()
-        input = super(DatePickerInput, self).render(
-            name, value, self.gett_attrs(attrs, format))
-
-        attrs = {
+    def get_context(self, name, value, attrs):
+        ctx = super(DatePickerInput, self).get_context(name, value, attrs)
+        ctx['div_attrs'] = {
             'data-oscarWidget': 'date',
-            'data-dateFormat': datetime_format_to_js_date_format(format),
+            'data-dateFormat': datetime_format_to_js_date_format(self.get_format()),
         }
-
-        div = format_html(u'<div class="input-group date"{}>', flatatt(attrs))
-        return mark_safe(u'<div class="form-inline">'
-                         u' {div}'
-                         u'  {input}'
-                         u'  <span class="input-group-addon">'
-                         u'   <i class="icon-calendar glyphicon-calendar"></i>'
-                         u'  </span>'
-                         u' </div>'
-                         u'</div>'
-                         .format(div=div, input=input))
+        ctx['icon_classes'] = 'icon-calendar glyphicon-calendar'
+        return ctx
 
 
 class DateTimePickerInput(DateTimeWidgetMixin, forms.DateTimeInput):
@@ -219,7 +193,7 @@ class DateTimePickerInput(DateTimeWidgetMixin, forms.DateTimeInput):
     without localize=True.
 
     For localized widgets refer to
-    https://docs.djangoproject.com/en/1.6/topics/i18n/formatting/#creating-custom-format-files # noqa
+    https://docs.djangoproject.com/en/1.11/topics/i18n/formatting/#creating-custom-format-files # noqa
     instead to override the format.
     """
     format_key = 'DATETIME_INPUT_FORMATS'
@@ -231,26 +205,14 @@ class DateTimePickerInput(DateTimeWidgetMixin, forms.DateTimeInput):
         if not include_seconds and self.format:
             self.format = re.sub(':?%S', '', self.format)
 
-    def render(self, name, value, attrs=None, renderer=None):
-        format = self.get_format()
-        input = super(DateTimePickerInput, self).render(
-            name, value, self.gett_attrs(attrs, format))
-
-        attrs = {
+    def get_context(self, name, value, attrs):
+        ctx = super(DateTimePickerInput, self).get_context(name, value, attrs)
+        ctx['div_attrs'] = {
             'data-oscarWidget': 'datetime',
-            'data-datetimeFormat': datetime_format_to_js_datetime_format(format),
+            'data-datetimeFormat': datetime_format_to_js_datetime_format(self.get_format()),
         }
-
-        div = format_html(u'<div class="input-group date"{}>', flatatt(attrs))
-        return mark_safe(u'<div class="form-inline">'
-                         u' {div}'
-                         u'  {input}'
-                         u'  <span class="input-group-addon">'
-                         u'   <i class="icon-calendar glyphicon-calendar"></i>'
-                         u'  </span>'
-                         u' </div>'
-                         u'</div>'
-                         .format(div=div, input=input))
+        ctx['icon_classes'] = 'icon-calendar glyphicon-calendar'
+        return ctx
 
 
 class AdvancedSelect(forms.Select):

--- a/src/oscar/templates/oscar/forms/widgets/date_time_picker.html
+++ b/src/oscar/templates/oscar/forms/widgets/date_time_picker.html
@@ -1,0 +1,8 @@
+<div class="form-inline">
+    <div class="input-group date" {% for name, value in div_attrs.items %}{{ name }}="{{ value|stringformat:'s' }}"{% endfor %}>
+        {% include "django/forms/widgets/input.html" %}
+        <span class="input-group-addon">
+            <i class="{{ icon_classes }}"></i>
+        </span>
+    </div>
+</div>

--- a/tests/integration/forms/test_widget.py
+++ b/tests/integration/forms/test_widget.py
@@ -6,6 +6,75 @@ from django.test import TestCase
 from oscar.forms import widgets
 
 
+class TimePickerInputTestCase(TestCase):
+
+    def test_div_attrs_context(self):
+        i = widgets.TimePickerInput(format='%H:%M')
+        ctx = i.get_context('test_input', None, {})
+        self.assertEqual(ctx['div_attrs'], {
+            'data-oscarWidget': 'time',
+            'data-timeFormat': 'hh:ii',
+        })
+
+    def test_icon_classes_context(self):
+        i = widgets.TimePickerInput(format='%H:%M')
+        ctx = i.get_context('test_input', None, {})
+        self.assertEqual(ctx['icon_classes'], 'icon-time glyphicon-time')
+
+    def test_input_format_unicode(self):
+        # Check that the widget can handle unicode formats
+        i = widgets.TimePickerInput(format=u'τ-%H:%M')
+        time = datetime.time(10, 47)
+        html = i.render('time', time)
+        self.assertIn(u'value="τ-10:47"', html)
+
+
+class DatePickerInputTestCase(TestCase):
+
+    def test_div_attrs_context(self):
+        i = widgets.DatePickerInput(format='%d/%m/%Y')
+        ctx = i.get_context('test_input', None, {})
+        self.assertEqual(ctx['div_attrs'], {
+            'data-oscarWidget': 'date',
+            'data-dateFormat': 'dd/mm/yyyy',
+        })
+
+    def test_icon_classes_context(self):
+        i = widgets.DatePickerInput(format='%H:%M')
+        ctx = i.get_context('test_input', None, {})
+        self.assertEqual(ctx['icon_classes'], 'icon-calendar glyphicon-calendar')
+
+    def test_datepickerinput_format_unicode(self):
+        # Check that the widget can handle unicode formats
+        i = widgets.DatePickerInput(format=u'δ-%d/%m/%Y')
+        date = datetime.date(2017, 5, 1)
+        html = i.render('date', date)
+        self.assertIn(u'value="δ-01/05/2017"', html)
+
+
+class DateTimePickerInputTestCase(TestCase):
+
+    def test_div_attrs_context(self):
+        i = widgets.DateTimePickerInput(format='%d/%m/%Y %H:%M')
+        ctx = i.get_context('test_input', None, {})
+        self.assertEqual(ctx['div_attrs'], {
+            'data-oscarWidget': 'datetime',
+            'data-datetimeFormat': 'dd/mm/yyyy hh:ii',
+        })
+
+    def test_icon_classes_context(self):
+        i = widgets.DateTimePickerInput(format='%d/%m/%Y %H:%M')
+        ctx = i.get_context('test_input', None, {})
+        self.assertEqual(ctx['icon_classes'], 'icon-calendar glyphicon-calendar')
+
+    def test_datetimepickerinput_format_unicode(self):
+        # Check that the widget can handle unicode formats
+        i = widgets.DateTimePickerInput(format=u'δ-%d/%m/%Y %H:%M')
+        date = datetime.datetime(2017, 5, 1, 10, 57)
+        html = i.render('datetime', date)
+        self.assertIn(u'value="δ-01/05/2017 10:57"', html)
+
+
 class TestWidgetsDatetimeFormat(TestCase):
 
     def test_datetime_to_date_format_conversion(self):
@@ -23,27 +92,6 @@ class TestWidgetsDatetimeFormat(TestCase):
         )
         for format_, expected in format_testcases:
             self.assertEqual(widgets.datetime_format_to_js_time_format(format_), expected)
-
-    def test_timepickerinput_format_unicode(self):
-        # Check that the widget can handle unicode formats
-        i = widgets.TimePickerInput(format=u'τ-%H:%M')
-        time = datetime.time(10, 47)
-        html = i.render('time', time)
-        self.assertIn(u'value="τ-10:47"', html)
-
-    def test_datepickerinput_format_unicode(self):
-        # Check that the widget can handle unicode formats
-        i = widgets.DatePickerInput(format=u'δ-%d/%m/%Y')
-        date = datetime.date(2017, 5, 1)
-        html = i.render('date', date)
-        self.assertIn(u'value="δ-01/05/2017"', html)
-
-    def test_datetimepickerinput_format_unicode(self):
-        # Check that the widget can handle unicode formats
-        i = widgets.DateTimePickerInput(format=u'δ-%d/%m/%Y %H:%M')
-        date = datetime.datetime(2017, 5, 1, 10, 57)
-        html = i.render('datetime', date)
-        self.assertIn(u'value="δ-01/05/2017 10:57"', html)
 
 
 class AdvancedSelectWidgetTestCase(TestCase):


### PR DESCRIPTION
This allows us to reuse a single template for all three widgets (date, time, datetime).