### PR TITLE
Deprecate ProductManager and BrowsableProductManager.

### DIFF
--- a/docs/source/releases/v2.0.rst
+++ b/docs/source/releases/v2.0.rst
@@ -138,3 +138,9 @@ Deprecated features
 ~~~~~~~~~~~~~~~~~~~
 
 - ``offer.Range.contains()`` is deprecated. Use ``contains_product()`` instead.
+
+- ``catalogue.managers.ProductManager`` is deprecated.
+  Use ``catalogue.managers.ProductQuerySet.as_manager()`` instead.
+
+- ``catalogue.managers.BrowsableProductManager`` is deprecated.
+  Use ``Product.objects.browsable()`` instead.

--- a/sandbox/apps/sitemaps.py
+++ b/sandbox/apps/sitemaps.py
@@ -48,7 +48,7 @@ class StaticSitemap(I18nSitemap):
 class ProductSitemap(I18nSitemap):
 
     def items(self):
-        return Product.browsable.all()
+        return Product.objects.browsable()
 
 
 class CategorySitemap(I18nSitemap):

--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -20,14 +20,14 @@ from django.utils.translation import gettext_lazy as _
 from django.utils.translation import get_language, pgettext_lazy
 from treebeard.mp_tree import MP_Node
 
-from oscar.core.loading import get_class, get_classes, get_model
+from oscar.core.loading import get_class, get_model
 from oscar.core.utils import slugify
 from oscar.core.validators import non_python_keyword
 from oscar.models.fields import AutoSlugField, NullCharField
 from oscar.models.fields.slugfield import SlugField
 
-ProductManager, BrowsableProductManager = get_classes(
-    'catalogue.managers', ['ProductManager', 'BrowsableProductManager'])
+BrowsableProductManager = get_class('catalogue.managers', 'BrowsableProductManager')
+ProductQuerySet = get_class('catalogue.managers', 'ProductQuerySet')
 ProductAttributesContainer = get_class(
     'catalogue.product_attributes', 'ProductAttributesContainer')
 Selector = get_class('partner.strategy', 'Selector')
@@ -324,7 +324,9 @@ class AbstractProduct(models.Model):
             "This flag indicates if this product can be used in an offer "
             "or not"))
 
-    objects = ProductManager()
+    objects = ProductQuerySet.as_manager()
+    # browsable property is deprecated and will be removed in Oscar 2.1
+    # Use Product.objects.browsable() instead.
     browsable = BrowsableProductManager()
 
     class Meta:

--- a/src/oscar/apps/catalogue/managers.py
+++ b/src/oscar/apps/catalogue/managers.py
@@ -1,6 +1,8 @@
 from django.db import models
 from django.db.models import Count
 
+from oscar.core.decorators import deprecated
+
 
 class ProductQuerySet(models.query.QuerySet):
 
@@ -21,12 +23,10 @@ class ProductQuerySet(models.query.QuerySet):
         return self.filter(parent=None)
 
 
+@deprecated
 class ProductManager(models.Manager):
     """
-    Uses ProductQuerySet and proxies its methods to allow chaining
-
-    Once Django 1.7 lands, this class can probably be removed:
-    https://docs.djangoproject.com/en/dev/releases/1.7/#calling-custom-queryset-methods-from-the-manager  # noqa
+    Deprecated. Use ProductQuerySet.as_manager() instead.
     """
 
     def get_queryset(self):
@@ -41,10 +41,13 @@ class ProductManager(models.Manager):
 
 class BrowsableProductManager(ProductManager):
     """
-    Excludes non-canonical products
+    Deprecated. Use Product.objects.browsable() instead.
 
-    Could be deprecated after Oscar 0.7 is released
+    The @deprecated decorator isn't applied to the class, because doing
+    so would log warnings, and we still initialise this class
+    in the Product.browsable for backward compatibility.
     """
 
+    @deprecated
     def get_queryset(self):
         return super().get_queryset().browsable()

--- a/src/oscar/apps/catalogue/search_handlers.py
+++ b/src/oscar/apps/catalogue/search_handlers.py
@@ -94,7 +94,7 @@ class SimpleProductSearchHandler(MultipleObjectMixin):
         self.object_list = self.get_queryset()
 
     def get_queryset(self):
-        qs = Product.browsable.base_queryset()
+        qs = Product.objects.browsable().base_queryset()
         if self.categories:
             qs = qs.filter(categories__in=self.categories).distinct()
         return qs

--- a/src/oscar/apps/customer/history.py
+++ b/src/oscar/apps/customer/history.py
@@ -14,7 +14,7 @@ def get(request):
     ids = extract(request)
 
     # Reordering as the ID order gets messed up in the query
-    product_dict = Product.browsable.in_bulk(ids)
+    product_dict = Product.objects.browsable().in_bulk(ids)
     ids.reverse()
     return [product_dict[id] for id in ids if id in product_dict]
 

--- a/src/oscar/apps/dashboard/catalogue/views.py
+++ b/src/oscar/apps/dashboard/catalogue/views.py
@@ -120,7 +120,7 @@ class ProductListView(SingleTableView):
         """
         Build the queryset for this list
         """
-        queryset = Product.browsable.base_queryset()
+        queryset = Product.objects.browsable().base_queryset()
         queryset = self.filter_queryset(queryset)
         queryset = self.apply_search(queryset)
         return queryset

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -443,7 +443,7 @@ class AbstractConditionalOffer(models.Model):
         cond_range = self.condition.range
         if cond_range.includes_all_products:
             # Return ALL the products
-            queryset = Product.browsable
+            queryset = Product.objects.browsable()
         else:
             queryset = cond_range.all_products()
         return queryset.filter(is_discountable=True).exclude(
@@ -987,7 +987,7 @@ class AbstractRange(models.Model):
         Product = get_model("catalogue", "Product")
         if self.includes_all_products:
             # Filter out child products
-            return Product.browsable.all()
+            return Product.objects.browsable()
 
         return Product.objects.filter(
             Q(id__in=self._included_product_ids()) |

--- a/src/oscar/apps/promotions/models.py
+++ b/src/oscar/apps/promotions/models.py
@@ -313,7 +313,7 @@ class AutomaticProductList(AbstractProductList):
 
     def get_queryset(self):
         Product = get_model('catalogue', 'Product')
-        qs = Product.browsable.base_queryset().select_related('stats')
+        qs = Product.objects.browsable().base_queryset().select_related('stats')
         if self.method == self.BESTSELLING:
             return qs.order_by('-stats__score')
         return qs.order_by('-date_created')

--- a/src/oscar/core/decorators.py
+++ b/src/oscar/core/decorators.py
@@ -1,6 +1,6 @@
 import warnings
 
-from oscar.utils.deprecation import RemovedInOscar20Warning
+from oscar.utils.deprecation import RemovedInOscar21Warning
 
 
 def deprecated(obj):
@@ -10,7 +10,7 @@ def deprecated(obj):
         return _deprecated_func(f=obj)
 
 
-def _deprecated_func(f, warn_cls=RemovedInOscar20Warning):
+def _deprecated_func(f, warn_cls=RemovedInOscar21Warning):
     def _deprecated(*args, **kwargs):
         message = "Method '%s' is deprecated and will be " \
             "removed in the next version of django-oscar" \
@@ -20,7 +20,7 @@ def _deprecated_func(f, warn_cls=RemovedInOscar20Warning):
     return _deprecated
 
 
-def _deprecated_cls(cls, warn_cls=RemovedInOscar20Warning):
+def _deprecated_cls(cls, warn_cls=RemovedInOscar21Warning):
     class Deprecated(cls):
         def __init__(self, *args, **kwargs):
             message = "Class '%s' is deprecated and will be " \

--- a/src/oscar/utils/deprecation.py
+++ b/src/oscar/utils/deprecation.py
@@ -1,2 +1,2 @@
-class RemovedInOscar20Warning(DeprecationWarning):
+class RemovedInOscar21Warning(DeprecationWarning):
     pass

--- a/tests/integration/catalogue/test_options.py
+++ b/tests/integration/catalogue/test_options.py
@@ -23,14 +23,14 @@ class ProductOptionTests(TestCase):
 
     def test_queryset_per_product_class(self):
         self.product_class.options.add(self.option)
-        qs = Product.browsable.base_queryset().filter(id=self.product.id)
+        qs = Product.objects.browsable().base_queryset().filter(id=self.product.id)
         product = qs.first()
         self.assertTrue(product.has_options)
         self.assertEquals(product.num_product_class_options, 1)
 
     def test_queryset_per_product(self):
         self.product.product_options.add(self.option)
-        qs = Product.browsable.base_queryset().filter(id=self.product.id)
+        qs = Product.objects.browsable().base_queryset().filter(id=self.product.id)
         product = qs.first()
         self.assertTrue(product.has_options)
         self.assertEquals(product.num_product_options, 1)

--- a/tests/integration/catalogue/test_product.py
+++ b/tests/integration/catalogue/test_product.py
@@ -70,6 +70,12 @@ class TopLevelProductTests(ProductTests):
     def test_top_level_products_are_part_of_browsable_set(self):
         product = Product.objects.create(
             product_class=self.product_class, title="Kopfhörer")
+        self.assertEqual(set([product]), set(Product.objects.browsable()))
+
+    def test_top_level_products_are_part_of_browsable_deprecated(self):
+        # Test for deprecated Product.browsable.
+        product = Product.objects.create(
+            product_class=self.product_class, title="Kopfhörer")
         self.assertEqual(set([product]), set(Product.browsable.all()))
 
 
@@ -100,6 +106,13 @@ class ChildProductTests(ProductTests):
         self.assertEqual(False, p.get_is_discountable())
 
     def test_child_products_are_not_part_of_browsable_set(self):
+        Product.objects.create(
+            product_class=self.product_class, parent=self.parent,
+            structure=Product.CHILD)
+        self.assertEqual(set([self.parent]), set(Product.objects.browsable()))
+
+    def test_child_products_are_not_part_of_browsable_deprecated(self):
+        # Test for deprecated Product.browsable
         Product.objects.create(
             product_class=self.product_class, parent=self.parent,
             structure=Product.CHILD)


### PR DESCRIPTION
Fixes #2756.

1. Deprecate `ProductManager` - use `ProductQuerySet.as_manager()` instead. Support for this was [added in Django 1.7](https://docs.djangoproject.com/en/dev/releases/1.7/#calling-custom-queryset-methods-from-the-manager).

2. Deprecate `BrowsableProductManager` - use `Product.objects.browsable()` instead.

These changes make it much easier to override the product manager.

Edit: I thought about moving `managers.ProductQuerySet` to `querysets.ProductQuerySet` but decided against it - too much hassle for not much gain.