### PR TITLE
Remove unnecessary webob dependency from oscar.test utils.

### DIFF
--- a/src/oscar/core/compat.py
+++ b/src/oscar/core/compat.py
@@ -10,6 +10,13 @@ from django.utils import six
 from oscar.core.loading import get_model
 
 
+try:
+    # Python 3
+    from http.cookies import _unquote
+except ImportError:
+    from Cookie import _unquote
+
+
 # A setting that can be used in foreign key declarations
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 try:
@@ -72,6 +79,13 @@ def existing_user_fields(fields):
 
 
 # Python3 compatibility layer
+
+def unquote_cookie(cookie_value):
+    """
+    Make sure a cookie value is unescaped from double quotes
+    """
+    return _unquote(cookie_value)
+
 
 """
 Unicode compatible wrapper for CSV reader and writer that abstracts away

--- a/src/oscar/test/utils.py
+++ b/src/oscar/test/utils.py
@@ -3,8 +3,6 @@ from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.sessions.backends.db import SessionStore
 from django.core.signing import Signer
 from django.test import RequestFactory as BaseRequestFactory
-from webob.compat import bytes_
-from webob.cookies import _unquote
 
 from oscar.core.loading import get_class, get_model
 
@@ -28,13 +26,3 @@ class RequestFactory(BaseRequestFactory):
         request.cookies_to_delete = []
 
         return request
-
-
-def extract_cookie_value(response_cookies, cookie_name):
-    """
-    Making sure cookie unescaped from double quotes when extracting from
-    test response using Webob approach of cookie parsing.
-    """
-    oscar_open_basket_cookie = bytes_(response_cookies[cookie_name])
-    oscar_open_basket_cookie = _unquote(oscar_open_basket_cookie)
-    return oscar_open_basket_cookie.decode('utf-8')

--- a/tests/functional/customer/test_history.py
+++ b/tests/functional/customer/test_history.py
@@ -2,12 +2,11 @@ from django.conf import settings
 from django.http import HttpRequest
 from django.urls import reverse
 
-from oscar.test.factories import create_product
-from oscar.core.compat import get_user_model
 from oscar.apps.customer import history
+from oscar.core.compat import get_user_model, unquote_cookie
 from oscar.templatetags.history_tags import get_back_button
+from oscar.test.factories import create_product
 from oscar.test.testcases import WebTestCase
-from oscar.test.utils import extract_cookie_value
 
 
 User = get_user_model()
@@ -26,7 +25,7 @@ class HistoryHelpersTest(WebTestCase):
     def test_id_gets_added_to_cookie(self):
         response = self.app.get(self.product.get_absolute_url())
         request = HttpRequest()
-        request.COOKIES[COOKIE_NAME] = extract_cookie_value(response.test_app.cookies, COOKIE_NAME)
+        request.COOKIES[COOKIE_NAME] = unquote_cookie(response.test_app.cookies[COOKIE_NAME])
         self.assertTrue(self.product.id in history.extract(request))
 
     def test_get_back_button(self):

--- a/tests/functional/test_basket.py
+++ b/tests/functional/test_basket.py
@@ -7,15 +7,14 @@ from django.urls import reverse
 from django.utils.six.moves import http_client
 from django.utils.translation import ugettext
 
-from oscar.test.factories import create_product
-from oscar.core.compat import get_user_model
-from oscar.test import factories
-from oscar.test.basket import add_product
-from oscar.test.utils import extract_cookie_value
 from oscar.apps.basket import reports
 from oscar.apps.basket.models import Basket
-from oscar.test.testcases import WebTestCase
 from oscar.apps.partner import strategy
+from oscar.core.compat import get_user_model, unquote_cookie
+from oscar.test import factories
+from oscar.test.basket import add_product
+from oscar.test.factories import create_product
+from oscar.test.testcases import WebTestCase
 
 
 User = get_user_model()
@@ -60,9 +59,7 @@ class AnonAddToBasketViewTests(WebTestCase):
         self.assertTrue('oscar_open_basket' in self.response.test_app.cookies)
 
     def test_price_is_recorded(self):
-        oscar_open_basket_cookie = extract_cookie_value(
-            self.response.test_app.cookies, 'oscar_open_basket'
-        )
+        oscar_open_basket_cookie = unquote_cookie(self.response.test_app.cookies['oscar_open_basket'])
         basket_id = oscar_open_basket_cookie.split(':')[0]
         basket = Basket.objects.get(id=basket_id)
         line = basket.lines.get(product=self.product)


### PR DESCRIPTION
The logic we were performing in `extract_cookie_value` is unnecessary - where we need to unquote cookie values we can just use `http.cookies._unquote` as Django itself does.

Fixes #2547.