### PR TITLE
Add Github contributor guidelines and issue templates.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing to Oscar
+
+Thank you for considering to help Oscar!
+
+We welcome all support, whether on bug reports, code, design, reviews, tests,
+documentation, translations or just feature requests.
+
+## Using the issue tracker
+
+The [issue tracker](https://github.com/django-oscar/django-oscar/issues) is
+the preferred channel for bug reports, feature requests and
+submitting pull requests.
+
+Please *don't use the issue tracker for support* - use [the 'django-oscar' tag on Stack Overflow](http://stackoverflow.com/questions/tagged/django-oscar) (preferred) or our [mailing list](https://groups.google.com/forum/#!forum/django-oscar).
+
+## Translations
+
+Please submit any new or improved translations through [Transifex](https://www.transifex.com/projects/p/django-oscar/).

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,21 @@
+Found a bug? Please fill out the sections below.
+
+### Issue Summary
+
+A summary of the issue.
+
+### Steps to Reproduce
+
+It's essential that you provide enough information for someone else to replicate the problem you're seeing. Simply describing something that's broken on your current project is not enough!
+
+1. (for example) Form the catalogue app with `./manage.py oscar_fork_app catalogue myproject/`
+2. Edit models.py as follows...
+3. ...
+
+Any other relevant information. For example, why do you consider this a bug and what did you expect to happen instead?
+
+### Technical details
+
+* Python version: Run `python --version`.
+* Django version: Look in your requirements.txt, or run `pip show django | grep Version`.
+* Oscar version: Look in your requirements.txt, or run `pip show django-oscar | grep Version`.


### PR DESCRIPTION
This is to try and (a) help people provide more complete information when submitting issues and (b) direct people who want support to other channels instead of creating an issue on Github (which seems to be happening a lot lately).

Borrowed liberally from https://github.com/wagtail/wagtail/ .