### PR TITLE
Drop transifex-client from requirements.

### DIFF
--- a/docs/source/internals/contributing/writing-documentation.rst
+++ b/docs/source/internals/contributing/writing-documentation.rst
@@ -6,7 +6,6 @@ Directory Structure
 -------------------
 
 The docs are built by calling ``make docs`` from your Oscar directory.
-Note: This requires Python 3.5 or 3.6, as `transifex-client` only supports these.
 The ``make docs`` command currently uses `python3`,
 so make sure it links to one of these versions.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,6 @@ isort==4.3.4
 pyprof2calltree==1.4.3
 ipdb==0.11
 ipython==5.5.0
-transifex-client==0.13.1
 
 # Country data
 pycountry==17.9.23

--- a/transifex.sh
+++ b/transifex.sh
@@ -16,7 +16,7 @@ then
     echo "[https://www.transifex.com]
 hostname = https://www.transifex.com
 password = $TRANSIFEX_PASSWORD
-token =
+token = 
 username = oscar_bot" > ~/.transifexrc
     tx push --source --no-interactive
 fi


### PR DESCRIPTION
It is installed separately in transifex.sh for travis, and not required for developing on Oscar.