### PR TITLE
Deprecate ProductManager and BrowsableProductManager

### DIFF
--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -20,14 +20,14 @@ from django.utils.translation import gettext_lazy as _
 from django.utils.translation import get_language, pgettext_lazy
 from treebeard.mp_tree import MP_Node
 
-from oscar.core.loading import get_class, get_model
+from oscar.core.loading import get_class, get_classes, get_model
 from oscar.core.utils import slugify
 from oscar.core.validators import non_python_keyword
 from oscar.models.fields import AutoSlugField, NullCharField
 from oscar.models.fields.slugfield import SlugField
 
-ProductQuerySet = get_class(
-    'catalogue.managers', 'ProductQuerySet')
+ProductQuerySet, BrowsableProductQuerySet = get_classes(
+    'catalogue.managers', ['ProductQuerySet', 'BrowsableProductQuerySet'])
 ProductAttributesContainer = get_class(
     'catalogue.product_attributes', 'ProductAttributesContainer')
 Selector = get_class('partner.strategy', 'Selector')

--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -20,14 +20,14 @@ from django.utils.translation import gettext_lazy as _
 from django.utils.translation import get_language, pgettext_lazy
 from treebeard.mp_tree import MP_Node
 
-from oscar.core.loading import get_class, get_classes, get_model
+from oscar.core.loading import get_class, get_model
 from oscar.core.utils import slugify
 from oscar.core.validators import non_python_keyword
 from oscar.models.fields import AutoSlugField, NullCharField
 from oscar.models.fields.slugfield import SlugField
 
-ProductManager, BrowsableProductManager = get_classes(
-    'catalogue.managers', ['ProductManager', 'BrowsableProductManager'])
+ProductQuerySet = get_class(
+    'catalogue.managers', 'ProductQuerySet')
 ProductAttributesContainer = get_class(
     'catalogue.product_attributes', 'ProductAttributesContainer')
 Selector = get_class('partner.strategy', 'Selector')
@@ -347,8 +347,8 @@ class AbstractProduct(models.Model):
             "This flag indicates if this product can be used in an offer "
             "or not"))
 
-    objects = ProductManager()
-    browsable = BrowsableProductManager()
+    objects = ProductQuerySet.as_manager()
+    browsable = ProductQuerySet.as_manager().browsable()
 
     class Meta:
         abstract = True

--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -348,7 +348,7 @@ class AbstractProduct(models.Model):
             "or not"))
 
     objects = ProductQuerySet.as_manager()
-    browsable = ProductQuerySet.as_manager().browsable()
+    browsable = BrowsableProductQuerySet.as_manager()
 
     class Meta:
         abstract = True

--- a/src/oscar/apps/catalogue/managers.py
+++ b/src/oscar/apps/catalogue/managers.py
@@ -17,16 +17,25 @@ class ProductQuerySet(models.query.QuerySet):
     def browsable(self):
         """
         Excludes non-canonical products.
+
+        Method is deprecated. Use BrowsableProductQuerySet instead.
         """
         return self.filter(parent=None)
+
+class BrowsableProductQuerySet(ProductQuerySet):
+
+    def base_queryset(self):
+        """
+        Excludes non-canonical products
+        """
+        return super().base_queryset().filter(parent=None)
 
 
 class ProductManager(models.Manager):
     """
     Uses ProductQuerySet and proxies its methods to allow chaining
 
-    Use of this class is deprecated. Use ProductQuerySet.as_manager()
-    instead.
+    Use of this class is deprecated. Use ProductQuerySet.as_manager() instead.
     """
 
     def get_queryset(self):
@@ -43,8 +52,7 @@ class BrowsableProductManager(ProductManager):
     """
     Excludes non-canonical products
 
-    Use of this class is deprecated. Use ProductQuerySet.as_manager().browsable()
-    instead.
+    Use of this class is deprecated. Use BrowsableProductQuerySet.as_manager() instead.
     """
 
     def get_queryset(self):

--- a/src/oscar/apps/catalogue/managers.py
+++ b/src/oscar/apps/catalogue/managers.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.db.models import Count
-
+from oscar.core.decorators import deprecated
 
 class ProductQuerySet(models.query.QuerySet):
 
@@ -30,7 +30,7 @@ class BrowsableProductQuerySet(ProductQuerySet):
         """
         return super().base_queryset().filter(parent=None)
 
-
+@deprecated
 class ProductManager(models.Manager):
     """
     Uses ProductQuerySet and proxies its methods to allow chaining
@@ -47,7 +47,7 @@ class ProductManager(models.Manager):
     def base_queryset(self):
         return self.get_queryset().base_queryset()
 
-
+@deprecated
 class BrowsableProductManager(ProductManager):
     """
     Excludes non-canonical products

--- a/src/oscar/apps/catalogue/managers.py
+++ b/src/oscar/apps/catalogue/managers.py
@@ -25,8 +25,8 @@ class ProductManager(models.Manager):
     """
     Uses ProductQuerySet and proxies its methods to allow chaining
 
-    Once Django 1.7 lands, this class can probably be removed:
-    https://docs.djangoproject.com/en/dev/releases/1.7/#calling-custom-queryset-methods-from-the-manager  # noqa
+    Use of this class is deprecated. Use ProductQuerySet.as_manager()
+    instead.
     """
 
     def get_queryset(self):
@@ -43,7 +43,8 @@ class BrowsableProductManager(ProductManager):
     """
     Excludes non-canonical products
 
-    Could be deprecated after Oscar 0.7 is released
+    Use of this class is deprecated. Use ProductQuerySet.as_manager().browsable()
+    instead.
     """
 
     def get_queryset(self):


### PR DESCRIPTION
Summary of changes addressing issue #2756 [UPDATED]:

- added deprecation note in docstring for `catalogue.managers.ProductManager`, `catalogue.managers.BrowsableProductManager`, and `catalogue.managers.ProductQuerySet.browsable()`
- updated `AbstractProduct.objects` to use `ProductQuerySet.as_manager()`
- created `catalogue.managers.BrowsableProductQuerySet`
- updated `AbstractProduct.browsable` to use `BrowsableProductQuerySet.as_manager()`