### PR TITLE
Drop the use of empty and . values for the form action attribute

### DIFF
--- a/docs/source/releases/v2.0.rst
+++ b/docs/source/releases/v2.0.rst
@@ -29,6 +29,8 @@ Removal of deprecated features
 
 Minor changes
 ~~~~~~~~~~~~~
+ - Dropped ``action=""`` and ``action="."`` attributes, following the lead of Django
+   and as per the HTML5 specification.
 
 Dependency changes
 ------------------

--- a/sandbox/templates/gateway/form.html
+++ b/sandbox/templates/gateway/form.html
@@ -16,7 +16,7 @@
 {% endblock %}
 
 {% block content %}
-    <form action="." method="post">
+    <form method="post">
         <p>{% trans "Let us know your email address and we'll create a dashboard user for you and email you the details." %}</p>
         {% csrf_token %}
         {% include 'partials/form_fields.html' with form=form %}

--- a/src/oscar/templates/README.rst
+++ b/src/oscar/templates/README.rst
@@ -6,7 +6,7 @@ Forms
 
 Forms should be marked-up as::
 
-    <form method="post" action="." class="form-horizontal">
+    <form method="post" class="form-horizontal">
         {% csrf_token %}
         {% include 'partials/form_fields.html' %}
         <div class="form-group col-sm-offset-4 col-sm-8">
@@ -19,7 +19,7 @@ The ``.col-sm-offset-4`` class aligns the buttons with the fields.
 
 Alternatively, use::
     
-    <form method="post" action="." class="form-horizontal">
+    <form method="post" class="form-horizontal">
         {% csrf_token %}
         {% include 'partials/form_fields.html' %}
         <div class="control-group">

--- a/src/oscar/templates/oscar/basket/partials/basket_content.html
+++ b/src/oscar/templates/oscar/basket/partials/basket_content.html
@@ -35,7 +35,7 @@
     {% endblock %}
 
     {% block basket_form_main %}
-        <form action="." method="post" class="basket_summary" id="basket_formset">
+        <form method="post" class="basket_summary" id="basket_formset">
             {% csrf_token %}
             {{ formset.management_form }}
 

--- a/src/oscar/templates/oscar/catalogue/reviews/review_form.html
+++ b/src/oscar/templates/oscar/catalogue/reviews/review_form.html
@@ -3,7 +3,7 @@
 
 {% block product_review %}
     <div id="addreview" class="review_add">
-        <form id="add_review_form" method="post" action="./#addreview">
+        <form id="add_review_form" method="post" action="#addreview">
             <fieldset>
                 <legend>{% trans "Leave a product review" %}</legend>
                 {% csrf_token %}

--- a/src/oscar/templates/oscar/catalogue/reviews/review_list.html
+++ b/src/oscar/templates/oscar/catalogue/reviews/review_list.html
@@ -36,7 +36,7 @@
         {% include 'catalogue/reviews/review_product.html' %}
 
         {% if reviews %}
-            <form action="." method="get" class="form-inline">
+            <form method="get" class="form-inline">
                 {% for field in form %}
                     {{ field.label }}
                     {{ field }}

--- a/src/oscar/templates/oscar/checkout/gateway.html
+++ b/src/oscar/templates/oscar/checkout/gateway.html
@@ -15,7 +15,7 @@
 
 {% block content %}
 
-    <form action="." method="post" class="form-stacked well">
+    <form method="post" class="form-stacked well">
         {% csrf_token %}
         {{ form.non_field_errors }}
 

--- a/src/oscar/templates/oscar/checkout/user_address_delete.html
+++ b/src/oscar/templates/oscar/checkout/user_address_delete.html
@@ -17,7 +17,7 @@
 {% block checkout_title %}{% trans "Delete address?" %}{% endblock %}
 
 {% block shipping_address %}
-    <form action="." method="post" id="delete_address_{{ object.id }}">
+    <form method="post" id="delete_address_{{ object.id }}">
         {% csrf_token %}
         <div class="well">
             <address>

--- a/src/oscar/templates/oscar/checkout/user_address_form.html
+++ b/src/oscar/templates/oscar/checkout/user_address_form.html
@@ -18,7 +18,7 @@
 
 {% block shipping_address %}
     <div class="well">
-        <form id="update_user_address" action="." method="post" class="form form-horizontal">
+        <form id="update_user_address" method="post" class="form form-horizontal">
             {% csrf_token %}
             {% include "partials/form_fields.html" with form=form style='horizontal' %}
             <div class="form-group">

--- a/src/oscar/templates/oscar/customer/alerts/alert_list.html
+++ b/src/oscar/templates/oscar/customer/alerts/alert_list.html
@@ -5,7 +5,7 @@
     {% if not alerts %}
         <p>{% trans "You do not have any active alerts for out-of-stock products." %}</p>
     {% else %}
-        <form action="." method="post" id="alerts_form">
+        <form method="post" id="alerts_form">
             {% csrf_token %}
             <table class="table table-striped table-bordered">
                 <tr>

--- a/src/oscar/templates/oscar/customer/order/order_list.html
+++ b/src/oscar/templates/oscar/customer/order/order_list.html
@@ -20,7 +20,7 @@
     {% if orders or form.is_bound %}
         <div class="well">
             <h2>{% trans "Filter" %}</h2>
-            <form action="." method="get" class="form-horizontal">
+            <form method="get" class="form-horizontal">
                 {% include "partials/form_fields.html" with form=form style='horizontal' %}
                 <div class="form-group">
                     <div class="col-sm-offset-4 col-sm-8">

--- a/src/oscar/templates/oscar/customer/profile/change_password_form.html
+++ b/src/oscar/templates/oscar/customer/profile/change_password_form.html
@@ -2,5 +2,5 @@
 {% load i18n %}
 
 {% block tabcontent %}
-    {% include 'partials/form.html' with form_id="change_password_form" action="." %}
+    {% include 'partials/form.html' with form_id="change_password_form" %}
 {% endblock tabcontent %}

--- a/src/oscar/templates/oscar/customer/profile/profile_delete.html
+++ b/src/oscar/templates/oscar/customer/profile/profile_delete.html
@@ -3,7 +3,7 @@
 
 {% block tabcontent %}
     <p>{% trans "Please confirm your password to delete your profile." %}</p>
-    <form id="delete_profile_form" action="." method="post" class="form-horizontal">
+    <form id="delete_profile_form" method="post" class="form-horizontal">
         {% csrf_token %}
         {% include "partials/form_fields.html" %}
         <div class="alert alert-warning">

--- a/src/oscar/templates/oscar/customer/profile/profile_form.html
+++ b/src/oscar/templates/oscar/customer/profile/profile_form.html
@@ -2,5 +2,5 @@
 {% load i18n %}
 
 {% block tabcontent %}
-    {% include 'partials/form.html' with form_id="profile_form" action="." %}
+    {% include 'partials/form.html' with form_id="profile_form" %}
 {% endblock tabcontent %}

--- a/src/oscar/templates/oscar/customer/registration.html
+++ b/src/oscar/templates/oscar/customer/registration.html
@@ -22,7 +22,7 @@
 {% block content %}
     <div class="row">
         <div class="col-sm-6 register_form">
-            <form id="register_form" action="." method="post" class="form-stacked">
+            <form id="register_form" method="post" class="form-stacked">
                 {% csrf_token %}
                 {% include "partials/form_fields.html"  %}
                 <button name="registration_submit" type="submit" value="Register" class="btn btn-primary btn-lg" data-loading-text="{%trans 'Registering...' %}">{% trans 'Register' %}</button>

--- a/src/oscar/templates/oscar/customer/wishlists/wishlists_delete.html
+++ b/src/oscar/templates/oscar/customer/wishlists/wishlists_delete.html
@@ -20,7 +20,7 @@
 {% endblock %}
 
 {% block tabcontent %}
-    <form action="." method="post">
+    <form method="post">
         {% csrf_token %}
         <p>
             {% blocktrans with name=wishlist.name %}

--- a/src/oscar/templates/oscar/customer/wishlists/wishlists_form.html
+++ b/src/oscar/templates/oscar/customer/wishlists/wishlists_form.html
@@ -23,7 +23,7 @@
 {% endblock %}
 
 {% block tabcontent %}
-    <form action="." method="post" data-behaviours="lock">
+    <form method="post" data-behaviours="lock">
         {% csrf_token %}
         {% if not wishlist %}
             <p>{% trans "What should your new wish list be called?" %}</p>

--- a/src/oscar/templates/oscar/dashboard/catalogue/attribute_option_group_delete.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/attribute_option_group_delete.html
@@ -44,7 +44,7 @@
         <div class="table-header">
             <h2>{% trans "Delete Attribute Option Group" %}</h2>
         </div>
-        <form action="." method="post" class="well">
+        <form method="post" class="well">
             {% csrf_token %}
             {% if is_popup %}<input type="hidden" name="{{ is_popup_var }}" value="1" />{% endif %}
             {% if not is_popup %}

--- a/src/oscar/templates/oscar/dashboard/catalogue/attribute_option_group_list.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/attribute_option_group_list.html
@@ -25,7 +25,7 @@
 {% block dashboard_content %}
     {% if attribute_option_groups %}
         {% block product_list %}
-            <form action="." method="post">
+            <form method="post">
                 {% csrf_token %}
                 {% render_table attribute_option_groups %}
             </form>

--- a/src/oscar/templates/oscar/dashboard/catalogue/category_delete.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/category_delete.html
@@ -23,7 +23,7 @@
     <div class="table-header">
         <h2>{% trans "Delete category" %}</h2>
     </div>
-    <form action="." method="post" class="well">
+    <form method="post" class="well">
         {% csrf_token %}
         {{ form }}
         {% blocktrans with name=object.name %}

--- a/src/oscar/templates/oscar/dashboard/catalogue/product_class_delete.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/product_class_delete.html
@@ -26,7 +26,7 @@
         <div class="table-header">
             <h2>{% trans "Delete product type" %}</h2>
         </div>
-        <form action="." method="post" class="well">
+        <form method="post" class="well">
             {% csrf_token %}
             {{ form }}
             <p>

--- a/src/oscar/templates/oscar/dashboard/catalogue/product_delete.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/product_delete.html
@@ -29,7 +29,7 @@
     <div class="table-header">
         <h2>{{ title }}</h2>
     </div>
-    <form action="." method="post" class="well">
+    <form method="post" class="well">
         {% csrf_token %}
 
         <p>

--- a/src/oscar/templates/oscar/dashboard/catalogue/product_list.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/product_list.html
@@ -44,7 +44,7 @@
             <h3><i class="icon-search icon-large"></i>{% trans "Search Products" %}</h3>
         </div>
         <div class="well">
-            <form action="." method="get" class="form-inline">
+            <form method="get" class="form-inline">
                 {% comment %}
                     Add the current query string to the search form so that the
                     sort order is not reset when searching.
@@ -63,7 +63,7 @@
 
     {% if products %}
         {% block product_list %}
-            <form action="." method="post">
+            <form method="post">
                 {% csrf_token %}
                 {% render_table products %}
             </form>

--- a/src/oscar/templates/oscar/dashboard/comms/detail.html
+++ b/src/oscar/templates/oscar/dashboard/comms/detail.html
@@ -30,7 +30,7 @@
 {% block dashboard_content %}
 
 
-    <form method="post" action="." class="form-stacked">
+    <form method="post" class="form-stacked">
         <div class="tabbable dashboard">
             {% if preview %}
                 <ul class="nav nav-tabs">

--- a/src/oscar/templates/oscar/dashboard/offers/offer_delete.html
+++ b/src/oscar/templates/oscar/dashboard/offers/offer_delete.html
@@ -27,7 +27,7 @@
 {% endblock %}
 
 {% block dashboard_content %}
-    <form action="." method="post">
+    <form method="post">
         {% csrf_token %}
         <p>{% trans "Are you sure you want to delete this offer?" %}</p>
         <div class="form-actions">

--- a/src/oscar/templates/oscar/dashboard/offers/offer_detail.html
+++ b/src/oscar/templates/oscar/dashboard/offers/offer_detail.html
@@ -22,7 +22,7 @@
 
 {% block header %}
     <div class="page-header">
-        <form id="status_form" class="pull-right" method="post" action=".">
+        <form id="status_form" class="pull-right" method="post">
             {% csrf_token %}
             {% if offer.is_suspended %}
                 <button type="submit" class="btn btn-success" name="unsuspend" data-loading-text="{% trans 'Reinstating...' %}">{% trans "Reinstate offer" %}</button>

--- a/src/oscar/templates/oscar/dashboard/offers/offer_list.html
+++ b/src/oscar/templates/oscar/dashboard/offers/offer_list.html
@@ -26,13 +26,13 @@
 
 {% block dashboard_content %}
     <div class="well">
-        <form action="." method="get" class="form-inline">
+        <form method="get" class="form-inline">
             {% include 'dashboard/partials/form_fields_inline.html' with form=form %}
             <button type="submit" class="btn btn-primary" data-loading-text="{% trans 'Searching...' %}">{% trans "Search" %}</button>
         </form>
     </div>
 
-    <form action="." method="post" class="order_table">
+    <form method="post" class="order_table">
         {% csrf_token %}
         <table class="table table-striped table-bordered">
             <caption>

--- a/src/oscar/templates/oscar/dashboard/offers/step_form.html
+++ b/src/oscar/templates/oscar/dashboard/offers/step_form.html
@@ -52,7 +52,7 @@
             {% endblock %}
         </div>
         <div class="{% if session_offer %}col-md-6{% else %}col-md-9{% endif %}">
-            <form action="." method="post" class="form-stacked wysiwyg fixed-actions">
+            <form method="post" class="form-stacked wysiwyg fixed-actions">
                 <div class="table-header">
                     <h3>{{ title }}</h3>
                 </div>

--- a/src/oscar/templates/oscar/dashboard/orders/order_detail.html
+++ b/src/oscar/templates/oscar/dashboard/orders/order_detail.html
@@ -96,7 +96,7 @@
                 <div class="table-header">
                     <h3>{% trans "Items ordered" %}</h3>
                 </div>
-                <form id="order_lines_form" action="." method="post" class="form-inline">
+                <form id="order_lines_form" method="post" class="form-inline">
                     {% csrf_token %}
                     {% block order_lines %}
                         <table class="table table-striped table-bordered table-hover">
@@ -313,7 +313,7 @@
                     {% endblock line_actions %}
                 </form>
 
-                <form action="." method="post" id="order_status_form">
+                <form method="post" id="order_status_form">
                     {% csrf_token %}
                     {% block order_actions %}
                         <div class="well">
@@ -620,7 +620,7 @@
                                         <td>
                                             {% if note.is_editable %}
                                                 &nbsp;<a href="{% url 'dashboard:order-detail-note' number=order.number note_id=note.id %}#notes" class="btn btn-info">{% trans "Edit" %}</a>
-                                                <form action="." method="post" class="pull-left flat">
+                                                <form method="post" class="pull-left flat">
                                                     {% csrf_token %}
                                                     <input type="hidden" name="order_action" value="delete_note" />
                                                     <input type="hidden" name="note_id" value="{{ note.id }}" />

--- a/src/oscar/templates/oscar/dashboard/orders/order_list.html
+++ b/src/oscar/templates/oscar/dashboard/orders/order_list.html
@@ -30,7 +30,7 @@
         <h3><i class="icon-search icon-large"></i>{% trans "Search" %}</h3>
     </div>
     <div class="well">
-        <form action="." method="get" class="form-inline" id="search_form">
+        <form method="get" class="form-inline" id="search_form">
             {% for field in form %}
                 {% if "order" in field.id_for_label %}
                     {% if field.is_hidden %}
@@ -60,7 +60,7 @@
                         <button type="button" class="close" data-dismiss="modal">&times;</button>
                         <h3>{% trans "Advanced Search" %}</h3>
                     </div>
-                    <form action="." method="get" class="form-horizontal">
+                    <form method="get" class="form-horizontal">
                         <div class="modal-body">
                             <div class="container-fluid">
                             {% csrf_token %}
@@ -89,7 +89,7 @@
     </div>
 
     {% if orders %}
-        <form action="." method="post" class="order_table" id="orders_form">
+        <form method="post" class="order_table" id="orders_form">
             {% csrf_token %}
             {% include "dashboard/orders/partials/bulk_edit_form.html" with status=active_status %}
 

--- a/src/oscar/templates/oscar/dashboard/orders/shippingaddress_form.html
+++ b/src/oscar/templates/oscar/dashboard/orders/shippingaddress_form.html
@@ -26,7 +26,7 @@
 
 {% block content %}
 
-    <form action="." method="post" class="well form-horizontal">
+    <form method="post" class="well form-horizontal">
         {% csrf_token %}
         {% include "dashboard/partials/form_fields.html" with form=form %}
         <div class="form-actions">

--- a/src/oscar/templates/oscar/dashboard/pages/delete.html
+++ b/src/oscar/templates/oscar/dashboard/pages/delete.html
@@ -28,7 +28,7 @@
     <div class="table-header">
         <h2>{% trans "Delete page" %}</h2>
     </div>
-    <form action="." method="post" class="well">
+    <form method="post" class="well">
         {% csrf_token %}
         {{ form }}
         <p>{% blocktrans with title=object.title %}Delete page <strong>{{ title }}</strong> - are you sure?{% endblocktrans %}</p>

--- a/src/oscar/templates/oscar/dashboard/pages/index.html
+++ b/src/oscar/templates/oscar/dashboard/pages/index.html
@@ -29,7 +29,7 @@
         <h3><i class="icon-search icon-large"></i>{% trans "Search" %}</h3>
     </div>
     <div class="well">
-        <form action="." method="get" class="form-inline">
+        <form method="get" class="form-inline">
             {% include "dashboard/partials/form_fields_inline.html" with form=form %}
             <button type="submit" class="btn btn-primary" data-loading-text="{% trans 'Searching...' %}">{% trans "Search" %}</button>
             <a href="{% url 'dashboard:page-list' %}" class="btn btn-default">{% trans "Reset" %}</a>
@@ -42,7 +42,7 @@
 
 
     {% if flatpage_list %}
-        <form action="." method="post">
+        <form method="post">
             {% csrf_token %}
             <table class="table table-striped table-bordered table-hover">
                 <thead>

--- a/src/oscar/templates/oscar/dashboard/pages/update.html
+++ b/src/oscar/templates/oscar/dashboard/pages/update.html
@@ -28,7 +28,7 @@
     <h2>{{ title }}</h2>
 </div>
 
-<form action="." method="post" class="well form-stacked wysiwyg" enctype="multipart/form-data">
+<form method="post" class="well form-stacked wysiwyg" enctype="multipart/form-data">
     {% csrf_token %}
     {% include 'dashboard/partials/form_fields.html' with form=form %}
     <div class="form-actions">

--- a/src/oscar/templates/oscar/dashboard/partners/partner_delete.html
+++ b/src/oscar/templates/oscar/dashboard/partners/partner_delete.html
@@ -27,7 +27,7 @@
 {% endblock %}
 
 {% block dashboard_content %}
-    <form action="." method="post">
+    <form method="post">
         {% csrf_token %}
         <p>{% trans "Are you sure you want to delete this partner?" %}</p>
         <div class="form-actions">

--- a/src/oscar/templates/oscar/dashboard/partners/partner_list.html
+++ b/src/oscar/templates/oscar/dashboard/partners/partner_list.html
@@ -24,7 +24,7 @@
 
 {% block dashboard_content %}
     <div class="well">
-        <form action="." method="get" class="form-inline">
+        <form method="get" class="form-inline">
             {% include 'dashboard/partials/form_fields_inline.html' with form=form %}
             <button type="submit" class="btn btn-primary" data-loading-text="{% trans 'Searching...' %}">{% trans "Search" %}</button>
             {% if is_filtered %}
@@ -33,7 +33,7 @@
         </form>
     </div>
 
-    <form action="." method="post" class="order_table">
+    <form method="post" class="order_table">
         {% csrf_token %}
         <table class="table table-striped table-bordered">
             <caption>

--- a/src/oscar/templates/oscar/dashboard/partners/partner_user_form.html
+++ b/src/oscar/templates/oscar/dashboard/partners/partner_user_form.html
@@ -28,7 +28,7 @@
 {% block headertext %}{{ title }}{% endblock %}
 
 {% block dashboard_content %}
-    <form action="." method="post" class="well form-stacked wysiwyg" enctype="multipart/form-data">
+    <form method="post" class="well form-stacked wysiwyg" enctype="multipart/form-data">
         {% csrf_token %}
         {% include 'dashboard/partials/form_fields.html' with form=form %}
         <div class="form-actions">

--- a/src/oscar/templates/oscar/dashboard/partners/partner_user_select.html
+++ b/src/oscar/templates/oscar/dashboard/partners/partner_user_select.html
@@ -28,7 +28,7 @@
 {% block dashboard_content %}
     {% block users_form %}
         <div class="well">
-            <form action="." method="get" class="form-inline">
+            <form method="get" class="form-inline">
                 {% include 'dashboard/partials/form_fields_inline.html' with form=form %}
                 <button type="submit" class="btn btn-primary" data-loading-text="{% trans 'Searching...' %}">{% trans "Search" %}</button>
                 {% if form.is_bound %}

--- a/src/oscar/templates/oscar/dashboard/promotions/delete.html
+++ b/src/oscar/templates/oscar/dashboard/promotions/delete.html
@@ -28,7 +28,7 @@
     <div class="table-header">
         {% trans "Delete content block" %}
     </div>
-    <form action="." method="post" class="well">
+    <form method="post" class="well">
         {% csrf_token %}
         {{ form }}
         <p>{% blocktrans %}Delete {{ object.type }} content block <strong>{{ object.name }}</strong> - are you sure?{% endblocktrans %}</p>

--- a/src/oscar/templates/oscar/dashboard/promotions/delete_pagepromotion.html
+++ b/src/oscar/templates/oscar/dashboard/promotions/delete_pagepromotion.html
@@ -23,7 +23,7 @@
     <div class="table-header">
         {% trans "Remove promotion" %}
     </div>
-    <form action="." method="post" class="well">
+    <form method="post" class="well">
         {% csrf_token %}
         <p>{% blocktrans %}Remove {{ object.content_object.type }} content block <strong>{{ object.name }}</strong> from page <strong>{{ object.page_url }}</strong> - are you sure?{% endblocktrans %}</p>
 

--- a/src/oscar/templates/oscar/dashboard/promotions/form.html
+++ b/src/oscar/templates/oscar/dashboard/promotions/form.html
@@ -26,7 +26,7 @@
             <h2>{% trans "Content block" %}</h2>
         </div>
 
-        <form action="." method="post" enctype="multipart/form-data" class="well form-stacked wysiwyg">
+        <form method="post" enctype="multipart/form-data" class="well form-stacked wysiwyg">
             {% csrf_token %}
             {% include "dashboard/partials/form_fields.html" with form=form %}
 
@@ -57,7 +57,7 @@
                             <td><a href="{{ link.page_url }}">{{ link.page_url }}</a></td>
                             <td>{{ link.position }}</td>
                             <td>
-                                <form action="." method="post" >
+                                <form method="post" >
                                     {% csrf_token %}
                                     <input type="hidden" name="action" value="remove_from_page" />
                                     <input type="hidden" name="pagepromotion_id" value="{{ link.id }}" />
@@ -76,7 +76,7 @@
             <h3>{% trans "Add to a page" %}</h3>
         </div>
         <div class="well">
-            <form action="." method="post" class="form-stacked">
+            <form method="post" class="form-stacked">
                 {% csrf_token %}
                 <input type="hidden" name="action" value="add_to_page" />
                 {% include "dashboard/partials/form_fields.html" with form=link_form %}

--- a/src/oscar/templates/oscar/dashboard/ranges/range_delete.html
+++ b/src/oscar/templates/oscar/dashboard/ranges/range_delete.html
@@ -27,7 +27,7 @@
 {% endblock %}
 
 {% block dashboard_content %}
-    <form action="." method="post" class="well">
+    <form method="post" class="well">
         <p>{% trans "Are you sure you want to delete this range?" %}</p>
         {% csrf_token %}
         <div class="form-actions">

--- a/src/oscar/templates/oscar/dashboard/ranges/range_form.html
+++ b/src/oscar/templates/oscar/dashboard/ranges/range_form.html
@@ -28,7 +28,7 @@
 {% endblock %}
 
 {% block dashboard_content %}
-    <form action="." method="post" class="form-stacked well wysiwyg">
+    <form method="post" class="form-stacked well wysiwyg">
         {% csrf_token %}
         {% include "dashboard/partials/form_fields.html" with form=form %}
         {% block form_actions %}

--- a/src/oscar/templates/oscar/dashboard/ranges/range_product_list.html
+++ b/src/oscar/templates/oscar/dashboard/ranges/range_product_list.html
@@ -38,7 +38,7 @@
 
         <div class="well">
 
-            <form action="." method="post" class="form-stacked" enctype="multipart/form-data">
+            <form method="post" class="form-stacked" enctype="multipart/form-data">
                 {% csrf_token %}
                 <input type="hidden" name="action" value="add_products"/>
                 {% include 'dashboard/partials/form_fields.html' with form=form %}
@@ -78,7 +78,7 @@
             {% endwith %}
 
             {% if products %}
-                <form action="." method="post">
+                <form method="post">
                     {% csrf_token %}
                     <table class="table table-striped table-bordered table-hover">
                         <caption>

--- a/src/oscar/templates/oscar/dashboard/reports/index.html
+++ b/src/oscar/templates/oscar/dashboard/reports/index.html
@@ -24,7 +24,7 @@
         <h3><i class="icon-bar-chart icon-large"></i>{% trans "Reporting dashboard" %}</h3>
     </div>
     <div class="well">
-        <form method="get" action="." class="form-inline">
+        <form method="get" class="form-inline">
             {% include "dashboard/partials/form_fields_inline.html" with form=form %}
             <span class="form-group">
                 <button type="submit" class="btn btn-primary" data-loading-text="{% trans 'Generating...' %}">{% trans "Generate report" %}</button>

--- a/src/oscar/templates/oscar/dashboard/reviews/review_delete.html
+++ b/src/oscar/templates/oscar/dashboard/reviews/review_delete.html
@@ -28,7 +28,7 @@
     <div class="table-header">
         <h2>{% trans "Review" %}</h2>
     </div>
-    <form action="." method="post" class="well">
+    <form method="post" class="well">
         {% csrf_token %}
 
         <table class="table table-striped table-bordered table-hover">

--- a/src/oscar/templates/oscar/dashboard/reviews/review_list.html
+++ b/src/oscar/templates/oscar/dashboard/reviews/review_list.html
@@ -29,7 +29,7 @@
         <h3><i class="icon-search icon-large"></i>{% trans "Review Search" %}</h3>
     </div>
     <div class="well">
-        <form action="." method="get" class="form-inline">
+        <form method="get" class="form-inline">
             {% include 'dashboard/partials/form_fields_inline.html' with form=form %}
             <button type="submit" class="btn btn-primary top-spacer" data-loading-text="{% trans 'Searching...' %}">{% trans "Search" %}</button>
         </form>
@@ -37,7 +37,7 @@
 
     {% if review_list %}
 
-        <form action="." method="post">
+        <form method="post">
             {% csrf_token %}
             <table class="table table-striped table-bordered table-hover">
                 <caption>

--- a/src/oscar/templates/oscar/dashboard/reviews/review_update.html
+++ b/src/oscar/templates/oscar/dashboard/reviews/review_update.html
@@ -25,7 +25,7 @@
 {% endblock %}
 
 {% block dashboard_content %}
-    <form action="." method="post" class="form-stacked" enctype="multipart/form-data">
+    <form method="post" class="form-stacked" enctype="multipart/form-data">
         {% csrf_token %}
         <div class="table-header">
             <h3>{% trans "Review information" %}</h3>

--- a/src/oscar/templates/oscar/dashboard/shipping/weight_band_delete.html
+++ b/src/oscar/templates/oscar/dashboard/shipping/weight_band_delete.html
@@ -42,7 +42,7 @@
             </tr>
         </tbody>
     </table>
-    <form action="." method="post" class="well">
+    <form method="post" class="well">
         <p>{% trans "Are you sure you want to delete this weight band method?" %}</p>
         {% csrf_token %}
         <div class="form-actions">

--- a/src/oscar/templates/oscar/dashboard/shipping/weight_band_form.html
+++ b/src/oscar/templates/oscar/dashboard/shipping/weight_band_form.html
@@ -29,7 +29,7 @@
 
 {% block dashboard_content %}
     <div class="well">
-        <form action="." method="post" class="form-stacked">
+        <form method="post" class="form-stacked">
             {% csrf_token %}
             {% include "dashboard/partials/form_fields.html" with form=form %}
             {% block form_actions %}

--- a/src/oscar/templates/oscar/dashboard/shipping/weight_based_delete.html
+++ b/src/oscar/templates/oscar/dashboard/shipping/weight_based_delete.html
@@ -25,7 +25,7 @@
 {% endblock %}
 
 {% block dashboard_content %}
-    <form action="." method="post" class="well">
+    <form method="post" class="well">
         <p>{% trans "Are you sure you want to delete this shipping method?" %}</p>
         {% csrf_token %}
         <div class="form-actions">

--- a/src/oscar/templates/oscar/dashboard/shipping/weight_based_detail.html
+++ b/src/oscar/templates/oscar/dashboard/shipping/weight_based_detail.html
@@ -87,7 +87,7 @@
         {% endif %}
 
         <h2>{% trans "Add a new weight band" %}</h2>
-        <form action="." method="post">
+        <form method="post">
             {% csrf_token %}
             {% include "dashboard/partials/form_fields.html" with form=form %}
             <button type="submit" class="btn btn-primary" data-loading-text="{% trans 'Adding...' %}">{% trans 'Add weight band' %}</button>

--- a/src/oscar/templates/oscar/dashboard/shipping/weight_based_form.html
+++ b/src/oscar/templates/oscar/dashboard/shipping/weight_based_form.html
@@ -39,7 +39,7 @@
 {% endblock %}
 
 {% block dashboard_content %}
-    <form action="." method="post" class="form-stacked well wysiwyg">
+    <form method="post" class="form-stacked well wysiwyg">
         {% csrf_token %}
         {% include "dashboard/partials/form_fields.html" with form=form %}
         {% block form_actions %}

--- a/src/oscar/templates/oscar/dashboard/users/alerts/delete.html
+++ b/src/oscar/templates/oscar/dashboard/users/alerts/delete.html
@@ -30,7 +30,7 @@
     </div>
     <div class="well">
         {% include 'dashboard/users/alerts/partials/alert.html' %}
-        <form action="." method="post" >
+        <form method="post">
             {% csrf_token %}
             <div class="form-actions">
                 <p>{% trans "Are you sure that you want to delete this alert?" %}</p>

--- a/src/oscar/templates/oscar/dashboard/users/alerts/list.html
+++ b/src/oscar/templates/oscar/dashboard/users/alerts/list.html
@@ -26,7 +26,7 @@
         <h3><i class="icon-search icon-large"></i> {% trans "Search product alerts" %}</h3>
     </div>
     <div class="well">
-        <form action="." method="get" class="form-inline">
+        <form method="get" class="form-inline">
             {% include "dashboard/partials/form_fields_inline.html" with form=form %}
             <button type="submit" class="btn btn-primary" data-loading-text="{% trans 'Searching...' %}">{% trans "Search" %}</button>
             {% trans "or" %}

--- a/src/oscar/templates/oscar/dashboard/users/alerts/update.html
+++ b/src/oscar/templates/oscar/dashboard/users/alerts/update.html
@@ -27,7 +27,7 @@
     <div class="table-header">
         <h2 class="pull-left">{% blocktrans with id=alert.id %}Product alert #{{ id }}{% endblocktrans %}</h2>
         <div class="pull-right">
-            <form action="." method="post" class="form-inline">
+            <form method="post" class="form-inline">
                 {% csrf_token %}
                 {% include 'dashboard/partials/form_fields_inline.html' %}
                 <button type='submit' class="btn btn-primary" data-loading-text="{% trans 'Saving...' %}">{% trans "Save" %}</button>

--- a/src/oscar/templates/oscar/dashboard/users/index.html
+++ b/src/oscar/templates/oscar/dashboard/users/index.html
@@ -29,7 +29,7 @@
         <h3><i class="icon-search icon-large"></i> {% trans "Search" %}</h3>
     </div>
     <div class="well">
-        <form action="." method="get" class="form-inline">
+        <form method="get" class="form-inline">
             {% include "dashboard/partials/form_fields_inline.html" with form=form %}
             <button type="submit" name="search" class="btn btn-primary" data-loading-text="{% trans 'Searching...' %}">{% trans "Search" %}</button>
             <a href="{% url 'dashboard:users-index' %}" class="btn btn-default">{% trans "Reset" %}</a>
@@ -38,7 +38,7 @@
 
     {% block users_list %}
         {% if users.data %}
-          <form id="user_list_form" action="." method="post" class="form-inline">
+          <form id="user_list_form" method="post" class="form-inline">
             {% csrf_token %}
             {% render_table users %}
           </form>

--- a/src/oscar/templates/oscar/dashboard/vouchers/voucher_delete.html
+++ b/src/oscar/templates/oscar/dashboard/vouchers/voucher_delete.html
@@ -42,7 +42,7 @@
                 <tr><th>{% trans "Discount" %}</th><td>{{ voucher.benefit.description|safe }}</td></tr>
             </tbody>
         </table>
-        <form action="." method="post">
+        <form method="post">
             {% csrf_token %}
             <div class="form-actions">
                 <button class="btn btn-danger btn-lg" type="submit" data-loading-text="{% trans 'Deleting...' %}">{% trans "Delete" %}</button> {% trans "or" %}

--- a/src/oscar/templates/oscar/dashboard/vouchers/voucher_form.html
+++ b/src/oscar/templates/oscar/dashboard/vouchers/voucher_form.html
@@ -37,7 +37,7 @@
             {% endif %}
         </h2>
     </div>
-    <form action="." method="post" class="well form-stacked">
+    <form method="post" class="well form-stacked">
         {% csrf_token %}
         {% include "dashboard/partials/form_fields.html" with form=form %}
         {% block form_actions %}

--- a/src/oscar/templates/oscar/dashboard/vouchers/voucher_list.html
+++ b/src/oscar/templates/oscar/dashboard/vouchers/voucher_list.html
@@ -35,7 +35,7 @@
             <h3><i class="icon-search icon-large"></i>{% trans "Search" %}</h3>
         </div>
         <div class="well">
-            <form action="." method="get" class="form-inline">
+            <form method="get" class="form-inline">
                 {% include 'dashboard/partials/form_fields_inline.html' with form=form %}
                 <button type="submit" class="btn btn-primary" data-loading-text="{% trans 'Searching...' %}">{% trans "Search" %}</button>
                 <a href="{% url 'dashboard:voucher-list' %}" class="btn btn-default">{% trans "Reset" %}</a>

--- a/src/oscar/templates/oscar/dashboard/vouchers/voucher_set_detail.html
+++ b/src/oscar/templates/oscar/dashboard/vouchers/voucher_set_detail.html
@@ -69,7 +69,7 @@
     <h3><i class="icon-search icon-large"></i>{% trans "Search" %}</h3>
 </div>
 <div class="well">
-    <form action="." method="get" class="form-inline">
+    <form method="get" class="form-inline">
 		{% include 'partials/form_fields_inline.html' with form=form %}
 		<button type="submit" class="btn btn-primary">{% trans "Search" %}</button>
 		<a href="{% url 'dashboard:voucher-list' %}" class="btn">{% trans "Reset" %}</a>

--- a/src/oscar/templates/oscar/dashboard/vouchers/voucher_set_form.html
+++ b/src/oscar/templates/oscar/dashboard/vouchers/voucher_set_form.html
@@ -37,7 +37,7 @@
             {% endif %}
         </h2>
     </div>
-    <form action="." method="post" class="well form-stacked">
+    <form method="post" class="well form-stacked">
         {% csrf_token %}
         {% include "dashboard/partials/form_fields.html" with form=form %}
         {% block form_actions %}

--- a/src/oscar/templates/oscar/registration/password_reset_confirm.html
+++ b/src/oscar/templates/oscar/registration/password_reset_confirm.html
@@ -20,7 +20,7 @@
 {% block content %}
     {% if validlink %}
         <p>{% trans "Please enter your new password twice so we can verify you typed it in correctly." %}</p>
-        <form id="password_reset_form" action="" method="post">
+        <form id="password_reset_form" method="post">
             {% csrf_token %}
             {% include 'partials/form_fields.html' %}
             <div class="form-group form-actions">

--- a/src/oscar/templates/oscar/registration/password_reset_form.html
+++ b/src/oscar/templates/oscar/registration/password_reset_form.html
@@ -16,7 +16,7 @@
 
 {% block content %}
 
-    <form id="password_reset_form" action="." method="post">
+    <form id="password_reset_form" method="post">
         {% csrf_token %}
         <p>{% trans "Forgotten your password? Enter your e-mail address below, and we'll e-mail instructions for setting a new one." %}</p>
         {% include 'partials/form_fields.html' with style='stacked' %}

--- a/src/oscar/templates/oscar/search/results.html
+++ b/src/oscar/templates/oscar/search/results.html
@@ -41,7 +41,7 @@
 {% endblock %}
 
 {% block content %}
-    <form method="get" action="." class="form-horizontal">
+    <form method="get" class="form-horizontal">
         {# Render other search params as hidden inputs #}
         {% for value in selected_facets %}
             <input type="hidden" name="selected_facets" value="{{ value }}" />


### PR DESCRIPTION
[Following Django](https://github.com/django/django/commit/4660ce5a6930e07899ed083801845ee4c44c09df), this commit drops the use of empty action attributes, inline with the HTML5 spec.