### PR TITLE
Optimize Range checks, and fix missing excluded_products in range.all_products()

### DIFF
--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -85,6 +85,11 @@ class AbstractCategory(MP_Node):
 
     Uses django-treebeard.
     """
+    #: Allow comparison of categories on a limited number of fields by ranges.
+    #: When the Category model is overwriten to provide CMS content, defining
+    #: this avoids fetching a lot of unneeded extra data from the database.
+    COMPARISON_FIELDS = ('pk', 'path', 'depth')
+
     name = models.CharField(_('Name'), max_length=255, db_index=True)
     description = models.TextField(_('Description'), blank=True)
     image = models.ImageField(_('Image'), upload_to='categories', blank=True,

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -440,12 +440,7 @@ class AbstractConditionalOffer(models.Model):
         if not self.has_products:
             return Product.objects.none()
 
-        cond_range = self.condition.range
-        if cond_range.includes_all_products:
-            # Return ALL the products
-            queryset = Product.objects.browsable()
-        else:
-            queryset = cond_range.all_products()
+        queryset = self.condition.range.all_products()
         return queryset.filter(is_discountable=True).exclude(
             structure=Product.CHILD)
 
@@ -1007,8 +1002,9 @@ class AbstractRange(models.Model):
 
         Product = get_model("catalogue", "Product")
         if self.includes_all_products:
-            # Filter out child products
-            return Product.objects.browsable()
+            # Filter out child products and blacklisted products
+            return Product.objects.browsable().exclude(
+                id__in=self._excluded_product_ids())
 
         return Product.objects.filter(
             Q(id__in=self._included_product_ids()) |

--- a/tests/integration/offer/test_range.py
+++ b/tests/integration/offer/test_range.py
@@ -22,10 +22,12 @@ class TestWholeSiteRange(TestCase):
     def test_whitelisting(self):
         self.range.add_product(self.prod)
         self.assertTrue(self.range.contains_product(self.prod))
+        self.assertIn(self.prod, self.range.all_products())
 
     def test_blacklisting(self):
         self.range.excluded_products.add(self.prod)
         self.assertFalse(self.range.contains_product(self.prod))
+        self.assertNotIn(self.prod, self.range.all_products())
 
 
 class TestChildRange(TestCase):


### PR DESCRIPTION
See the commit messages of each individual commit.

This:
* optimized the range queries, so `range.contains_product()` works more efficiently.
* Fixes a inconsistency, where `range.all_products()` missed didn't exclude the blacklisted products when `range.includes_all_products=True`
* Makes sure not the full category data is pulled from the database when only a contains/is-descendant check is performed.