### PR TITLE
Reduce maximum line length in flake8 config to 119 characters.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ filterwarnings =
 exclude = migrations
 ignore = F405,W503,E731
 max-complexity = 10
-max-line-length=159
+max-line-length=119
 
 [isort]
 line_length = 79

--- a/src/oscar/apps/dashboard/views.py
+++ b/src/oscar/apps/dashboard/views.py
@@ -201,13 +201,15 @@ class PopUpWindowCreateUpdateMixin(object):
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
 
-        if RelatedFieldWidgetWrapper.TO_FIELD_VAR in self.request.GET or RelatedFieldWidgetWrapper.TO_FIELD_VAR in self.request.POST:
+        if (RelatedFieldWidgetWrapper.TO_FIELD_VAR in self.request.GET or
+                RelatedFieldWidgetWrapper.TO_FIELD_VAR in self.request.POST):
             to_field = self.request.GET.get(RelatedFieldWidgetWrapper.TO_FIELD_VAR,
                                             self.request.POST.get(RelatedFieldWidgetWrapper.TO_FIELD_VAR))
             ctx['to_field'] = to_field
             ctx['to_field_var'] = RelatedFieldWidgetWrapper.TO_FIELD_VAR
 
-        if RelatedFieldWidgetWrapper.IS_POPUP_VAR in self.request.GET or RelatedFieldWidgetWrapper.IS_POPUP_VAR in self.request.POST:
+        if (RelatedFieldWidgetWrapper.IS_POPUP_VAR in self.request.GET or
+                RelatedFieldWidgetWrapper.IS_POPUP_VAR in self.request.POST):
             is_popup = self.request.GET.get(RelatedFieldWidgetWrapper.IS_POPUP_VAR,
                                             self.request.POST.get(RelatedFieldWidgetWrapper.IS_POPUP_VAR))
             ctx['is_popup'] = is_popup

--- a/tests/functional/dashboard/test_catalogue.py
+++ b/tests/functional/dashboard/test_catalogue.py
@@ -353,7 +353,9 @@ class AttributeOptionGroupUpdateMixin(object):
         self.assertEqual(response.context['form'].instance, self.attribute_option_group)
         self.assertInContext(response, 'attribute_option_formset')
         self.assertIsInstance(response.context['attribute_option_formset'], AttributeOptionFormSet)
-        self.assertEqual(response.context['attribute_option_formset'].initial_forms[0].instance, self.attribute_option_group.options.first())
+        self.assertEqual(
+            response.context['attribute_option_formset'].initial_forms[0].instance,
+            self.attribute_option_group.options.first())
         self.assertInContext(response, 'title')
         self.assertEqual(response.context['title'], self.title)
 
@@ -708,7 +710,8 @@ class TestAttributeOptionGroupDeleteView(AttributeOptionGroupDeleteMixin,
         self._set_up_display_delete_form_disallowed_vars()
         self._set_up_pop_up_window_vars()
 
-        ProductAttributeFactory(type='multi_option', name='Sizes', code='sizes', option_group=self.attribute_option_group)
+        ProductAttributeFactory(
+            type='multi_option', name='Sizes', code='sizes', option_group=self.attribute_option_group)
 
         params = {
             self.is_popup_var: self.is_popup,
@@ -736,7 +739,8 @@ class TestAttributeOptionGroupDeleteView(AttributeOptionGroupDeleteMixin,
         self._set_up_display_delete_form_vars()
         self._set_up_display_delete_form_disallowed_vars()
 
-        ProductAttributeFactory(type='multi_option', name='Sizes', code='sizes', option_group=self.attribute_option_group)
+        ProductAttributeFactory(
+            type='multi_option', name='Sizes', code='sizes', option_group=self.attribute_option_group)
 
         self.response = self.get(self.url)
 

--- a/tests/integration/core/test_loading.py
+++ b/tests/integration/core/test_loading.py
@@ -224,7 +224,8 @@ class TestMovedClasses(TestCase):
         self.assertTrue(isinstance(LineFormset(instance=self.wishlist).forms[0], WishListLineForm))
 
     def test_load_formsets_mixed_destination(self):
-        BaseBasketLineFormSet, BasketLineForm = get_classes('basket.forms', ('BaseBasketLineFormSet', 'BasketLineForm'))
+        BaseBasketLineFormSet, BasketLineForm = get_classes(
+            'basket.forms', ('BaseBasketLineFormSet', 'BasketLineForm'))
         self.assertEqual('oscar.apps.basket.formsets', BaseBasketLineFormSet.__module__)
         self.assertEqual('oscar.apps.basket.forms', BasketLineForm.__module__)
         StockRecordForm, StockRecordFormSet = get_classes(

--- a/tests/integration/offer/test_absolute_benefit.py
+++ b/tests/integration/offer/test_absolute_benefit.py
@@ -136,7 +136,7 @@ class TestAnAbsoluteDiscountAppliedWithCountCondition(TestCase):
         self.assertEqual(4, self.basket.num_items_with_discount)
         self.assertEqual(0, self.basket.num_items_without_discount)
 
-    def test_applies_correctly_to_basket_which_exceeds_condition_with_smaller_prices_than_discount_and_higher_prices_first(self):
+    def test_applies_basket_exceeding_condition_smaller_prices_than_discount_higher_prices_first(self):
         add_products(self.basket, [
             (D('2.00'), 2), (D('4.00'), 2)])
         result = self.benefit.apply(self.basket, self.condition, self.offer)


### PR DESCRIPTION
I am not sure where the current value of 159 was from, but it is far too long in my opinion, and overflows on Github (and on most editors). 

I propose to use the same convention as Django and set a line length of 119 characters. This is the width of Github code review as well.