### PR TITLE
Add a link to the Signals topic of Django's documentation

### DIFF
--- a/docs/source/ref/signals.rst
+++ b/docs/source/ref/signals.rst
@@ -2,8 +2,10 @@
 Signals
 =======
 
-Oscar implements a number of custom signals that provide useful hook-points for
-adding functionality.
+Oscar implements a number of custom signals_ that provide useful hook-points
+for adding functionality.
+
+.. _signals: https://docs.djangoproject.com/en/stable/topics/signals/
 
 ``product_viewed``
 ------------------


### PR DESCRIPTION
This PR modifies [Signals](https://django-oscar.readthedocs.io/en/latest/ref/signals.html) page to refer corresponding documentation topic of Django.