### PR TITLE
Add a step to the tox lint env to check that i18n messages can be compiled

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,7 @@ deps =
 commands =
     flake8 src tests setup.py
     isort -q --recursive --diff src/ tests/
+    django-admin.py compilemessages
 
 
 [testenv:sandbox]


### PR DESCRIPTION
Previously we have had invalid translations in the repo which cannot be compiled - this adds a check to the tox/travis build to ensure that messages can be compiled.