### PR TITLE
Update ModelFormSetView subclasses to use new factory_kwargs attribute.

### DIFF
--- a/docs/source/releases/v1.6.rst
+++ b/docs/source/releases/v1.6.rst
@@ -118,7 +118,7 @@ Backwards incompatible changes in Oscar 1.6
  - Fixed a regression introduced in Oscar 1.5 (see :issue:`2664`) where
    ``StockRequired.availability_policy`` was dependent on the product
    having a price. Price and availability are now decoupled, and it is possible
-   to defer determination of a price until a product is added to the basket.  
+   to defer determination of a price until a product is added to the basket.
 
  - ``oscar.apps.customer.auth_backends.EmailBackend`` now rejects inactive users
    (where ``User.is_active`` is ``False``).
@@ -155,6 +155,10 @@ Backwards incompatible changes in Oscar 1.6
  - ``oscar.forms.widgets.RemoteSelect`` was updated to work with version 4 of
    select2. Instead of rendering a hidden input it now renders a normal
    ``select`` element.
+
+ - The django-extra-views dependency was upgraded to version 0.11, and the
+   basket views that rely on ``extra_views.ModelFormSetView`` updated to use the
+   new factory_kwargs attribute.
 
  - jQuery UI was removed from Oscar's static files. Projects that require it
    should install it at the project level.

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ install_requires = [
     # PIL is required for image fields, Pillow is the "friendly" PIL fork
     'pillow>=4.0',
     # We use the ModelFormSetView from django-extra-views for the basket page
-    'django-extra-views>=0.2,<0.11',
+    'django-extra-views>=0.11,<0.12',
     # Search support
     'django-haystack>=2.5.0,<3.0.0',
     # Treebeard is used for categories

--- a/src/oscar/apps/basket/views.py
+++ b/src/oscar/apps/basket/views.py
@@ -34,8 +34,10 @@ class BasketView(ModelFormSetView):
     basket_model = get_model('basket', 'Basket')
     formset_class = BasketLineFormSet
     form_class = BasketLineForm
-    extra = 0
-    can_delete = True
+    factory_kwargs = {
+        'extra': 0,
+        'can_delete': True
+    }
     template_name = 'basket/basket.html'
 
     def get_formset_kwargs(self):
@@ -416,8 +418,10 @@ class SavedView(ModelFormSetView):
     basket_model = get_model('basket', 'basket')
     formset_class = SavedLineFormSet
     form_class = SavedLineForm
-    extra = 0
-    can_delete = True
+    factory_kwargs = {
+        'extra': 0,
+        'can_delete': True
+    }
 
     def get(self, request, *args, **kwargs):
         return redirect('basket:summary')


### PR DESCRIPTION
Support for the old-style attributes was dropped in django-extra-views 0.11 (see [changelog](https://github.com/AndrewIngram/django-extra-views/blob/master/CHANGELOG.rst))

Also pin the version in setup.py as the package does not use semantic versioning (i.e, there are breaking changes between 0.x releases).

Fixes #2688.