### PR TITLE
Make OrderPlacementMixin more customizable

### DIFF
--- a/src/oscar/apps/checkout/mixins.py
+++ b/src/oscar/apps/checkout/mixins.py
@@ -270,7 +270,7 @@ class OrderPlacementMixin(CheckoutSessionMixin):
         return reverse('checkout:thank-you')
 
     def send_confirmation_message(self, order, code, **kwargs):
-        ctx = self.get_message_context(order)
+        ctx = self.get_message_context(order, code)
         try:
             event_type = CommunicationEventType.objects.get(code=code)
         except CommunicationEventType.DoesNotExist:
@@ -292,7 +292,7 @@ class OrderPlacementMixin(CheckoutSessionMixin):
             logger.warning("Order #%s - no %s communication event type",
                            order.number, code)
 
-    def get_message_context(self, order):
+    def get_message_context(self, order, code):
         ctx = {
             'user': self.request.user,
             'order': order,

--- a/src/oscar/apps/checkout/mixins.py
+++ b/src/oscar/apps/checkout/mixins.py
@@ -270,7 +270,17 @@ class OrderPlacementMixin(CheckoutSessionMixin):
         return reverse('checkout:thank-you')
 
     def send_confirmation_message(self, order, code, **kwargs):
-        ctx = self.get_message_context(order, code)
+        try:
+            ctx = self.get_message_context(order, code)
+        except TypeError:
+            # It seems like the get_message_context method was overridden and
+            # it does not support the code argument yet
+            logger.warning(
+                'The signature of the get_message_context method has changed, '
+                'please update it in your codebase'
+            )
+            ctx = self.get_message_context(order)
+
         try:
             event_type = CommunicationEventType.objects.get(code=code)
         except CommunicationEventType.DoesNotExist:
@@ -292,7 +302,7 @@ class OrderPlacementMixin(CheckoutSessionMixin):
             logger.warning("Order #%s - no %s communication event type",
                            order.number, code)
 
-    def get_message_context(self, order, code):
+    def get_message_context(self, order, code=None):
         ctx = {
             'user': self.request.user,
             'order': order,

--- a/tests/functional/checkout/test_customer_checkout.py
+++ b/tests/functional/checkout/test_customer_checkout.py
@@ -265,5 +265,5 @@ class TestOrderPlacementMixin(CheckoutMixin, WebTestCase):
             self.enter_shipping_address()
             self.place_order()
 
-        mock_logger.warning.assert_called_once()
+        self.assertTrue(mock_logger.warning.called)
         self.assertTrue(get_message_context.called)

--- a/tests/functional/checkout/test_customer_checkout.py
+++ b/tests/functional/checkout/test_customer_checkout.py
@@ -1,4 +1,5 @@
 from http import client as http_client
+from unittest.mock import patch
 
 from django.urls import reverse
 
@@ -8,6 +9,7 @@ from oscar.test.testcases import WebTestCase
 from . import CheckoutMixin
 
 Order = get_model('order', 'Order')
+OrderPlacementMixin = get_class('checkout.mixins', 'OrderPlacementMixin')
 ConditionalOffer = get_model('offer', 'ConditionalOffer')
 UserAddress = get_model('address', 'UserAddress')
 GatewayForm = get_class('checkout.forms', 'GatewayForm')
@@ -244,3 +246,24 @@ class TestThankYouView(CheckoutMixin, WebTestCase):
         test_url = '%s?order_id=%s' % (reverse('checkout:thank-you'), order.pk)
         response = self.get(test_url, status='*', user=user)
         self.assertEqual(response.status_code, http_client.NOT_FOUND)
+
+
+class TestOrderPlacementMixin(CheckoutMixin, WebTestCase):
+
+    @patch('oscar.apps.checkout.mixins.logger')
+    def test_get_message_context_with_no_code(self, mock_logger):
+        original_get_message_context = OrderPlacementMixin.get_message_context
+
+        def get_message_context(self_, order):
+            get_message_context.called = True
+            return original_get_message_context(self_, order)
+        get_message_context.called = False
+
+        with patch.object(OrderPlacementMixin, 'get_message_context',
+                          get_message_context):
+            self.add_product_to_basket()
+            self.enter_shipping_address()
+            self.place_order()
+
+        mock_logger.warning.assert_called_once()
+        self.assertTrue(get_message_context.called)


### PR DESCRIPTION
This PR changes the signature of the `get_message_context` method to make it useful for various event codes that could be provided to the `send_confirmation_message` method.