### PR TITLE
Added setting for calculating offer discounts over the price including tax.

### DIFF
--- a/docs/source/ref/settings.rst
+++ b/docs/source/ref/settings.rst
@@ -317,6 +317,18 @@ Default: Round down to the nearest hundredth of a unit using ``decimal.Decimal.q
 A function responsible for rounding decimal amounts when offer discount
 calculations don't lead to legitimate currency values.
 
+``OSCAR_OFFERS_INCL_TAX``
+
+Default: ``False``
+
+If ``True``, offers will be applied to prices including taxes instead of on
+prices excluding tax. Oscar used to always calculate offers on prices excluding
+tax so the default is ``False``. This setting also affects the meaning of
+absolute prices in offers. So a flat discount of 10 pounds in an offer will
+be treated as 10 pounds before taxes if ``OSCAR_OFFERS_INCL_TAX`` remains
+``False`` and 10 pounds after taxes if ``OSCAR_OFFERS_INCL_TAX`` is set to
+``True``.
+
 Basket settings
 ===============
 

--- a/docs/source/releases/v2.0.rst
+++ b/docs/source/releases/v2.0.rst
@@ -29,6 +29,10 @@ Support for Python 2.7 and Python 3.4 has been dropped.
 What's new in Oscar 2.0?
 ------------------------
 
+- Added an ``OSCAR_OFFERS_INCL_TAX`` setting which can be used to configure whether
+  offer discounts are applied on the tax-inclusive amount. This defaults to ``False``,
+  to preserve the original behaviour of discount application.
+
 Removal of deprecated features
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/oscar/apps/offer/benefits.py
+++ b/src/oscar/apps/offer/benefits.py
@@ -1,5 +1,6 @@
 from decimal import Decimal as D
 
+from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 from oscar.core.loading import get_class, get_classes, get_model
@@ -19,11 +20,13 @@ __all__ = [
 ]
 
 
-def apply_discount(line, discount, quantity, offer=None):
+def apply_discount(line, discount, quantity, offer=None, incl_tax=None):
     """
     Apply a given discount to the passed basket
     """
-    line.discount(discount, quantity, incl_tax=False, offer=offer)
+    # use OSCAR_OFFERS_INCL_TAX setting if incl_tax is left unspecified.
+    incl_tax = incl_tax if incl_tax is not None else settings.OSCAR_OFFERS_INCL_TAX
+    line.discount(discount, quantity, incl_tax=incl_tax, offer=offer)
 
 
 class PercentageDiscountBenefit(Benefit):

--- a/src/oscar/core/utils.py
+++ b/src/oscar/core/utils.py
@@ -1,7 +1,9 @@
 import datetime
+import decimal
 import logging
 import re
 import unicodedata
+
 from babel.dates import format_timedelta as format_td
 
 from django.conf import settings
@@ -168,3 +170,18 @@ def get_default_currency():
     OSCAR_DEFAULT_CURRENCY as something it needs to generate a migration for.
     """
     return settings.OSCAR_DEFAULT_CURRENCY
+
+
+def round_half_up(money):
+    """
+    Explicitly round a decimal to 2 places half up, as should be used for
+    money.
+
+    >>> exponent = decimal.Decimal('0.01')
+    >>> should_not_be_one = decimal.Decimal('1.005')
+    >>> should_not_be_one.quantize(exponent)
+    Decimal('1.00')
+    >>> round_half_up(should_not_be_one)
+    Decimal('1.01')
+    """
+    return money.quantize(decimal.Decimal('0.01'), decimal.ROUND_HALF_UP)

--- a/src/oscar/defaults.py
+++ b/src/oscar/defaults.py
@@ -87,6 +87,9 @@ OSCAR_SLUG_ALLOW_UNICODE = False
 # Cookies
 OSCAR_COOKIES_DELETE_ON_LOGOUT = ['oscar_recently_viewed_products', ]
 
+# Offers
+OSCAR_OFFERS_INCL_TAX = False
+
 # Hidden Oscar features, e.g. wishlists or reviews
 OSCAR_HIDDEN_FEATURES = []
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -126,3 +126,4 @@ OSCAR_LINE_STATUS_PIPELINE = {'a': ('b', ), 'b': ()}
 
 SECRET_KEY = 'notverysecret'
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'
+FIXTURE_DIRS = [location('unit/fixtures')]

--- a/tests/unit/basket/test_offers.py
+++ b/tests/unit/basket/test_offers.py
@@ -1,0 +1,159 @@
+from decimal import Decimal as D, ROUND_HALF_UP
+
+from django.test import TestCase, RequestFactory
+from django.urls import reverse
+from django.conf import settings
+
+from oscar.core.loading import get_model, get_class, get_classes
+from oscar.test.factories import UserFactory
+
+Basket = get_model("basket", "Basket")
+Product = get_model("catalogue", "Product")
+factory = RequestFactory()
+Applicator = get_class("offer.applicator", "Applicator")
+Selector, UK = get_classes("partner.strategy", ["Selector", "UK"])
+
+
+class UKSelector(Selector):
+    def strategy(self, request=None, user=None, **kwargs):
+        return UK(request)
+
+
+def money(amount):
+    return amount.quantize(D("0.01"), ROUND_HALF_UP)
+
+
+def get_user_basket(user, request):
+    editable_baskets = Basket.objects.filter(status__in=["Open", "Saved"])
+    basket, __ = editable_baskets.get_or_create(owner=user)
+    basket.strategy = UKSelector().strategy(request=request, user=user)
+    basket.reset_offer_applications()
+    if not basket.is_empty:
+        Applicator().apply(basket, user, request)
+    request.session[settings.OSCAR_BASKET_COOKIE_OPEN] = basket.pk
+    request.session.save()
+    return basket
+
+
+class OfferTest(TestCase):
+    fixtures = ["catalogue", "offer"]
+
+    def check_general_truths(self, basket):
+        inverse_tax_multiplier = D(1) / (D(1) + UK.rate)
+        calculated_total_excl_tax = money(
+            inverse_tax_multiplier * basket.total_incl_tax
+        )
+
+        self.assertEqual(
+            calculated_total_excl_tax,
+            basket.total_excl_tax,
+            "The total price without tax should conform to the standard "
+            "formula for calculating tax (as a percentage)",
+        )
+        self.assertAlmostEqual(
+            basket.total_excl_tax_excl_discounts / basket.total_incl_tax_excl_discounts,
+            basket.total_excl_tax / basket.total_incl_tax,
+            4,
+            "The ratio of price with tax and without tax should be the same for the "
+            "price with and without discounts. If that is not the case people would "
+            "be able to change the tax they must pay by gaming the discount.",
+        )
+        self.assertNotAlmostEqual(
+            basket.total_excl_tax_excl_discounts - basket.total_excl_tax,
+            basket.total_incl_tax_excl_discounts - basket.total_incl_tax,
+            2,
+            "The discount over the total excluding tax can never be the same as "
+            "the discount over the total including tax. Otherwise our tax rate"
+            "would not be linear over the amount.",
+        )
+        self.assertEqual(
+            basket.total_excl_tax + basket.total_tax,
+            basket.total_incl_tax,
+            "The tax summation should amount to the total_incl_tax"
+        )
+
+    def test_offer_incl_tax(self):
+        "The offer should be calculated as if it was declared including tax"
+        with self.settings(OSCAR_OFFERS_INCL_TAX=True):
+            self.assertEqual(Basket.objects.count(), 0)
+
+            admin = UserFactory()
+            self.client.force_login(admin)
+
+            # throw an item in the basket
+            basket_add_url = reverse("basket:add", args=(2,))
+            body = {"quantity": 1}
+            response = self.client.post(basket_add_url, body)
+
+            # throw another item in the basket so the offer activates
+            basket_add_url = reverse("basket:add", args=(3,))
+            body = {"quantity": 2}
+            response = self.client.post(basket_add_url, body)
+
+            request = factory.post(basket_add_url, body)
+            request.user = admin
+            request.session = self.client.session
+
+            basket = get_user_basket(admin, request)
+
+            self.assertEqual(response.status_code, 302)
+            self.assertEqual(Basket.objects.count(), 1)
+
+            # now go and check if the offer was applied correctly
+            self.assertEqual(
+                basket.total_incl_tax_excl_discounts - basket.total_incl_tax,
+                D("10.00"),
+                "The offer should be a flat 10 pound discount on the total "
+                "including tax",
+            )
+            self.assertEqual(
+                basket.total_discount,
+                D("10.00"),
+                "The total discount property should properly reflect the discount"
+                "applied.",
+            )
+            self.check_general_truths(basket)
+
+    def test_offer_excl_tax(self):
+        "The offer should be calculated as if it was declared excluding tax"
+        with self.settings(OSCAR_OFFERS_INCL_TAX=False):
+            self.assertEqual(Basket.objects.count(), 0)
+
+            admin = UserFactory()
+            self.client.force_login(admin)
+
+            # throw an item in the basket
+            basket_add_url = reverse("basket:add", args=(2,))
+            body = {"quantity": 1}
+            response = self.client.post(basket_add_url, body)
+
+            # throw another item in the basket so the offer activates
+            basket_add_url = reverse("basket:add", args=(3,))
+            body = {"quantity": 2}
+            response = self.client.post(basket_add_url, body)
+
+            # now go and check if dat offer was handled correctly
+            request = factory.post(basket_add_url, body)
+            request.user = admin
+            request.session = self.client.session
+
+            basket = get_user_basket(admin, request)
+
+            self.assertEqual(response.status_code, 302)
+            self.assertEqual(Basket.objects.count(), 1)
+
+            # now go and check if the offer was applied correctly
+            self.assertEqual(
+                basket.total_excl_tax_excl_discounts - basket.total_excl_tax,
+                D("10.00"),
+                "The offer should be a flat 10 pound discount on the total "
+                "excluding tax",
+            )
+            self.assertEqual(
+                basket.total_discount,
+                D("10.00"),
+                "The total discount property should properly reflect the discount"
+                "applied.",
+            )
+
+            self.check_general_truths(basket)

--- a/tests/unit/fixtures/catalogue.json
+++ b/tests/unit/fixtures/catalogue.json
@@ -1,0 +1,199 @@
+[
+{
+    "model": "catalogue.product",
+    "pk": 2,
+    "fields": {
+        "structure": "standalone",
+        "upc": "673873",
+        "parent": null,
+        "title": "Hermes Bikini",
+        "slug": "dikke-shit-ouwe",
+        "description": "<p>Vet ding dit hoor</p>",
+        "product_class": 1,
+        "rating": null,
+        "date_created": "2018-06-27T09:11:35.813Z",
+        "date_updated": "2018-08-22T13:25:11.724Z",
+        "is_discountable": true,
+        "product_options": []
+    }
+},
+{
+    "model": "catalogue.product",
+    "pk": 3,
+    "fields": {
+        "structure": "standalone",
+        "upc": "piet",
+        "parent": null,
+        "title": "Hubble Photo",
+        "slug": "henk",
+        "description": "<p>30cm x 55cm</p>",
+        "product_class": 1,
+        "rating": null,
+        "date_created": "2018-07-10T13:06:53.822Z",
+        "date_updated": "2018-08-22T13:25:58.500Z",
+        "is_discountable": true,
+        "product_options": []
+    }
+},
+{
+    "model": "catalogue.productclass",
+    "pk": 1,
+    "fields": {
+        "name": "Spullen",
+        "slug": "dik-products",
+        "requires_shipping": true,
+        "track_stock": false,
+        "options": []
+    }
+},
+{
+    "model": "catalogue.category",
+    "pk": 1,
+    "fields": {
+        "path": "0001",
+        "depth": 1,
+        "numchild": 0,
+        "name": "Ambulant goods",
+        "description": "<p>Some ambulant goods</p>",
+        "image": "",
+        "slug": "root"
+    }
+},
+{
+    "model": "catalogue.productcategory",
+    "pk": 1,
+    "fields": {
+        "product": 2,
+        "category": 1
+    }
+},
+{
+    "model": "catalogue.productcategory",
+    "pk": 2,
+    "fields": {
+        "product": 3,
+        "category": 1
+    }
+},
+{
+    "model": "catalogue.productattribute",
+    "pk": 1,
+    "fields": {
+        "product_class": 1,
+        "name": "henk",
+        "code": "henkie",
+        "type": "text",
+        "option_group": null,
+        "required": true
+    }
+},
+{
+    "model": "catalogue.productattributevalue",
+    "pk": 2,
+    "fields": {
+        "attribute": 1,
+        "product": 2,
+        "value_text": "bka",
+        "value_integer": null,
+        "value_boolean": null,
+        "value_float": null,
+        "value_richtext": null,
+        "value_date": null,
+        "value_datetime": null,
+        "value_option": null,
+        "value_file": "",
+        "value_image": "",
+        "entity_content_type": null,
+        "entity_object_id": null,
+        "value_multi_option": []
+    }
+},
+{
+    "model": "catalogue.productattributevalue",
+    "pk": 3,
+    "fields": {
+        "attribute": 1,
+        "product": 3,
+        "value_text": "bah bah",
+        "value_integer": null,
+        "value_boolean": null,
+        "value_float": null,
+        "value_richtext": null,
+        "value_date": null,
+        "value_datetime": null,
+        "value_option": null,
+        "value_file": "",
+        "value_image": "",
+        "entity_content_type": null,
+        "entity_object_id": null,
+        "value_multi_option": []
+    }
+},
+{
+    "model": "catalogue.productimage",
+    "pk": 1,
+    "fields": {
+        "product": 3,
+        "original": "images/products/2018/07/ActiOn_35.jpg",
+        "caption": "",
+        "display_order": 0,
+        "date_created": "2018-07-10T13:08:38.050Z"
+    }
+},
+{
+    "model": "catalogue.productimage",
+    "pk": 2,
+    "fields": {
+        "product": 2,
+        "original": "images/products/2018/08/11lekkerECHICKORIG-large-4x3.jpg",
+        "caption": "",
+        "display_order": 0,
+        "date_created": "2018-08-20T14:44:21.688Z"
+    }
+},
+{
+    "model": "partner.stockrecord",
+    "pk": 1,
+    "fields": {
+        "product": 2,
+        "partner": 1,
+        "partner_sku": "henk",
+        "price_currency": "EUR",
+        "price_excl_tax": "400.00",
+        "price_retail": "500.00",
+        "cost_price": "300.00",
+        "num_in_stock": 23,
+        "num_allocated": null,
+        "low_stock_threshold": null,
+        "date_created": "2018-06-27T14:29:31.007Z",
+        "date_updated": "2018-07-09T10:54:12.295Z"
+    }
+},
+{
+    "model": "partner.stockrecord",
+    "pk": 2,
+    "fields": {
+        "product": 3,
+        "partner": 1,
+        "partner_sku": "asdasd",
+        "price_currency": "EUR",
+        "price_excl_tax": "23.00",
+        "price_retail": "0.05",
+        "cost_price": null,
+        "num_in_stock": null,
+        "num_allocated": null,
+        "low_stock_threshold": null,
+        "date_created": "2018-07-10T13:06:53.849Z",
+        "date_updated": "2018-08-10T12:34:05.460Z"
+    }
+},
+{
+    "model": "partner.partner",
+    "pk": 1,
+    "fields": {
+        "code": "mezelf",
+        "name": "mezelf",
+        "users": []
+    }
+}
+]

--- a/tests/unit/fixtures/offer.json
+++ b/tests/unit/fixtures/offer.json
@@ -1,0 +1,146 @@
+[
+{
+    "model": "offer.conditionaloffer",
+    "pk": 1,
+    "fields": {
+        "name": "Offer for coupon 'henk'",
+        "slug": "offer-for-coupon-henk",
+        "description": "",
+        "offer_type": "Voucher",
+        "exclusive": true,
+        "status": "Open",
+        "condition": 1,
+        "benefit": 1,
+        "priority": 0,
+        "start_datetime": null,
+        "end_datetime": null,
+        "max_global_applications": null,
+        "max_user_applications": null,
+        "max_basket_applications": null,
+        "max_discount": null,
+        "total_discount": "0.00",
+        "num_applications": 0,
+        "num_orders": 0,
+        "redirect_url": "",
+        "date_created": "2018-08-20T14:45:23.650Z"
+    }
+},
+{
+    "model": "offer.conditionaloffer",
+    "pk": 2,
+    "fields": {
+        "name": "korting",
+        "slug": "korting",
+        "description": "",
+        "offer_type": "Site",
+        "exclusive": false,
+        "status": "Open",
+        "condition": 2,
+        "benefit": 2,
+        "priority": 0,
+        "start_datetime": "2018-08-20T00:00:00Z",
+        "end_datetime": "2019-03-06T16:45:00Z",
+        "max_global_applications": null,
+        "max_user_applications": null,
+        "max_basket_applications": null,
+        "max_discount": null,
+        "total_discount": "0.00",
+        "num_applications": 0,
+        "num_orders": 0,
+        "redirect_url": "",
+        "date_created": "2018-08-20T14:48:46.515Z"
+    }
+},
+{
+    "model": "offer.benefit",
+    "pk": 1,
+    "fields": {
+        "range": 1,
+        "type": "Shipping percentage",
+        "value": "10.00",
+        "max_affected_items": null,
+        "proxy_class": ""
+    }
+},
+{
+    "model": "offer.benefit",
+    "pk": 2,
+    "fields": {
+        "range": 1,
+        "type": "Absolute",
+        "value": "10.00",
+        "max_affected_items": null,
+        "proxy_class": ""
+    }
+},
+{
+    "model": "offer.condition",
+    "pk": 1,
+    "fields": {
+        "range": 1,
+        "type": "Count",
+        "value": "1.00",
+        "proxy_class": ""
+    }
+},
+{
+    "model": "offer.condition",
+    "pk": 2,
+    "fields": {
+        "range": 2,
+        "type": "Count",
+        "value": "1.00",
+        "proxy_class": ""
+    }
+},
+{
+    "model": "offer.range",
+    "pk": 1,
+    "fields": {
+        "name": "henk",
+        "slug": "de-range",
+        "description": "<p>Dikke range bo</p>",
+        "is_public": true,
+        "includes_all_products": false,
+        "proxy_class": "",
+        "date_created": "2018-08-20T14:43:16.775Z",
+        "excluded_products": [],
+        "classes": [],
+        "included_categories": []
+    }
+},
+{
+    "model": "offer.range",
+    "pk": 2,
+    "fields": {
+        "name": "lekker wijf",
+        "slug": "lekker-wijf",
+        "description": "",
+        "is_public": true,
+        "includes_all_products": false,
+        "proxy_class": "",
+        "date_created": "2018-08-20T14:44:40.015Z",
+        "excluded_products": [],
+        "classes": [],
+        "included_categories": []
+    }
+},
+{
+    "model": "offer.rangeproduct",
+    "pk": 1,
+    "fields": {
+        "range": 1,
+        "product": 3,
+        "display_order": 0
+    }
+},
+{
+    "model": "offer.rangeproduct",
+    "pk": 2,
+    "fields": {
+        "range": 2,
+        "product": 2,
+        "display_order": 0
+    }
+}
+]


### PR DESCRIPTION
This makes offers including tax accessible.
The incl_tax parameter used to be hardcoded to False in apply_discount. ?

In creating the tests for this thing, I found the current calculation, over
the price excluding tax to be incorrect. I added the test and
marked it as skipped.