### PR TITLE
Mention support for Django 2.0

### DIFF
--- a/docs/source/releases/v1.6.rst
+++ b/docs/source/releases/v1.6.rst
@@ -19,8 +19,8 @@ Table of contents:
 Compatibility
 -------------
 
-Oscar 1.6 is compatible with Django 1.11 as well as Python 2.7, 3.4,
-3.5 and 3.6.
+Oscar 1.6 is compatible with Django 1.11 and 2.0 as well as Python 2.7 
+(Django 1.11 only), 3.4, 3.5 and 3.6.
 
 Official support for Django 1.8, 1.9 and 1.10 has been dropped.
 


### PR DESCRIPTION
The tox config and PyPI page both suggest that Django 2.0 is supported, but it isn't mentioned on the release notes.