### PR TITLE
[1.6.x] Add compatibility for Django 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: false
 language: python
 
+addons:
+  postgresql: "9.6"
+
 matrix:
   fast_finish: true
   include:
@@ -18,6 +21,10 @@ matrix:
       env: TOXENV=py35-django20
     - python: 3.6
       env: TOXENV=py36-django20
+    - python: 3.5
+      env: TOXENV=py35-django21
+    - python: 3.6
+      env: TOXENV=py36-django21
     - python: 3.6
       env: TOXENV=py36-djangomaster
 

--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -13,6 +13,7 @@ Release notes for each version of Oscar published to PyPI.
     v1.6
     v1.6.1
     v1.6.2
+    v1.6.3
 
 
 1.5 release branch

--- a/docs/source/releases/v1.6.3.rst
+++ b/docs/source/releases/v1.6.3.rst
@@ -2,12 +2,12 @@
 Oscar 1.6.3 release notes
 =========================
 
-:release: tbd
+:release: 2018-08-03
 
-This is Oscar 1.6.3, a bugfix release.
+This is Oscar 1.6.3, a compatibility release adding support for Django 2.1.
 
-Bug fixes
-=========
+Minor changes
+~~~~~~~~~~~~~
 
 - Replaced use of Django's procedural auth views with the corresponding
   class-based views.

--- a/docs/source/releases/v1.6.3.rst
+++ b/docs/source/releases/v1.6.3.rst
@@ -1,0 +1,13 @@
+=========================
+Oscar 1.6.3 release notes
+=========================
+
+:release: tbd
+
+This is Oscar 1.6.3, a bugfix release.
+
+Bug fixes
+=========
+
+- Replaced use of Django's procedural auth views with the corresponding
+  class-based views.

--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: Unix',

--- a/src/oscar/app.py
+++ b/src/oscar/app.py
@@ -39,22 +39,26 @@ class Shop(Application):
             # we can't namespace these urls as that prevents
             # the reverse function from working.
             url(r'^password-reset/$',
-                login_forbidden(auth_views.password_reset),
-                {'password_reset_form': self.password_reset_form,
-                 'post_reset_redirect': reverse_lazy('password-reset-done')},
+                login_forbidden(
+                    auth_views.PasswordResetView.as_view(
+                        form_class=self.password_reset_form,
+                        success_url=reverse_lazy('password-reset-done')
+                    )
+                ),
                 name='password-reset'),
             url(r'^password-reset/done/$',
-                login_forbidden(auth_views.password_reset_done),
+                login_forbidden(auth_views.PasswordResetDoneView.as_view()),
                 name='password-reset-done'),
             url(r'^password-reset/confirm/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>.+)/$',
-                login_forbidden(auth_views.password_reset_confirm),
-                {
-                    'post_reset_redirect': reverse_lazy('password-reset-complete'),
-                    'set_password_form': self.set_password_form,
-                },
+                login_forbidden(
+                    auth_views.PasswordResetConfirmView.as_view(
+                        form_class=self.set_password_form,
+                        success_url=reverse_lazy('password-reset-complete')
+                    )
+                ),
                 name='password-reset-confirm'),
             url(r'^password-reset/complete/$',
-                login_forbidden(auth_views.password_reset_complete),
+                login_forbidden(auth_views.PasswordResetCompleteView.as_view()),
                 name='password-reset-complete'),
         ]
 

--- a/src/oscar/apps/dashboard/app.py
+++ b/src/oscar/apps/dashboard/app.py
@@ -45,13 +45,11 @@ class DashboardApplication(BaseDashboardApplication):
             url(r'^comms/', self.comms_app.urls),
             url(r'^shipping/', self.shipping_app.urls),
 
-            url(r'^login/$', auth_views.login, {
-                'template_name': 'dashboard/login.html',
-                'authentication_form': AuthenticationForm,
-            }, name='login'),
-            url(r'^logout/$', auth_views.logout, {
-                'next_page': '/',
-            }, name='logout'),
+            url(r'^login/$',
+                auth_views.LoginView.as_view(template_name='dashboard/login.html',
+                                             authentication_form=AuthenticationForm),
+                name='login'),
+            url(r'^logout/$', auth_views.LogoutView.as_view(next_page='/'), name='logout'),
 
         ]
         return self.post_process_urls(urls)

--- a/tests/functional/customer/test_auth.py
+++ b/tests/functional/customer/test_auth.py
@@ -35,8 +35,10 @@ class TestAUserWhoseForgottenHerPassword(WebTest):
         self.assertTrue('path' in matches.groupdict())
         path = matches.groupdict()['path']
 
-        # Reset password and check we get redirect
-        reset_page = self.app.get(path)
+        # Reset password and check we get redirected
+        reset_page_redirect = self.app.get(path)
+        # The link in the email will redirect us to the password reset view
+        reset_page = self.app.get(reset_page_redirect.location)
         form = reset_page.forms['password_reset_form']
         form['new_password1'] = 'crazymonkey'
         form['new_password2'] = 'crazymonkey'

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -96,9 +96,6 @@ AUTH_PASSWORD_VALIDATORS = [
         }
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
-    },
-    {
         'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
     },
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,34,35,36}-django{111,20}
+    py{27,34,35,36}-django{111,20,21}
     py36-djangomaster
     lint
     sandbox
@@ -13,6 +13,7 @@ pip_pre = true
 deps =
     django111: django>=1.11,<2
     django20: django>=2.0,<2.1
+    django21: django>=2.1,<2.2
 
 
 [testenv:py36-djangomaster]


### PR DESCRIPTION
1. Drop use of procedural auth views that are removed in Django 2.1
2. Remove `CommonPasswordValidator` from test settings, as this catches some test passwords.