### PR TITLE
Fixes ``is_quality_allowed``, updated docs with correct default setting

### DIFF
--- a/docs/source/ref/settings.rst
+++ b/docs/source/ref/settings.rst
@@ -330,7 +330,7 @@ The time to live for the basket cookie in seconds.
 ``OSCAR_MAX_BASKET_QUANTITY_THRESHOLD``
 ---------------------------------------
 
-Default: ``None``
+Default: ``10000``
 
 The maximum number of products that can be added to a basket at once.
 

--- a/src/oscar/apps/basket/abstract_models.py
+++ b/src/oscar/apps/basket/abstract_models.py
@@ -141,10 +141,11 @@ class AbstractBasket(models.Model):
         with the respect to basket quantity threshold.
         """
         basket_threshold = settings.OSCAR_MAX_BASKET_QUANTITY_THRESHOLD
+        max_allowed = 0
         if basket_threshold:
             total_basket_quantity = self.num_items
             max_allowed = basket_threshold - total_basket_quantity
-            return max_allowed, basket_threshold
+        return max_allowed, basket_threshold
 
     def is_quantity_allowed(self, qty):
         """


### PR DESCRIPTION
See https://github.com/django-oscar/django-oscar/blob/master/src/oscar/apps/basket/abstract_models.py#L155

It always expects two results. When ``OSCAR_MAX_BASKET_QUANTITY_THRESHOLD`` is set to something that evaluates to ``False`` this will raise a TypeError exception:
```python
File ".../oscarapi/views/basket.py", line 78, in validate
    allowed, message = basket.is_quantity_allowed(quantity)
File ".../oscar/apps/basket/abstract_models.py", line155, in is_quantity_allowed
    max_allowed, basket_threshold = self.max_allowed_quantity()
TypeError: 'NoneType' object is not iterable
```

In the documentation the default value is set to ``None``. However in https://github.com/django-oscar/django-oscar/blob/master/src/oscar/defaults.py#L17 it's set to 10000. So I updated the documentation./