### PR TITLE
Fix 'Number of orders' table header in dashboard customer list view.

### DIFF
--- a/src/oscar/apps/dashboard/users/tables.py
+++ b/src/oscar/apps/dashboard/users/tables.py
@@ -1,3 +1,5 @@
+from django.utils.translation import gettext_lazy as _
+
 from django_tables2 import A, Column, LinkColumn, TemplateColumn
 
 from oscar.core.loading import get_class
@@ -16,7 +18,7 @@ class UserTable(DashboardTable):
     active = Column(accessor='is_active')
     staff = Column(accessor='is_staff')
     date_registered = Column(accessor='date_joined')
-    num_orders = Column(accessor='orders.count', orderable=False)
+    num_orders = Column(accessor='orders.count', orderable=False, verbose_name=_('Number of Orders'))
     actions = TemplateColumn(
         template_name='dashboard/users/user_row_actions.html',
         verbose_name=' ')


### PR DESCRIPTION
The table header for "number of orders" in the customer list view in the dashboard is wrong - I think this must have broken when we updated django-tables2.

![image](https://user-images.githubusercontent.com/160227/41199064-00cb3a8c-6c94-11e8-949e-994406214d91.png)

Patch changes it to:

![image](https://user-images.githubusercontent.com/160227/41199070-1dd29d32-6c94-11e8-98d6-e89225f7c433.png)
