### PR TITLE
Remove redundant form_fields include from dashboard/users/detail.html

### DIFF
--- a/src/oscar/templates/oscar/dashboard/users/detail.html
+++ b/src/oscar/templates/oscar/dashboard/users/detail.html
@@ -88,7 +88,6 @@
                             <td>
                                 <form id="password_reset_form" action="{% url 'dashboard:user-password-reset' pk=customer.id %}" method="post" class="form-horizontal">
                                     {% csrf_token %}
-                                    {% include 'dashboard/partials/form_fields.html' %}
                                     <button type="submit" class="btn btn-primary btn-lg" data-loading-text="{% trans 'Sending...' %}">{% trans 'Send password reset email' %}</button>
                                 </form>
                             </td>


### PR DESCRIPTION
There is no `form` in the context of `dashboard.users.views.UserDetailView`, and so no fields to render. The password reset form has no fields. Leaving this there is problematic if you want to override this view and add a form to it...