### PR TITLE
Remove unused OSCAR_SETTINGS setting

### DIFF
--- a/docs/source/releases/v1.6.rst
+++ b/docs/source/releases/v1.6.rst
@@ -106,6 +106,8 @@ Minor changes
    allowed quantity in it based on product availability and basket threshold
    (see :issue:`1412`).
 
+ - An unused setting ``OSCAR_SETTINGS`` was removed from ``oscar.core.defaults``.   
+
 .. _incompatible_in_1.6:
 
 Backwards incompatible changes in Oscar 1.6

--- a/src/oscar/defaults.py
+++ b/src/oscar/defaults.py
@@ -250,6 +250,3 @@ OSCAR_SEARCH_FACETS = {
 
 OSCAR_PROMOTIONS_ENABLED = True
 OSCAR_PRODUCT_SEARCH_HANDLER = None
-
-OSCAR_SETTINGS = dict(
-    [(k, v) for k, v in locals().items() if k.startswith('OSCAR_')])


### PR DESCRIPTION
`OSCAR_SETTINGS` just duplicates all of Oscar's settings into a dictionary, which is then not used anywhere. Looking back at the project history, it seems like it hasn't been used for a few years.