### PR TITLE
Fix admin URLs in getting started docs.

### DIFF
--- a/docs/source/internals/getting_started.rst
+++ b/docs/source/internals/getting_started.rst
@@ -181,7 +181,7 @@ you will also need to include Django's i18n URLs:
 
         # The Django admin is not officially supported; expect breakage.
         # Nonetheless, it's often useful for debugging.
-        url(r'^admin/', include(admin.site.urls)),
+        url(r'^admin/', admin.site.urls),
 
         url(r'', include(application.urls)),
     ]


### PR DESCRIPTION
The ability to include(admin.site.urls) was removed in Django 2 - if you follow the documentation as it currently is you get an error:

> django.core.exceptions.ImproperlyConfigured: Passing a 3-tuple to include() is not supported. Pass a 2-tuple containing the list of patterns and app_name, and provide the namespace argument to include() instead.