### PR TITLE
Remove various deprecated utilities, methods and classes.

### DIFF
--- a/docs/source/releases/v2.0.rst
+++ b/docs/source/releases/v2.0.rst
@@ -43,10 +43,21 @@ Removal of deprecated features
 
   Product alert emails are now sent as Communication Events.
 
+- ``customer.forms.SetPasswordForm`` and ``customer.forms.PasswordChangeForm``
+  have been removed. Use ``django.contrib.auth.forms.SetPasswordForm`` and
+  ``django.contrib.auth.forms.PasswordChangeForm`` instead.
+
+- The ``views.decorators.staff_member_required`` decorator has been removed. Use
+  ``permissions_required(['is_staff']`` instead.
+
+- The ``UserAddress.num_orders`` property has been removed. Use
+  ``num_orders_as_shipping_address`` and ``num_orders_as_billing_address``
+  instead.
+
 Minor changes
 ~~~~~~~~~~~~~
- - Dropped ``action=""`` and ``action="."`` attributes, following the lead of Django
-   and as per the HTML5 specification.
+- Dropped ``action=""`` and ``action="."`` attributes, following the lead of Django
+  and as per the HTML5 specification.
 
 - Replaced use of Django's procedural auth views with the corresponding
   class-based views.

--- a/src/oscar/app.py
+++ b/src/oscar/app.py
@@ -3,6 +3,7 @@
 from django.conf import settings
 from django.conf.urls import url
 from django.contrib.auth import views as auth_views
+from django.contrib.auth.forms import SetPasswordForm
 from django.urls import reverse_lazy
 
 from oscar.core.application import Application
@@ -23,7 +24,7 @@ class Shop(Application):
     offer_app = get_class('offer.app', 'application')
 
     password_reset_form = get_class('customer.forms', 'PasswordResetForm')
-    set_password_form = get_class('customer.forms', 'SetPasswordForm')
+    set_password_form = SetPasswordForm
 
     def get_urls(self):
         urls = [

--- a/src/oscar/apps/address/abstract_models.py
+++ b/src/oscar/apps/address/abstract_models.py
@@ -9,7 +9,6 @@ from django.utils.translation import pgettext_lazy
 from phonenumber_field.modelfields import PhoneNumberField
 
 from oscar.core.compat import AUTH_USER_MODEL
-from oscar.core.decorators import deprecated
 from oscar.models.fields import UppercaseCharField
 
 
@@ -580,11 +579,6 @@ class AbstractUserAddress(AbstractShippingAddress):
             raise exceptions.ValidationError({
                 '__all__': [_("This address is already in your address"
                               " book")]})
-
-    @property
-    @deprecated
-    def num_orders(self):
-        return self.num_orders_as_shipping_address
 
 
 class AbstractBillingAddress(AbstractAddress):

--- a/src/oscar/apps/customer/forms.py
+++ b/src/oscar/apps/customer/forms.py
@@ -15,7 +15,6 @@ from django.utils.translation import pgettext_lazy
 from oscar.apps.customer.utils import get_password_reset_url, normalise_email
 from oscar.core.compat import (
     existing_user_fields, get_user_model)
-from oscar.core.decorators import deprecated
 from oscar.core.loading import get_class, get_model, get_profile_class
 from oscar.forms import widgets
 
@@ -73,22 +72,6 @@ class PasswordResetForm(auth_forms.PasswordResetForm):
             get_password_reset_url(user))
 
         return reset_url
-
-
-@deprecated
-class SetPasswordForm(auth_forms.SetPasswordForm):
-    """
-    Deprecated - use django.contrib.auth.forms.SetPasswordForm instead.
-    """
-    pass
-
-
-@deprecated
-class PasswordChangeForm(auth_forms.PasswordChangeForm):
-    """
-    Deprecated - use django.contrib.auth.forms.PasswordChangeForm instead.
-    """
-    pass
 
 
 class EmailAuthenticationForm(AuthenticationForm):

--- a/src/oscar/apps/customer/views.py
+++ b/src/oscar/apps/customer/views.py
@@ -4,6 +4,7 @@ from django.contrib import messages
 from django.contrib.auth import login as auth_login
 from django.contrib.auth import logout as auth_logout
 from django.contrib.auth import update_session_auth_hash
+from django.contrib.auth.forms import PasswordChangeForm
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import ObjectDoesNotExist
 from django.shortcuts import get_object_or_404, redirect
@@ -26,7 +27,6 @@ Dispatcher = get_class('customer.utils', 'Dispatcher')
 EmailAuthenticationForm, EmailUserCreationForm, OrderSearchForm = get_classes(
     'customer.forms', ['EmailAuthenticationForm', 'EmailUserCreationForm',
                        'OrderSearchForm'])
-PasswordChangeForm = get_class('customer.forms', 'PasswordChangeForm')
 ProfileForm, ConfirmPasswordForm = get_classes(
     'customer.forms', ['ProfileForm', 'ConfirmPasswordForm'])
 UserAddressForm = get_class('address.forms', 'UserAddressForm')

--- a/src/oscar/views/decorators.py
+++ b/src/oscar/views/decorators.py
@@ -6,13 +6,6 @@ from django.core.exceptions import PermissionDenied
 from django.shortcuts import render
 from django.urls import reverse_lazy
 
-from oscar.core.decorators import deprecated
-
-
-@deprecated
-def staff_member_required(view_func, login_url=None):
-    return permissions_required(['is_staff'], login_url=login_url)(view_func)
-
 
 def check_permissions(user, permissions):
     """
@@ -24,8 +17,6 @@ def check_permissions(user, permissions):
     (e.g. 'is_active', 'is_superuser').
 
     Example usage:
-    - permissions_required(['is_staff', ])
-      would replace staff_member_required
     - permissions_required(['is_anonymous', ])
       would replace login_forbidden
     - permissions_required((['is_staff',], ['partner.dashboard_access']))

--- a/tests/integration/core/test_decorator.py
+++ b/tests/integration/core/test_decorator.py
@@ -1,12 +1,11 @@
 import warnings
 
 from django.contrib.auth.models import AnonymousUser, Permission
-from django.core.exceptions import PermissionDenied
-from django.test import TestCase, RequestFactory
+from django.test import TestCase
 
 from oscar.core.decorators import deprecated
 from oscar.test import factories
-from oscar.views.decorators import check_permissions, staff_member_required
+from oscar.views.decorators import check_permissions
 
 
 class TestPermissionsDecorator(TestCase):
@@ -37,26 +36,6 @@ class TestPermissionsDecorator(TestCase):
             check_permissions(user_with_perm, ['address.add_country']))
         self.assertFalse(
             check_permissions(user_without_perm, ['address.add_country']))
-
-    def test_staff_member_required_decorator(self):
-        staff_user = factories.UserFactory(is_staff=True)
-        non_staff_user = factories.UserFactory()
-        logged_out_user = AnonymousUser()
-
-        dummy_view = lambda request: True
-
-        request = RequestFactory().get('/')
-
-        request.user = staff_user
-        self.assertEqual(True, staff_member_required(dummy_view)(request))
-
-        request.user = non_staff_user
-        with self.assertRaises(PermissionDenied):
-            staff_member_required(dummy_view)(request)
-
-        request.user = logged_out_user
-        response = staff_member_required(dummy_view)(request)
-        self.assertEqual(response.status_code, 302)     # Redirect to login
 
 
 class TestDeprecatedDecorator(TestCase):


### PR DESCRIPTION
This PR removes:

- `customer.forms.SetPasswordForm`
- `customer.forms.PasswordChangeForm`
- `views.decorators.staff_member_required`
- `UserAddress.num_orders`