### PR TITLE
Fix docs formatting

### DIFF
--- a/docs/source/ref/apps/customer.rst
+++ b/docs/source/ref/apps/customer.rst
@@ -32,7 +32,7 @@ The alerts module provides functionality that allows customers to sign up for
 email alerts when out-of-stock products come back in stock. A form for signing
 up is displayed on product detail pages when a product is not in stock.
 
-If the ``OSCAR_EAGER_ALERTS` setting is ``True``, then alerts are sent as soon
+If the ``OSCAR_EAGER_ALERTS`` setting is ``True``, then alerts are sent as soon
 as affected stock records are updated. Alternatively, the management command
 ``oscar_send_alerts`` can be used to send alerts periodically.
 


### PR DESCRIPTION
Fix formatting of the [Alerts](https://django-oscar.readthedocs.io/en/latest/ref/apps/customer.html#alerts) section at the `Docs » Oscar Core Apps explained » Customer` page.