### PR TITLE
Update urls.py configuration

### DIFF
--- a/docs/source/howto/how_to_change_a_url.rst
+++ b/docs/source/howto/how_to_change_a_url.rst
@@ -41,8 +41,8 @@ illustrates this nicely::
 
         def get_urls(self):
             urls = [
-                url(r'^catalogue/', include(self.catalogue_app.urls)),
-                url(r'^basket/', include(self.basket_app.urls)),
+                url(r'^catalogue/', self.catalogue_app.urls),
+                url(r'^basket/', self.basket_app.urls),
                 # ...
             ]
 
@@ -55,7 +55,7 @@ property from the root app::
 
     urlpatterns = [
         # Your other URLs
-        url(r'', include(application.urls)),
+        url(r'', application.urls),
     ]
 
 Changing sub app
@@ -103,7 +103,7 @@ instead of Oscar's default instance.  Hence, create a subclass of Oscar's main
         # Override get_urls method
         def get_urls(self):
             urlpatterns = [
-                url(r'^catalog/', include(self.catalogue_app.urls)),
+                url(r'^catalog/', self.catalogue_app.urls),
                 # all the remaining URLs, removed for simplicity
                 # ...
             ]
@@ -119,7 +119,7 @@ it to use your new application instance instead of Oscar's default::
 
     urlpatterns = [
        # Your other URLs
-       url(r'', include(application.urls)),
+       url(r'', application.urls),
     ]
 
 All URLs containing ``catalogue`` previously are now displayed as ``catalog``.

--- a/docs/source/howto/how_to_disable_an_app_or_feature.rst
+++ b/docs/source/howto/how_to_disable_an_app_or_feature.rst
@@ -16,10 +16,10 @@ over the URLs structure.  So your root ``urls.py`` should have::
 
     urlpatterns = [
         ...
-        url(r'', include(application.urls)),
+        url(r'', application.urls),
     ]
 
-where ``application`` is a subclass of ``oscar.app.Shop`` which overrides the 
+where ``application`` is a subclass of ``oscar.app.Shop`` which overrides the
 link to the dashboard app::
 
     # myproject/app.py
@@ -28,12 +28,12 @@ link to the dashboard app::
 
     class MyShop(Shop):
 
-        # Override the core dashboard_app instance to use a blank application 
+        # Override the core dashboard_app instance to use a blank application
         # instance.  This means no dashboard URLs are included.
         dashboard_app = Application()
 
 The only remaining task is to ensure your templates don't reference any
-dashboard URLs. 
+dashboard URLs.
 
 How to disable Oscar feature
 ============================

--- a/docs/source/internals/getting_started.rst
+++ b/docs/source/internals/getting_started.rst
@@ -186,6 +186,28 @@ you will also need to include Django's i18n URLs:
         url(r'', include(application.urls)),
     ]
 
+For `Django > 1.9`_ pass ``application.urls`` directly to ``path``. For `Django > 2.0`_ use ``path`` and ``re_path`` instead of ``url``.:
+
+.. _`Django > 2.0`: https://docs.djangoproject.com/en/2.0/releases/2.0/#simplified-url-routing-syntax
+.. _`Django > 1.9`: https://docs.djangoproject.com/en/2.0/releases/1.9/#passing-a-3-tuple-or-an-app-name-to-include
+
+.. code-block:: django
+
+    from django.contrib import admin
+    from django.urls import path, include, re_path
+    from oscar.app import application
+
+    urlpatterns = [
+        re_path('^i18n/', include('django.conf.urls.i18n')),
+
+        # The Django admin is not officially supported; expect breakage.
+        # Nonetheless, it's often useful for debugging.
+        re_path('^admin/', admin.site.urls),
+    
+        path('', application.urls),
+    ]
+
+
 Search backend
 ==============
 If you're happy with basic search for now, you can just add Haystack's simple

--- a/docs/source/internals/getting_started.rst
+++ b/docs/source/internals/getting_started.rst
@@ -172,39 +172,23 @@ you will also need to include Django's i18n URLs:
 
 .. code-block:: django
 
-    from django.conf.urls import include, url
+    from django.conf.urls import include, url  # < Django-2.0
+    # from django.urls import include, path  # > Django-2.0
     from django.contrib import admin
     from oscar.app import application
 
     urlpatterns = [
         url(r'^i18n/', include('django.conf.urls.i18n')),
+        # path('i18n/', include('django.conf.urls.i18n')),  # > Django-2.0
 
         # The Django admin is not officially supported; expect breakage.
         # Nonetheless, it's often useful for debugging.
+
         url(r'^admin/', admin.site.urls),
+        # path('admin/', admin.site.urls),  # > Django-2.0
 
-        url(r'', include(application.urls)),
-    ]
-
-For `Django > 1.9`_ pass ``application.urls`` directly to ``path``. For `Django > 2.0`_ use ``path`` and ``re_path`` instead of ``url``.:
-
-.. _`Django > 2.0`: https://docs.djangoproject.com/en/2.0/releases/2.0/#simplified-url-routing-syntax
-.. _`Django > 1.9`: https://docs.djangoproject.com/en/2.0/releases/1.9/#passing-a-3-tuple-or-an-app-name-to-include
-
-.. code-block:: django
-
-    from django.contrib import admin
-    from django.urls import path, include, re_path
-    from oscar.app import application
-
-    urlpatterns = [
-        re_path('^i18n/', include('django.conf.urls.i18n')),
-
-        # The Django admin is not officially supported; expect breakage.
-        # Nonetheless, it's often useful for debugging.
-        re_path('^admin/', admin.site.urls),
-    
-        path('', application.urls),
+        url(r'', application.urls),
+        # path('', application.urls),  # > Django-2.0
     ]
 
 


### PR DESCRIPTION
Django 2.0  uses django.urls.path() function which allows for a simpler, more readable URL routing syntax.

From Django 1.9, application.urls should be passed directly,  without include.