### PR TITLE
Improve charge computation in `WeightBased` shipping method

### DIFF
--- a/src/oscar/apps/shipping/abstract_models.py
+++ b/src/oscar/apps/shipping/abstract_models.py
@@ -151,13 +151,16 @@ class AbstractWeightBased(AbstractBase):
             return D('0.00')
 
         top_band = self.top_band
-        if weight < top_band.upper_limit:
+        if weight <= top_band.upper_limit:
             band = self.get_band_for_weight(weight)
             return band.charge
         else:
             quotient, remaining_weight = divmod(weight, top_band.upper_limit)
-            remainder_band = self.get_band_for_weight(remaining_weight)
-            return quotient * top_band.charge + remainder_band.charge
+            if remaining_weight:
+                remainder_band = self.get_band_for_weight(remaining_weight)
+                return quotient * top_band.charge + remainder_band.charge
+            else:
+                return quotient * top_band.charge
 
     def get_band_for_weight(self, weight):
         """

--- a/tests/integration/shipping/test_model_method.py
+++ b/tests/integration/shipping/test_model_method.py
@@ -222,3 +222,26 @@ class WeightBasedMethodTests(TestCase):
         method = Repository().apply_shipping_offer(
             basket, self.standard, offer)
         self.assertEqual(D('0.00'), method.discount(basket))
+
+    def test_get_charge_when_weight_is_divided_by_top_band_upper_limit_without_remainder(self):
+        # In case we have next bands
+        #       Upper limit, kg    Charge, USD
+        #       1                  2.00
+        #       2                  6.00
+        self.standard.bands.create(upper_limit=1, charge=D('2.00'))
+        self.standard.bands.create(upper_limit=2, charge=D('6.00'))
+
+        # for weight 100 kg we should get charge 300 USD:
+        # 100 kg / 2 kg * 6 USD = 300 USD
+        self.assertEqual(D('300.00'), self.standard.get_charge(100))
+
+        # for weight 100.01 kg we should get charge 302 USD:
+        #  (100 kg / 2 kg * 6 USD = 300 USD) + (2 USD for remainder 0.01 kg) = 302 USD
+        self.assertEqual(D('302.00'), self.standard.get_charge(100.01))
+
+        # for weight 2 kg we should get charge 6 USD
+        self.assertEqual(D('6.00'), self.standard.get_charge(2))
+
+        # for weight 2.01 kg we should get charge 8 USD:
+        # (2 kg / 2 kg * 6 USD = 6 USD) + (2 USD for remainder 0.01 kg) = 8 USD
+        self.assertEqual(D('8.00'), self.standard.get_charge(2.01))


### PR DESCRIPTION
When `remaining_weight` is "0" (zero) we should not get band for it.