### PR TITLE
Replace insecure md5 hash generation in Order.verification_hash()

### DIFF
--- a/docs/source/releases/v1.6.rst
+++ b/docs/source/releases/v1.6.rst
@@ -109,12 +109,31 @@ Minor changes
    allowed quantity in it based on product availability and basket threshold
    (see :issue:`1412`).
 
- - An unused setting ``OSCAR_SETTINGS`` was removed from ``oscar.core.defaults``.   
+ - An unused setting ``OSCAR_SETTINGS`` was removed from ``oscar.core.defaults``.
 
 .. _incompatible_in_1.6:
 
 Backwards incompatible changes in Oscar 1.6
 -------------------------------------------
+
+ - The mechanism used to generate verification hashes for anonymous orders was
+   changed due to a security vulnerability.
+   ``oscar.apps.order.Order.verification_hash()`` now uses
+   ``django.core.signing`` instead of generating its own MD5 hash for
+    tracking URLs for anonymous orders.
+
+   Projects that allow anonymous checkout are **strongly recommended** to
+   generate a new ``SECRET_KEY``, as the vulnerability exposed the
+   ``SECRET_KEY`` to potential exposure due to weaknesses in the hash generation
+   algorithm.
+
+   As a result of this change, order verification hashes generated previously
+   will no longer validate by default, and URLs generated with the old hash will
+   not be accessible.
+
+   Projects that wish to allow validation of old hashes
+   must specify a ``OSCAR_DEPRECATED_ORDER_VERIFY_KEY`` setting that is equal to
+   the ``SECRET_KEY`` that was in use prior to applying this change.
 
  - ``oscar.apps.customer.auth_backends.EmailBackend`` now rejects inactive users
    (where ``User.is_active`` is ``False``).

--- a/src/oscar/apps/customer/app.py
+++ b/src/oscar/apps/customer/app.py
@@ -96,7 +96,7 @@ class CustomerApplication(Application):
             url(r'^orders/$',
                 login_required(self.order_history_view.as_view()),
                 name='order-list'),
-            url(r'^order-status/(?P<order_number>[\w-]*)/(?P<hash>\w+)/$',
+            url(r'^order-status/(?P<order_number>[\w-]*)/(?P<hash>[A-z0-9-_=:]+)/$',
                 self.anon_order_detail_view.as_view(), name='anon-order'),
             url(r'^orders/(?P<order_number>[\w-]*)/$',
                 login_required(self.order_detail_view.as_view()),

--- a/src/oscar/apps/customer/views.py
+++ b/src/oscar/apps/customer/views.py
@@ -604,7 +604,7 @@ class AnonymousOrderDetailView(generic.DetailView):
         # Check URL hash matches that for order to prevent spoof attacks
         order = get_object_or_404(self.model, user=None,
                                   number=self.kwargs['order_number'])
-        if self.kwargs['hash'] != order.verification_hash():
+        if not order.check_verification_hash(self.kwargs['hash']):
             raise http.Http404()
         return order
 

--- a/src/oscar/apps/order/abstract_models.py
+++ b/src/oscar/apps/order/abstract_models.py
@@ -1,7 +1,10 @@
+import hashlib
+import logging
 from collections import OrderedDict
 from decimal import Decimal as D
 
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.core.signing import BadSignature, Signer
 from django.db import models
 from django.db.models import Sum
@@ -20,6 +23,9 @@ from oscar.core.utils import get_default_currency
 from oscar.models.fields import AutoSlugField
 
 from . import exceptions
+
+
+logger = logging.getLogger('oscar.order')
 
 
 @python_2_unicode_compatible
@@ -303,11 +309,38 @@ class AbstractOrder(models.Model):
         signer = Signer(salt='oscar.apps.order.Order')
         return signer.sign(self.number)
 
+    def check_deprecated_verification_hash(self, hash_to_check):
+        """
+        Backward compatible check for md5 hashes that were generated in
+        Oscar 1.5 and lower.
+
+        This must explicitly be enabled by setting OSCAR_DEPRECATED_ORDER_VERIFY_KEY,
+        which must not be equal to SECRET_KEY - i.e., the project must
+        have changed its SECRET_KEY since this change was applied.
+
+        TODO: deprecate this method in Oscar 2.0, and remove it in Oscar 2.1.
+        """
+        old_verification_key = getattr(settings, 'OSCAR_DEPRECATED_ORDER_VERIFY_KEY', None)
+        if old_verification_key is None:
+            return False
+
+        if old_verification_key == settings.SECRET_KEY:
+            raise ImproperlyConfigured(
+                'OSCAR_DEPRECATED_ORDER_VERIFY_KEY cannot be equal to SECRET_KEY')
+
+        logger.warning('Using insecure md5 hashing for order URL hash verification.')
+        string_to_hash = '%s%s' % (self.number, old_verification_key)
+        order_hash = hashlib.md5(string_to_hash.encode('utf8')).hexdigest()
+        return constant_time_compare(order_hash, hash_to_check)
+
     def check_verification_hash(self, hash_to_check):
         """
         Checks the received verification hash against this order number.
         Returns False if the verification failed, True otherwise.
         """
+        if self.check_deprecated_verification_hash(hash_to_check):
+            return True
+
         signer = Signer(salt='oscar.apps.order.Order')
         try:
             signed_number = signer.unsign(hash_to_check)


### PR DESCRIPTION
Fixes #2667. The current approach is insecure as noted there.

**Important note**: this change is obviously not backward compatible (i.e., old anonymous order status URLs will break). I don't know how to prevent that while still patching the security issue. Note that in any case URLs become invalid every time you change the `SECRET_KEY` - i.e., it was easy to break the URLs even before. 

Ideally sites should be changing `SECRET_KEY` after this fix is released - in which case there is no hope of backward compatibility (which is annoying - but I can't see a way around it).

I wonder whether we should be using a different signing key (not `SECRET_KEY`) to avoid this problem in future. Feedback on this is appreciated.