### PR TITLE
Drop support for category URLs without a primary key.

### DIFF
--- a/docs/source/releases/v2.0.rst
+++ b/docs/source/releases/v2.0.rst
@@ -43,6 +43,12 @@ Removal of deprecated features
 
   Product alert emails are now sent as Communication Events.
 
+- Support for category URLs without a primary key was removed.
+
+  Enforcement of unique slugs for categories was also removed, as enforcing
+  this was inefficient and not threadsafe. Since a primary key is now required
+  for category URLs, there is no need for slugs to be unique.
+
 Minor changes
 ~~~~~~~~~~~~~
  - Dropped ``action=""`` and ``action="."`` attributes, following the lead of Django

--- a/src/oscar/apps/catalogue/app.py
+++ b/src/oscar/apps/catalogue/app.py
@@ -19,9 +19,6 @@ class BaseCatalogueApplication(Application):
                 self.detail_view.as_view(), name='detail'),
             url(r'^category/(?P<category_slug>[\w-]+(/[\w-]+)*)_(?P<pk>\d+)/$',
                 self.category_view.as_view(), name='category'),
-            # Fallback URL if a user chops of the last part of the URL
-            url(r'^category/(?P<category_slug>[\w-]+(/[\w-]+)*)/$',
-                self.category_view.as_view()),
             url(r'^ranges/(?P<slug>[\w-]+)/$',
                 self.range_view.as_view(), name='range')]
         return self.post_process_urls(urlpatterns)

--- a/src/oscar/apps/catalogue/views.py
+++ b/src/oscar/apps/catalogue/views.py
@@ -1,8 +1,6 @@
-import warnings
-
 from django.contrib import messages
 from django.core.paginator import InvalidPage
-from django.http import Http404, HttpResponsePermanentRedirect
+from django.http import HttpResponsePermanentRedirect
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.http import urlquote
 from django.utils.translation import gettext_lazy as _
@@ -165,43 +163,7 @@ class ProductCategoryView(TemplateView):
         return super().get(request, *args, **kwargs)
 
     def get_category(self):
-        if 'pk' in self.kwargs:
-            # Usual way to reach a category page. We just look at the primary
-            # key, which is easy on the database. If the slug changed, get()
-            # will redirect appropriately.
-            # WARNING: Category.get_absolute_url needs to look up it's parents
-            # to compute the URL. As this is slightly expensive, Oscar's
-            # default implementation caches the method. That's pretty safe
-            # as ProductCategoryView does the lookup by primary key, which
-            # will work even if the cache is stale. But if you override this
-            # logic, consider if that still holds true.
-            return get_object_or_404(Category, pk=self.kwargs['pk'])
-        elif 'category_slug' in self.kwargs:
-            # DEPRECATED. TODO: Remove in Oscar 1.2.
-            # For SEO and legacy reasons, we allow chopping off the primary
-            # key from the URL. In that case, we have the target category slug
-            # and it's ancestors' slugs concatenated together.
-            # To save on queries, we pick the last slug, look up all matching
-            # categories and only then compare.
-            # Note that currently we enforce uniqueness of slugs, but as that
-            # might feasibly change soon, it makes sense to be forgiving here.
-            concatenated_slugs = self.kwargs['category_slug']
-            slugs = concatenated_slugs.split(Category._slug_separator)
-            try:
-                last_slug = slugs[-1]
-            except IndexError:
-                raise Http404
-            else:
-                for category in Category.objects.filter(slug=last_slug):
-                    if category.full_slug == concatenated_slugs:
-                        message = (
-                            "Accessing categories without a primary key"
-                            " is deprecated will be removed in Oscar 1.2.")
-                        warnings.warn(message, DeprecationWarning)
-
-                        return category
-
-        raise Http404
+        return get_object_or_404(Category, pk=self.kwargs['pk'])
 
     def redirect_if_necessary(self, current_path, category):
         if self.enforce_paths:

--- a/tests/functional/catalogue/test_catalogue.py
+++ b/tests/functional/catalogue/test_catalogue.py
@@ -1,7 +1,6 @@
 from http import client as http_client
 
 from django.conf import settings
-from django.core.cache import cache
 from django.urls import reverse
 from django.utils.translation import gettext
 
@@ -86,19 +85,3 @@ class TestProductCategoryView(WebTestCase):
         response = self.app.get(wrong_url)
         self.assertEqual(http_client.MOVED_PERMANENTLY, response.status_code)
         self.assertTrue(self.category.get_absolute_url() in response.location)
-
-    def test_can_chop_off_last_part_of_url(self):
-        # We cache category URLs, which normally is a safe thing to do, as
-        # the primary key stays the same and ProductCategoryView only looks
-        # at the key any way.
-        # But this test chops the URLs, and hence relies on the URLs being
-        # correct. So in this case, we start with a clean cache to ensure
-        # our URLs are correct.
-        cache.clear()
-
-        child_category = self.category.add_child(name='Cool products')
-        full_url = child_category.get_absolute_url()
-        chopped_url = full_url.rsplit('/', 2)[0]
-        parent_url = self.category.get_absolute_url()
-        response = self.app.get(chopped_url).follow()  # fails if no redirect
-        self.assertTrue(response.url.endswith(parent_url))

--- a/tests/integration/catalogue/test_category.py
+++ b/tests/integration/catalogue/test_category.py
@@ -27,17 +27,9 @@ class TestCategory(TestCase):
         self.assertTrue(self.products.slug)
         self.assertTrue(self.books.slug)
 
-    def test_enforces_slug_uniqueness(self):
-        more_books = self.products.add_child(name=self.books.name)
-        self.assertTrue(more_books.slug and more_books.slug != self.books.slug)
-
     def test_supplied_slug_is_not_altered(self):
         more_books = self.products.add_child(
             name=self.books.name, slug=self.books.slug)
-        self.assertEqual(more_books.slug, self.books.slug)
-
-    def test_duplicate_slugs_allowed_for_non_siblings(self):
-        more_books = Category.add_root(name=self.books.name)
         self.assertEqual(more_books.slug, self.books.slug)
 
     @override_settings(OSCAR_SLUG_ALLOW_UNICODE=True)


### PR DESCRIPTION
See #1674 - support for this has been deprecated since Oscar 1.1.

I have gone a bit further here and also removed the enforcement of unique slugs for categories, as this is unnecessary if URLs require a primary key, and the way it was being done was quite clumsy, and very inefficient for flat category structures. Open to feedback on this however as it is a fairly significant change.