### PR TITLE
Add compatibility for Django 2.1, and drop support for Python 3.4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,24 @@
 sudo: false
 language: python
 
+addons:
+  postgresql: "9.6"
+
 matrix:
   fast_finish: true
   include:
-    - python: 3.4
-      env: TOXENV=py34-django111
     - python: 3.5
       env: TOXENV=py35-django111
     - python: 3.6
       env: TOXENV=py36-django111
-    - python: 3.4
-      env: TOXENV=py34-django20
     - python: 3.5
       env: TOXENV=py35-django20
     - python: 3.6
       env: TOXENV=py36-django20
+    - python: 3.5
+      env: TOXENV=py35-django21
+    - python: 3.6
+      env: TOXENV=py36-django21
     - python: 3.6
       env: TOXENV=py36-djangomaster
 

--- a/docs/source/releases/v2.0.rst
+++ b/docs/source/releases/v2.0.rst
@@ -19,7 +19,10 @@ Table of contents:
 Compatibility
 -------------
 
-Oscar 2.0 requires Python 3.4 or higher.
+Oscar 2.0 is compatible with Django 1.11, Django 2.0 and Django 2.1 as well as
+Python 3.5 and 3.6.
+
+Support for Python 2.7 and Python 3.4 has been dropped.
 
 .. _new_in_2.0:
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ sys.path.append(os.path.join(PROJECT_DIR, 'src'))
 from oscar import get_version  # noqa isort:skip
 
 install_requires = [
-    'django>=1.11,<2.1',
+    'django>=1.11,<2.2',
     # PIL is required for image fields, Pillow is the "friendly" PIL fork
     'pillow>=4.0',
     # We use the ModelFormSetView from django-extra-views for the basket page
@@ -96,12 +96,12 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: Unix',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Libraries :: Application Frameworks']

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -96,9 +96,6 @@ AUTH_PASSWORD_VALIDATORS = [
         }
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
-    },
-    {
         'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
     },
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{34,35,36}-django{111,20}
+    py{35,36}-django{111,20,21}
     py36-djangomaster
     lint
     sandbox
@@ -13,6 +13,7 @@ pip_pre = true
 deps =
     django111: django>=1.11,<2
     django20: django>=2.0,<2.1
+    django21: django>=2.1b1,<2.2
 
 
 [testenv:py36-djangomaster]


### PR DESCRIPTION
Django 2.1 works fine already - the only issue was that more passwords have been added to the CommonPasswordValidator which caused some tests to fail. I've removed that validator from the test settings.

Python 3.4 reaches end of life in March 2019 and is not supported by Django 2.1 and above. Seeing as it will be another few months before Oscar 2 is released, I think we can safely drop support for it.