### PR TITLE
Fix description of the `add_product` method of the `Basket` model

### DIFF
--- a/src/oscar/apps/basket/abstract_models.py
+++ b/src/oscar/apps/basket/abstract_models.py
@@ -186,9 +186,6 @@ class AbstractBasket(models.Model):
         """
         Add a product to the basket
 
-        'stock_info' is the price and availability data returned from
-        a partner strategy class.
-
         The 'options' list should contains dicts with keys 'option' and 'value'
         which link the relevant product.Option model and string value
         respectively.


### PR DESCRIPTION
The `stock_info` attribute was removed from `add_product` method's signature at 05363f6854f179ee1a96511661302980be50ca6e, but it wasn't removed from the description. So it makes [the docs](https://django-oscar.readthedocs.io/en/latest/ref/apps/basket.html#oscar.apps.basket.abstract_models.AbstractBasket.add) a bit confusing.