### PR TITLE
Add phonenumbers dependency to setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ install_requires = [
     # For manipulating search URLs
     'purl>=0.7',
     # For phone number field
+    'phonenumbers',
     'django-phonenumber-field>=2.0,<2.1',
     # Used for oscar.test.contextmanagers.mock_signal_receiver
     'mock>=1.0.1,<3.0',


### PR DESCRIPTION
We cannot rely on this being installed by django-phonenumber-field. See https://github.com/django-oscar/django-oscar/issues/2681.

Fixes #2681.