### PR TITLE
Simplify and deprecate oscar.views.decorators.staff_member_required.

### DIFF
--- a/docs/source/releases/v1.6.rst
+++ b/docs/source/releases/v1.6.rst
@@ -181,5 +181,8 @@ The following features have been deprecated in this release:
   ``order.Line.line_price_excl_tax`` fields are deprecated and will be removed
   in Oscar 2.0.
 
+- ``oscar.views.decorators.staff_member_required`` is deprecated. Use
+  ``oscar.views.decorators.permissions_required(['is_staff'])`` instead.
+
 - Support for Django 1.8, 1.9 and 1.10 has been dropped in line with the
   Django project recommendation for third party apps.

--- a/src/oscar/views/decorators.py
+++ b/src/oscar/views/decorators.py
@@ -1,53 +1,16 @@
 from functools import wraps
 
-from django.contrib import messages
-from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.decorators import user_passes_test
-from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import render
 from django.urls import reverse_lazy
-from django.utils.six.moves.urllib import parse
-from django.utils.translation import ugettext_lazy as _
+
+from oscar.core.decorators import deprecated
 
 
+@deprecated
 def staff_member_required(view_func, login_url=None):
-    """
-    Ensure that the user is a logged-in staff member.
-
-    * If not authenticated, redirect to a specified login URL.
-    * If not staff, show a 403 page
-
-    This decorator is based on the decorator with the same name from
-    django.contrib.admin.views.decorators.  This one is superior as it allows a
-    redirect URL to be specified.
-    """
-    if login_url is None:
-        login_url = reverse_lazy('customer:login')
-
-    @wraps(view_func)
-    def _checklogin(request, *args, **kwargs):
-        if request.user.is_active and request.user.is_staff:
-            return view_func(request, *args, **kwargs)
-
-        # If user is not logged in, redirect to login page
-        if not request.user.is_authenticated:
-            # If the login url is the same scheme and net location then just
-            # use the path as the "next" url.
-            path = request.build_absolute_uri()
-            login_scheme, login_netloc = parse.urlparse(login_url)[:2]
-            current_scheme, current_netloc = parse.urlparse(path)[:2]
-            if ((not login_scheme or login_scheme == current_scheme) and
-                    (not login_netloc or login_netloc == current_netloc)):
-                path = request.get_full_path()
-
-            messages.warning(request, _("You must log in to access this page"))
-            return redirect_to_login(path, login_url, REDIRECT_FIELD_NAME)
-        else:
-            # User does not have permission to view this page
-            raise PermissionDenied
-
-    return _checklogin
+    return permissions_required(['is_staff'], login_url=login_url)(view_func)
 
 
 def check_permissions(user, permissions):

--- a/tests/integration/core/test_decorator.py
+++ b/tests/integration/core/test_decorator.py
@@ -1,11 +1,12 @@
 import warnings
 
 from django.contrib.auth.models import AnonymousUser, Permission
-from django.test import TestCase
+from django.core.exceptions import PermissionDenied
+from django.test import TestCase, RequestFactory
 
 from oscar.core.decorators import deprecated
 from oscar.test import factories
-from oscar.views.decorators import check_permissions
+from oscar.views.decorators import check_permissions, staff_member_required
 
 
 class TestPermissionsDecorator(TestCase):
@@ -36,6 +37,26 @@ class TestPermissionsDecorator(TestCase):
             check_permissions(user_with_perm, ['address.add_country']))
         self.assertFalse(
             check_permissions(user_without_perm, ['address.add_country']))
+
+    def test_staff_member_required_decorator(self):
+        staff_user = factories.UserFactory(is_staff=True)
+        non_staff_user = factories.UserFactory()
+        logged_out_user = AnonymousUser()
+
+        dummy_view = lambda request: True
+
+        request = RequestFactory().get('/')
+
+        request.user = staff_user
+        self.assertEqual(True, staff_member_required(dummy_view)(request))
+
+        request.user = non_staff_user
+        with self.assertRaises(PermissionDenied):
+            staff_member_required(dummy_view)(request)
+
+        request.user = logged_out_user
+        response = staff_member_required(dummy_view)(request)
+        self.assertEqual(response.status_code, 302)     # Redirect to login
 
 
 class TestDeprecatedDecorator(TestCase):


### PR DESCRIPTION
We stopped using this decorator in https://github.com/django-oscar/django-oscar/commit/344c9e5270f0729a45d393fed0987edfa6daf5b9#diff-4e8ddbf51a766c8a636cfe88894d0e07 (version 0.7) - it should have been deprecated at the time in favour of the new permissions decorator.

This patch deprecates the decorator and makes it wrap `permission_required`. I've added tests to make sure it still works correctly.