### PR TITLE
Use python3 while creating python virtualenv

### DIFF
--- a/docs/source/internals/sandbox.rst
+++ b/docs/source/internals/sandbox.rst
@@ -58,7 +58,7 @@ Install Oscar and its dependencies within a virtualenv:
 
     $ git clone https://github.com/django-oscar/django-oscar.git
     $ cd django-oscar
-    $ mkvirtualenv oscar  # needs virtualenvwrapper
+    $ mkvirtualenv --python=python3 oscar  # needs virtualenvwrapper
     (oscar) $ make sandbox
     (oscar) $ sandbox/manage.py runserver
 


### PR DESCRIPTION
Python2 is no longer support and follow the document to create env with python2 will go wrong.

https://github.com/django-oscar/django-oscar/issues/2746