### PR TITLE
Decouple price and availability in base strategies.

### DIFF
--- a/docs/source/releases/v1.6.rst
+++ b/docs/source/releases/v1.6.rst
@@ -115,6 +115,11 @@ Minor changes
 Backwards incompatible changes in Oscar 1.6
 -------------------------------------------
 
+ - Fixed a regression introduced in Oscar 1.5 (see :issue:`2664`) where
+   ``StockRequired.availability_policy`` was dependent on the product
+   having a price. Price and availability are now decoupled, and it is possible
+   to defer determination of a price until a product is added to the basket.  
+
  - ``oscar.apps.customer.auth_backends.EmailBackend`` now rejects inactive users
    (where ``User.is_active`` is ``False``).
 

--- a/src/oscar/apps/basket/abstract_models.py
+++ b/src/oscar/apps/basket/abstract_models.py
@@ -205,6 +205,11 @@ class AbstractBasket(models.Model):
         # Ensure that all lines are the same currency
         price_currency = self.currency
         stock_info = self.get_stock_info(product, options)
+
+        if not stock_info.price.exists:
+            raise ValueError(
+                "Strategy hasn't found a price for product %s" % product)
+
         if price_currency and stock_info.price.currency != price_currency:
             raise ValueError((
                 "Basket lines must all have the same currency. Proposed "

--- a/src/oscar/apps/basket/forms.py
+++ b/src/oscar/apps/basket/forms.py
@@ -212,6 +212,12 @@ class AddToBasketForm(forms.Form):
     def clean(self):
         info = self.basket.strategy.fetch_for_product(self.product)
 
+        # Check that a price was found by the strategy
+        if not info.price.exists:
+            raise forms.ValidationError(
+                _("This product cannot be added to the basket because a "
+                  "price could not be determined for it."))
+
         # Check currencies are sensible
         if (self.basket.currency and
                 info.price.currency != self.basket.currency):

--- a/src/oscar/apps/partner/strategy.py
+++ b/src/oscar/apps/partner/strategy.py
@@ -209,7 +209,7 @@ class StockRequired(object):
     """
 
     def availability_policy(self, product, stockrecord):
-        if not stockrecord or stockrecord.price_excl_tax is None:
+        if not stockrecord:
             return Unavailable()
         if not product.get_product_class().track_stock:
             return Available()

--- a/tests/integration/basket/test_forms.py
+++ b/tests/integration/basket/test_forms.py
@@ -193,13 +193,16 @@ class TestAddToBasketForm(TestCase):
             basket=basket, product=product, data=data)
         self.assertFalse(form.is_valid())
 
-    def test_for_empty_price_excl_tax(self):
+    def test_cannot_add_a_product_without_price(self):
         basket = factories.BasketFactory()
-        product_class = factories.ProductClassFactory(track_stock=False)
-        product = factories.ProductFactory(product_class=product_class, stockrecords=[])
-        factories.StockRecordFactory.build(price_excl_tax=None, product=product)
+        product = factories.create_product(price=None)
 
         data = {'quantity': 1}
-        form = forms.AddToBasketForm(basket=basket, product=product, data=data)
+        form = forms.AddToBasketForm(
+            basket=basket, product=product, data=data)
         self.assertFalse(form.is_valid())
-        self.assertEqual(form.errors['__all__'][0], 'unavailable')
+        self.assertEqual(
+            form.errors['__all__'][0],
+            'This product cannot be added to the basket because a price '
+            'could not be determined for it.',
+        )

--- a/tests/integration/basket/test_models.py
+++ b/tests/integration/basket/test_models.py
@@ -140,6 +140,11 @@ class TestAddingAProductToABasket(TestCase):
         with self.assertRaises(ValueError):
             self.basket.add(product)
 
+    def test_cannot_add_a_product_without_price(self):
+        product = factories.create_product(price=None)
+        with self.assertRaises(ValueError):
+            self.basket.add(product)
+
 
 class TestANonEmptyBasket(TestCase):
 


### PR DESCRIPTION
Revert the changes in #1913 that required a stock record to have `price_excl_tax` set in order to report the product as available, on the basis that price and availability should be kept separate.

Add separate checks to the basket form/add logic that checks at the time of
adding a product to the basket whether a price exists, and report an error if it doesn't. If a price is not found, then the add to basket form will raise a `ValidationError` - projects are responsible for ensuring that they supply a valid pricing strategy in such cases.

Fixes #2664.