### PR TITLE
Fix validation of empty/missing phone_number field in PhoneNumberMixin.

### DIFF
--- a/docs/source/releases/v1.6.rst
+++ b/docs/source/releases/v1.6.rst
@@ -110,6 +110,8 @@ Minor changes
 
  - An unused setting ``OSCAR_SETTINGS`` was removed from ``oscar.core.defaults``.
 
+ - Fixed ``PhoneNumberMixin``s handling of empty phone number fields in forms.
+
 .. _incompatible_in_1.6:
 
 Backwards incompatible changes in Oscar 1.6

--- a/src/oscar/forms/mixins.py
+++ b/src/oscar/forms/mixins.py
@@ -63,7 +63,7 @@ class PhoneNumberMixin(object):
             self.region_code = self.country.iso_3166_1_a2
 
     def clean_phone_number_field(self, field_name):
-        number = self.cleaned_data[field_name]
+        number = self.cleaned_data.get(field_name)
 
         # Empty
         if number in validators.EMPTY_VALUES:

--- a/tests/integration/core/test_mixins.py
+++ b/tests/integration/core/test_mixins.py
@@ -1,8 +1,11 @@
 from django import forms
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
+from oscar.apps.address.forms import AbstractAddressForm
 from oscar.apps.address.models import UserAddress
+from oscar.apps.order.models import ShippingAddress
 from oscar.forms.mixins import PhoneNumberMixin
+from oscar.test.factories import CountryFactory
 
 
 class PhoneNumberMixinTestCase(TestCase):
@@ -62,3 +65,89 @@ class PhoneNumberMixinTestCase(TestCase):
         field = form.fields['phone_number']
         self.assertEqual(field.label, 'Special number')
         self.assertEqual(field.help_text, 'Special help text')
+
+    @override_settings(OSCAR_REQUIRED_ADDRESS_FIELDS=('phone_number',))
+    def test_required_empty_field_raises_validation_error(self):
+
+        class TestForm(PhoneNumberMixin, AbstractAddressForm):
+            phone_number_fields = {
+                'phone_number': {
+                    'required': True,
+                    'help_text': '',
+                    'max_length': 32,
+                    'label': 'Phone number'
+                }
+            }
+
+            class Meta:
+                model = ShippingAddress
+                fields = ['country', 'phone_number', 'postcode']
+
+        CountryFactory(iso_3166_1_a2='GB', is_shipping_country=True)
+        form = TestForm(data={'phone_number': '', 'country': 'GB', 'postcode': 'WW1 2BB'})
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors['phone_number'], ['This field is required.'])
+
+    @override_settings(OSCAR_REQUIRED_ADDRESS_FIELDS=[])
+    def test_optional_empty_field_validates(self):
+
+        class TestForm(PhoneNumberMixin, AbstractAddressForm):
+            phone_number_fields = {
+                'phone_number': {
+                    'required': False,
+                    'help_text': '',
+                    'max_length': 32,
+                    'label': 'Phone number'
+                }
+            }
+
+            class Meta:
+                model = ShippingAddress
+                fields = ['country', 'phone_number', 'postcode']
+
+        CountryFactory(iso_3166_1_a2='GB', is_shipping_country=True)
+        form = TestForm(data={'phone_number': '', 'country': 'GB', 'postcode': 'WW1 2BB'})
+        self.assertTrue(form.is_valid())
+
+    @override_settings(OSCAR_REQUIRED_ADDRESS_FIELDS=[])
+    def test_invalid_number_fails_validation(self):
+
+        class TestForm(PhoneNumberMixin, AbstractAddressForm):
+            phone_number_fields = {
+                'phone_number': {
+                    'required': False,
+                    'help_text': '',
+                    'max_length': 32,
+                    'label': 'Phone number'
+                }
+            }
+
+            class Meta:
+                model = ShippingAddress
+                fields = ['country', 'phone_number', 'postcode']
+
+        CountryFactory(iso_3166_1_a2='GB', is_shipping_country=True)
+        form = TestForm(data={'phone_number': '123456', 'country': 'GB', 'postcode': 'WW1 2BB'})
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors['phone_number'], ['This is not a valid local phone format for UNITED KINGDOM.'])
+
+    @override_settings(OSCAR_REQUIRED_ADDRESS_FIELDS=[])
+    def test_valid_number_passes_validation(self):
+
+        class TestForm(PhoneNumberMixin, AbstractAddressForm):
+            phone_number_fields = {
+                'phone_number': {
+                    'required': False,
+                    'help_text': '',
+                    'max_length': 32,
+                    'label': 'Phone number'
+                }
+            }
+
+            class Meta:
+                model = ShippingAddress
+                fields = ['country', 'phone_number', 'postcode']
+
+        CountryFactory(iso_3166_1_a2='GB', is_shipping_country=True)
+        form = TestForm(data={'phone_number': '02089001234', 'country': 'GB', 'postcode': 'WW1 2BB'})
+        self.assertTrue(form.is_valid())


### PR DESCRIPTION
If a `phone_number` field is missing or empty, then `PhoneNumberMixin.clean()` fails with a key error because the field does not exist in `cleaned_data`. This patch fixes the `clean_phone_number_field()` method to only attempt to clean a field if it exists in `cleaned_data`.

Also added more comprehensive tests for the validation logic in the mixin, to ensure that required/optional phone number fields are correctly handled.