### PR TITLE
 Limit access to dashboard for partners to show only their stats

### DIFF
--- a/src/oscar/apps/dashboard/views.py
+++ b/src/oscar/apps/dashboard/views.py
@@ -185,10 +185,6 @@ class IndexView(TemplateView):
             'total_open_stock_alerts': open_alerts.count(),
             'total_closed_stock_alerts': closed_alerts.count(),
 
-            'total_site_offers': self.get_active_site_offers().count(),
-            'total_vouchers': self.get_active_vouchers().count(),
-            'total_promotions': self.get_number_of_promotions(),
-
             'total_customers': customers.count(),
             'total_open_baskets': baskets.count(),
             'total_orders': orders.count(),
@@ -201,6 +197,12 @@ class IndexView(TemplateView):
                 'status'
             ).values('status').annotate(freq=Count('id'))
         }
+        if user.is_staff:
+            stats.update(
+                total_site_offers=self.get_active_site_offers().count(),
+                total_vouchers=self.get_active_vouchers().count(),
+                total_promotions=self.get_number_of_promotions(),
+            )
         return stats
 
 

--- a/src/oscar/apps/dashboard/views.py
+++ b/src/oscar/apps/dashboard/views.py
@@ -75,17 +75,7 @@ class IndexView(TemplateView):
                 total += cls.objects.count()
         return total
 
-    def get_open_baskets(self, filters=None):
-        """
-        Get all open baskets. If *filters* dictionary is provided they will
-        be applied on all open baskets and return only filtered results.
-        """
-        if filters is None:
-            filters = {}
-        filters['status'] = Basket.OPEN
-        return Basket.objects.filter(**filters)
-
-    def get_hourly_report(self, hours=24, segments=10):
+    def get_hourly_report(self, orders, hours=24, segments=10):
         """
         Get report of order revenue split up in hourly chunks. A report is
         generated for the last *hours* (default=24) from the current time.
@@ -95,17 +85,15 @@ class IndexView(TemplateView):
         *segments* defines the number of labeling segments used for the y-axis
         when generating the y-axis labels (default=10).
         """
-        # Get datetime for 24 hours agao
+        # Get datetime for 24 hours ago
         time_now = now().replace(minute=0, second=0)
         start_time = time_now - timedelta(hours=hours - 1)
-
-        orders_last_day = Order.objects.filter(date_placed__gt=start_time)
 
         order_total_hourly = []
         for hour in range(0, hours, 2):
             end_time = start_time + timedelta(hours=2)
-            hourly_orders = orders_last_day.filter(date_placed__gt=start_time,
-                                                   date_placed__lt=end_time)
+            hourly_orders = orders.filter(date_placed__gte=start_time,
+                                          date_placed__lt=end_time)
             total = hourly_orders.aggregate(
                 Sum('total_incl_tax')
             )['total_incl_tax__sum'] or D('0.0')
@@ -146,13 +134,32 @@ class IndexView(TemplateView):
         datetime_24hrs_ago = now() - timedelta(hours=24)
 
         orders = Order.objects.all()
+        alerts = StockAlert.objects.all()
+        baskets = Basket.objects.filter(status=Basket.OPEN)
+        customers = User.objects.filter(orders__isnull=False).distinct()
+        lines = Line.objects.filter()
+
+        user = self.request.user
+        if not user.is_staff:
+            partners_ids = tuple(user.partners.values_list('id', flat=True))
+            orders = orders.filter(
+                lines__partner_id__in=partners_ids
+            ).distinct()
+            alerts = alerts.filter(stockrecord__partner_id__in=partners_ids)
+            baskets = baskets.filter(
+                lines__stockrecord__partner_id__in=partners_ids
+            ).distinct()
+            customers = customers.filter(
+                orders__lines__partner_id__in=partners_ids
+            ).distinct()
+            lines = lines.filter(partner_id__in=partners_ids)
+
         orders_last_day = orders.filter(date_placed__gt=datetime_24hrs_ago)
 
-        open_alerts = StockAlert.objects.filter(status=StockAlert.OPEN)
-        closed_alerts = StockAlert.objects.filter(status=StockAlert.CLOSED)
+        open_alerts = alerts.filter(status=StockAlert.OPEN)
+        closed_alerts = alerts.filter(status=StockAlert.CLOSED)
 
-        total_lines_last_day = Line.objects.filter(
-            order__in=orders_last_day).count()
+        total_lines_last_day = lines.filter(order__in=orders_last_day).count()
         stats = {
             'total_orders_last_day': orders_last_day.count(),
             'total_lines_last_day': total_lines_last_day,
@@ -165,14 +172,14 @@ class IndexView(TemplateView):
                 Sum('total_incl_tax')
             )['total_incl_tax__sum'] or D('0.00'),
 
-            'hourly_report_dict': self.get_hourly_report(hours=24),
-            'total_customers_last_day': User.objects.filter(
+            'hourly_report_dict': self.get_hourly_report(orders),
+            'total_customers_last_day': customers.filter(
                 date_joined__gt=datetime_24hrs_ago,
             ).count(),
 
-            'total_open_baskets_last_day': self.get_open_baskets({
-                'date_created__gt': datetime_24hrs_ago
-            }).count(),
+            'total_open_baskets_last_day': baskets.filter(
+                date_created__gt=datetime_24hrs_ago
+            ).count(),
 
             'total_products': Product.objects.count(),
             'total_open_stock_alerts': open_alerts.count(),
@@ -182,10 +189,10 @@ class IndexView(TemplateView):
             'total_vouchers': self.get_active_vouchers().count(),
             'total_promotions': self.get_number_of_promotions(),
 
-            'total_customers': User.objects.count(),
-            'total_open_baskets': self.get_open_baskets().count(),
+            'total_customers': customers.count(),
+            'total_open_baskets': baskets.count(),
             'total_orders': orders.count(),
-            'total_lines': Line.objects.count(),
+            'total_lines': lines.count(),
             'total_revenue': orders.aggregate(
                 Sum('total_incl_tax')
             )['total_incl_tax__sum'] or D('0.00'),

--- a/src/oscar/templates/oscar/dashboard/index.html
+++ b/src/oscar/templates/oscar/dashboard/index.html
@@ -158,7 +158,7 @@
         </table>
     </div>
     <div class="col-md-6">
-
+        {% if user.is_staff %}
         <table class="table table-striped table-bordered table-hover">
             <caption><i class="icon-gift icon-large"></i>{% trans "Offers, vouchers and promotions" %}</caption>
             <tr>
@@ -174,6 +174,7 @@
                 <td class="col-md-2" >{{ total_promotions }}</td>
             </tr>
         </table>
+        {% endif %}
     </div>
 </div>
 

--- a/src/oscar/test/testcases.py
+++ b/src/oscar/test/testcases.py
@@ -105,3 +105,8 @@ class WebTestCase(WebTest):
         self.assertContext(response)
         self.assertTrue(key in response.context,
                         "Context should contain a variable '%s'" % key)
+
+    def assertNotInContext(self, response, key):
+        self.assertContext(response)
+        self.assertTrue(key not in response.context,
+                        "Context should not contain a variable '%s'" % key)

--- a/tests/functional/dashboard/test_dashboard.py
+++ b/tests/functional/dashboard/test_dashboard.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 
 from oscar.core import prices
 from oscar.apps.dashboard.views import IndexView
+from oscar.apps.order.models import Order
 from oscar.test.testcases import WebTestCase
 from oscar.test.factories import create_order
 
@@ -28,7 +29,7 @@ class TestDashboardIndexForStaffUser(WebTestCase):
             self.assertTrue('Password' not in response.content.decode('utf8'))
 
     def test_includes_hourly_report_with_no_orders(self):
-        report = IndexView().get_hourly_report()
+        report = IndexView().get_hourly_report(Order.objects.all())
         self.assertEqual(len(report), 3)
 
         keys = ['max_revenue', 'order_total_hourly', 'y_range']
@@ -44,7 +45,7 @@ class TestDashboardIndexForStaffUser(WebTestCase):
                                         tax=D('0.00')))
         create_order(total=prices.Price('GBP', excl_tax=D('21.90'),
                                         tax=D('0.00')))
-        report = IndexView().get_hourly_report()
+        report = IndexView().get_hourly_report(Order.objects.all())
 
         self.assertEqual(len(report['order_total_hourly']), 12)
         self.assertEqual(len(report['y_range']), 11)


### PR DESCRIPTION
These changes makes the Dashboard more safe in terms of displaying potentially sensitive store information to non staff (probably partner) users and at the same time gives them an ability to see more relevant stats.