### PR TITLE
Fix error in Anonymous mode, rest_framework Request user is None

### DIFF
--- a/src/oscar/apps/partner/strategy.py
+++ b/src/oscar/apps/partner/strategy.py
@@ -58,7 +58,7 @@ class Base(object):
     def __init__(self, request=None):
         self.request = request
         self.user = None
-        if request and request.user.is_authenticated:
+        if request and request.user and request.user.is_authenticated:
             self.user = request.user
 
     def fetch_for_product(self, product, stockrecord=None):


### PR DESCRIPTION
I tried to implement example from [](https://django-oscar-api.readthedocs.io/en/latest/usage/customizing_oscarapi.html)

In anonymous mode I had an 500 error:
`File ".../django-oscar/src/oscar/apps/partner/strategy.py", line 61, in __init__
    if request and request.user.is_authenticated:
AttributeError: 'NoneType' object has no attribute 'is_authenticated'`

partner.strategy is used a first time by basket.middleware and the request object is django.core.handlers.wsgi.WSGIRequest and user is a AnonymousUser object.

But in the example when we create the strategy object

`strategy = Selector().strategy(
            request=request, user=request.user)`

The request object is rest_framework.request.Request in anonymous mode, user is None.

The error is the same when we use `products/<id>/price` endpoint.
