### PR TITLE
Deprecate Range.contains() alias for Range.contains_product()

### DIFF
--- a/docs/source/releases/v2.0.rst
+++ b/docs/source/releases/v2.0.rst
@@ -83,3 +83,5 @@ Dependency changes
 
 Deprecated features
 ~~~~~~~~~~~~~~~~~~~
+
+- ``offer.Range.contains()`` is deprecated. Use ``contains_product()`` instead.

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -16,6 +16,7 @@ from django.utils.timezone import get_current_timezone, now
 from django.utils.translation import gettext_lazy as _
 
 from oscar.core.compat import AUTH_USER_MODEL
+from oscar.core.decorators import deprecated
 from oscar.core.loading import get_class, get_classes, get_model
 from oscar.models import fields
 from oscar.templatetags.currency_filters import currency
@@ -655,8 +656,7 @@ class AbstractBenefit(BaseOfferMixin, models.Model):
         for line in basket.all_lines():
             product = line.product
 
-            if (not range.contains(product) or
-                    not self.can_apply_benefit(line)):
+            if (not range.contains_product(product) or not self.can_apply_benefit(line)):
                 continue
 
             price = unit_price(offer, line)
@@ -907,8 +907,10 @@ class AbstractRange(models.Model):
                         return True
         return False
 
-    # Shorter alias
-    contains = contains_product
+    # Deprecated alias
+    @deprecated
+    def contains(self, product):
+        return self.contains_product(product)
 
     def __get_pks_and_child_pks(self, queryset):
         """


### PR DESCRIPTION
Having a method alias like this makes it easy to break things when this class is overridden. 

If you override `contains_product()`, you would reasonably expect all calls to that method to use your overridden method. However `contains()` is not overridden and will continue to use the core method instead of the one you have replaced it with. Rather than expect a project to figure this out, we should just remove the alias.