### PR TITLE
missing pagination on offer dashboard views

### DIFF
--- a/src/oscar/apps/dashboard/offers/views.py
+++ b/src/oscar/apps/dashboard/offers/views.py
@@ -1,5 +1,6 @@
 import json
 
+from django.conf import settings
 from django.contrib import messages
 from django.core import serializers
 from django.core.serializers.json import DjangoJSONEncoder
@@ -32,6 +33,7 @@ class OfferListView(ListView):
     context_object_name = 'offers'
     template_name = 'dashboard/offers/offer_list.html'
     form_class = OfferSearchForm
+    paginate_by = settings.OSCAR_DASHBOARD_ITEMS_PER_PAGE
 
     def get_queryset(self):
         qs = self.model._default_manager.exclude(
@@ -333,6 +335,7 @@ class OfferDetailView(ListView):
     model = OrderDiscount
     template_name = 'dashboard/offers/offer_detail.html'
     context_object_name = 'order_discounts'
+    paginate_by = settings.OSCAR_DASHBOARD_ITEMS_PER_PAGE
 
     def dispatch(self, request, *args, **kwargs):
         self.offer = get_object_or_404(ConditionalOffer, pk=kwargs['pk'])

--- a/src/oscar/apps/dashboard/ranges/views.py
+++ b/src/oscar/apps/dashboard/ranges/views.py
@@ -28,6 +28,7 @@ class RangeListView(ListView):
     model = Range
     context_object_name = 'ranges'
     template_name = 'dashboard/ranges/range_list.html'
+    paginate_by = settings.OSCAR_DASHBOARD_ITEMS_PER_PAGE
 
 
 class RangeCreateView(CreateView):
@@ -97,6 +98,7 @@ class RangeProductListView(BulkEditMixin, ListView):
     context_object_name = 'products'
     actions = ('remove_selected_products', 'add_products')
     form_class = RangeProductForm
+    paginate_by = settings.OSCAR_DASHBOARD_ITEMS_PER_PAGE
 
     def post(self, request, *args, **kwargs):
         self.object_list = self.get_queryset()

--- a/tests/integration/dashboard/test_offer_views.py
+++ b/tests/integration/dashboard/test_offer_views.py
@@ -1,0 +1,67 @@
+
+import pytest
+
+from oscar.apps.dashboard.offers import views as offer_views
+from oscar.apps.dashboard.ranges import views as range_views
+from oscar.core.loading import get_model
+from oscar.test.factories import catalogue, offer
+
+Range = get_model('offer', 'Range')
+ConditionalOffer = get_model('offer', 'ConditionalOffer')
+
+
+@pytest.fixture
+def many_ranges():
+    for i in range(0, 30):
+        offer.RangeFactory()
+    return Range.objects.all()
+
+
+@pytest.fixture
+def many_offers():
+    for i in range(0, 30):
+        offer.ConditionalOfferFactory(
+            name='Test offer %d' % i
+        )
+
+
+@pytest.fixture
+def range_with_products():
+    productrange = offer.RangeFactory()
+    for i in range(0, 30):
+        product = catalogue.ProductFactory()
+        productrange.add_product(product)
+    return productrange
+
+
+@pytest.mark.django_db
+class TestDashboardOffers:
+
+    def test_range_list_view(self, rf, many_ranges):
+        request = rf.get('/')
+        view = range_views.RangeListView.as_view()
+        response = view(request)
+        # if these are missing the pagination is broken
+        assert response.context_data['paginator']
+        assert response.context_data['page_obj']
+        assert response.status_code == 200
+
+    def test_offer_list_view(self, rf, many_offers):
+        request = rf.get('/')
+        view = offer_views.OfferListView.as_view()
+        response = view(request)
+        # if these are missing the pagination is broken
+        assert response.context_data['paginator']
+        assert response.context_data['page_obj']
+        assert response.status_code == 200
+
+    def test_range_product_list_view(self, rf, range_with_products):
+        view = range_views.RangeProductListView.as_view()
+        pk = range_with_products.pk
+
+        request = rf.get('/')
+        response = view(request, pk=pk)
+        # if these are missing the pagination is broken
+        assert response.context_data['paginator']
+        assert response.context_data['page_obj']
+        assert response.status_code == 200


### PR DESCRIPTION
during development of large ecommerce site we ran into an exception
when accessing the list of offers and ranges:

AttributeError 'NoneType' object has no attribute 'paginator'
django_rangepaginator/templatetags/rangepaginator.py in paginate at line 12

This PR fixes all cases I could find where this happens, but chances are
some views need the same fix.