### PR TITLE
Fix example in shipping repository documentation

### DIFF
--- a/docs/source/howto/how_to_configure_shipping.rst
+++ b/docs/source/howto/how_to_configure_shipping.rst
@@ -83,10 +83,8 @@ For more complex logic, override the ``get_available_shipping_methods`` method:
 
    class Repository(repository.Repository):
 
-       def get_available_shipping_methods(
-               self, basket, user=None, shipping_addr=None,
-               request=None, **kwargs):
-           methods = (methods.Standard())
+       def get_available_shipping_methods(self, basket, user=None, shipping_addr=None, request=None, **kwargs):
+           methods = (methods.Standard(),)
            if shipping_addr and shipping_addr.country.code == 'GB':
                # Express is only available in the UK
                methods = (methods.Standard(), methods.Express())


### PR DESCRIPTION
`get_available_shipping_methods` must always return an iterable.