### PR TITLE
Fix debug error URLs whose handlers now require an exception.

### DIFF
--- a/sandbox/urls.py
+++ b/sandbox/urls.py
@@ -41,12 +41,11 @@ if settings.DEBUG:
     import debug_toolbar
 
     # Server statics and uploaded media
-    urlpatterns += static(settings.MEDIA_URL,
-                          document_root=settings.MEDIA_ROOT)
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
     # Allow error pages to be tested
     urlpatterns += [
-        url(r'^403$', handler403),
-        url(r'^404$', handler404),
+        url(r'^403$', handler403, {'exception': Exception()}),
+        url(r'^404$', handler404, {'exception': Exception()}),
         url(r'^500$', handler500),
         url(r'^__debug__/', include(debug_toolbar.urls)),
     ]


### PR DESCRIPTION
Since Django 2.0 the 403 and 404 handlers must accept an `exception` argument (this was introduced in Django 1.9). This patches the debug URLs to pass a dummy exception.