### PR TITLE
Remove extra closing paragraph tag.

### DIFF
--- a/src/oscar/templates/oscar/checkout/thank_you.html
+++ b/src/oscar/templates/oscar/checkout/thank_you.html
@@ -26,7 +26,7 @@
         Your order has been placed and a confirmation email has been sent - your order number is
         <strong>{{ number }}</strong>.
         {% endblocktrans %}
-        {% trans "Please make a note of this reference or print this page and quote it in any communication with us regarding your order." %}</p>
+        {% trans "Please make a note of this reference or print this page and quote it in any communication with us regarding your order." %}
     </p>
 
     <div class="row shipping-payment">


### PR DESCRIPTION
Noticed an extra closing paragraph tag in the thank you template. Found this because Django's [`assertInHTML`](https://docs.djangoproject.com/en/2.0/topics/testing/tools/#django.test.SimpleTestCase.assertInHTML) raises `AssertionError`s on invalid html.