### PR TITLE
Fix OfferWizard Visual Bug in OfferBenefitForm and OfferConditionForm

### DIFF
--- a/src/oscar/apps/dashboard/offers/views.py
+++ b/src/oscar/apps/dashboard/offers/views.py
@@ -113,8 +113,7 @@ class OfferWizardStepView(FormView):
         form_data = form.cleaned_data.copy()
         range = form_data.get('range', None)
         if range is not None:
-            form_data['range_id'] = range.id
-            del form_data['range']
+            form_data['range'] = range.id
         form_kwargs = {'data': form_data}
         json_data = json.dumps(form_kwargs, cls=DjangoJSONEncoder)
 
@@ -127,12 +126,7 @@ class OfferWizardStepView(FormView):
         session_data = self.request.session.setdefault(self.wizard_name, {})
         json_data = session_data.get(self._key(step_name), None)
         if json_data:
-            form_kwargs = json.loads(json_data)
-            if 'range_id' in form_kwargs['data']:
-                form_kwargs['data']['range'] = Range.objects.get(
-                    id=form_kwargs['data']['range_id'])
-                del form_kwargs['data']['range_id']
-            return form_kwargs
+            return json.loads(json_data)
 
         return {}
 

--- a/tests/functional/dashboard/test_offer.py
+++ b/tests/functional/dashboard/test_offer.py
@@ -193,7 +193,7 @@ class TestAnAdmin(testcases.WebTestCase):
         self.assertFalse('range' in condition_page.errors)
         self.assertEqual(len(condition_page.errors), 0)
 
-    def test_jump_back_to_incentive_step_for_existing_offer(self):
+    def test_jump_to_incentive_step_for_existing_offer(self):
         offer = factories.create_offer()
         url = reverse('dashboard:offer-benefit', kwargs={'pk': offer.id})
 
@@ -202,7 +202,7 @@ class TestAnAdmin(testcases.WebTestCase):
         self.assertFalse('range' in condition_page.errors)
         self.assertEqual(len(condition_page.errors), 0)
 
-    def test_jump_back_to_condition_step_for_existing_offer(self):
+    def test_jump_to_condition_step_for_existing_offer(self):
         offer = factories.create_offer()
         url = reverse('dashboard:offer-condition', kwargs={'pk': offer.id})
 

--- a/tests/functional/dashboard/test_offer.py
+++ b/tests/functional/dashboard/test_offer.py
@@ -146,3 +146,67 @@ class TestAnAdmin(testcases.WebTestCase):
         offer.refresh_from_db()
 
         self.assertEqual(offer.priority, 12)
+
+    def test_jump_back_to_incentive_step_for_new_offer(self):
+        list_page = self.get(reverse('dashboard:offer-list'))
+
+        metadata_page = list_page.click('Create new offer')
+        metadata_form = metadata_page.form
+        metadata_form['name'] = "Test offer"
+
+        benefit_page = metadata_form.submit().follow()
+        benefit_form = benefit_page.form
+        benefit_form['range'] = self.range.id
+        benefit_form['type'] = "Percentage"
+        benefit_form['value'] = "25"
+
+        benefit_form.submit()
+        benefit_page = self.get(reverse('dashboard:offer-benefit'))
+        # Accessing through context because WebTest form does not include an 'errors' field
+        benefit_form = benefit_page.context['form']
+
+        self.assertFalse('range' in benefit_form.errors)
+        self.assertEqual(len(benefit_form.errors), 0)
+
+    def test_jump_back_to_condition_step_for_new_offer(self):
+        list_page = self.get(reverse('dashboard:offer-list'))
+
+        metadata_page = list_page.click('Create new offer')
+        metadata_form = metadata_page.form
+        metadata_form['name'] = "Test offer"
+
+        benefit_page = metadata_form.submit().follow()
+        benefit_form = benefit_page.form
+        benefit_form['range'] = self.range.id
+        benefit_form['type'] = "Percentage"
+        benefit_form['value'] = "25"
+
+        condition_page = benefit_form.submit().follow()
+        condition_form = condition_page.form
+        condition_form['range'] = self.range.id
+        condition_form['type'] = "Count"
+        condition_form['value'] = "3"
+
+        condition_form.submit()
+        condition_page = self.get(reverse('dashboard:offer-condition'))
+
+        self.assertFalse('range' in condition_page.errors)
+        self.assertEqual(len(condition_page.errors), 0)
+
+    def test_jump_back_to_incentive_step_for_existing_offer(self):
+        offer = factories.create_offer()
+        url = reverse('dashboard:offer-benefit', kwargs={'pk': offer.id})
+
+        condition_page = self.get(url)
+
+        self.assertFalse('range' in condition_page.errors)
+        self.assertEqual(len(condition_page.errors), 0)
+
+    def test_jump_back_to_condition_step_for_existing_offer(self):
+        offer = factories.create_offer()
+        url = reverse('dashboard:offer-condition', kwargs={'pk': offer.id})
+
+        condition_page = self.get(url)
+
+        self.assertFalse('range' in condition_page.errors)
+        self.assertEqual(len(condition_page.errors), 0)


### PR DESCRIPTION
A fix for the Issue I created #2818

**Before**
<img width="689" alt="incentive before" src="https://user-images.githubusercontent.com/15933115/45169850-c03f8d00-b1fe-11e8-97aa-ff4133de0b3d.png">
 
**After**
<img width="690" alt="incentive after" src="https://user-images.githubusercontent.com/15933115/45169868-cd5c7c00-b1fe-11e8-8bb3-c821302a5a3a.png">

It also reduced the number of queries by one
<img width="215" alt="incentive query before" src="https://user-images.githubusercontent.com/15933115/45169902-dcdbc500-b1fe-11e8-84a4-f6fff9d3ff0d.png">
<img width="201" alt="incentive query after" src="https://user-images.githubusercontent.com/15933115/45169905-df3e1f00-b1fe-11e8-8e01-a28e67ec5df7.png">
