### PR TITLE
fix: usr: handle exception if SMTP Recipient is refused by server

### DIFF
--- a/src/oscar/apps/customer/utils.py
+++ b/src/oscar/apps/customer/utils.py
@@ -1,4 +1,5 @@
 import logging
+import smtplib
 
 from django.conf import settings
 from django.contrib.auth.tokens import default_token_generator
@@ -8,6 +9,7 @@ from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
 
 from oscar.core.loading import get_model
+
 
 
 CommunicationEvent = get_model('order', 'CommunicationEvent')
@@ -120,7 +122,10 @@ class Dispatcher(object):
         if self.mail_connection:
             self.mail_connection.send_messages([email])
         else:
-            email.send()
+            try:
+                email.send()
+            except smtplib.SMTPRecipientsRefused:
+                self.logger.warning("Sending email to %s failed. [SMTPRecipientsRefused]" % recipient)
 
         return email
 


### PR DESCRIPTION
Service fails if customer has a fake email address - missing try except block

  File "/home/pmarkowski/workspace/mtechnology/shop/venv/lib/python3.6/site-packages/oscar/apps/customer/utils.py", line 123, in send_email_messages
    email.send()
  File "/home/pmarkowski/workspace/mtechnology/shop/venv/lib/python3.6/site-packages/django/core/mail/message.py", line 294, in send
    return self.get_connection(fail_silently).send_messages([self])
  File "/home/pmarkowski/workspace/mtechnology/shop/venv/lib/python3.6/site-packages/django/core/mail/backends/smtp.py", line 110, in send_messages
    sent = self._send(message)
  File "/home/pmarkowski/workspace/mtechnology/shop/venv/lib/python3.6/site-packages/django/core/mail/backends/smtp.py", line 126, in _send
    self.connection.sendmail(from_email, recipients, message.as_bytes(linesep='\r\n'))
  File "/usr/lib64/python3.6/smtplib.py", line 881, in sendmail
    raise SMTPRecipientsRefused(senderrs)
smtplib.SMTPRecipientsRefused: {'wemiefwnifewnwfin@efwfewefw.pl': (450, b'4.1.2 <wemiefwnifewnwfin@efwfewefw.pl>: Recipient address rejected: Domain not found')}
ERROR 2018-07-29 14:54:55,237 [/home/pmarkowski/workspace/mtechnology/shop/venv/lib/python3.6/site-packages/django/core/servers/basehttp.py:124]
-- "POST /platnosci/accept/6/ HTTP/1.1" 500 226053