### PR TITLE
Fix address hash generate bug and success_url consistent

### DIFF
--- a/src/oscar/apps/checkout/mixins.py
+++ b/src/oscar/apps/checkout/mixins.py
@@ -175,13 +175,14 @@ class OrderPlacementMixin(CheckoutSessionMixin):
         """
         Update the user's address book based on the new shipping address
         """
+        # Create a new user address
+        user_addr = UserAddress(user=user)
+        addr.populate_alternative_model(user_addr)
         try:
             user_addr = user.addresses.get(
-                hash=addr.generate_hash())
+                hash=user_addr.generate_hash())
         except ObjectDoesNotExist:
-            # Create a new user address
-            user_addr = UserAddress(user=user)
-            addr.populate_alternative_model(user_addr)
+            pass
         if isinstance(addr, ShippingAddress):
             user_addr.num_orders_as_shipping_address += 1
         if isinstance(addr, BillingAddress):

--- a/src/oscar/apps/checkout/views.py
+++ b/src/oscar/apps/checkout/views.py
@@ -251,6 +251,9 @@ class ShippingMethodView(CheckoutSessionMixin, generic.FormView):
     pre_conditions = ['check_basket_is_not_empty',
                       'check_basket_is_valid',
                       'check_user_email_is_captured']
+    success_url = redirect('checkout:payment-method')
+
+
 
     def post(self, request, *args, **kwargs):
         self._methods = self.get_available_shipping_methods()
@@ -327,7 +330,7 @@ class ShippingMethodView(CheckoutSessionMixin, generic.FormView):
         return super().form_invalid(form)
 
     def get_success_response(self):
-        return redirect('checkout:payment-method')
+        return self.success_url
 
 
 # ==============
@@ -349,6 +352,7 @@ class PaymentMethodView(CheckoutSessionMixin, generic.TemplateView):
         'check_user_email_is_captured',
         'check_shipping_data_is_captured']
     skip_conditions = ['skip_unless_payment_is_required']
+    success_url = redirect('checkout:payment-details')
 
     def get(self, request, *args, **kwargs):
         # By default we redirect straight onto the payment details view. Shops
@@ -357,7 +361,7 @@ class PaymentMethodView(CheckoutSessionMixin, generic.TemplateView):
         return self.get_success_response()
 
     def get_success_response(self):
-        return redirect('checkout:payment-details')
+        return self.success_url
 
 
 # ================


### PR DESCRIPTION
Success_url consistent on the views i saw that not every view in the checkout flow uses a success_url so now it will

I also ran into a bug when generating a hash it. It wanted to save a new user address but the hash already existed so it crashed the checkout flow 
 