### PR TITLE
(FIX) double @ in dashboard users search form #2872

### DIFF
--- a/src/oscar/apps/dashboard/users/views.py
+++ b/src/oscar/apps/dashboard/users/views.py
@@ -10,7 +10,6 @@ from django.views.generic.detail import SingleObjectMixin
 from django.views.generic.edit import FormMixin
 from django_tables2 import SingleTableView
 
-from oscar.apps.customer.utils import normalise_email
 from oscar.core.compat import get_user_model
 from oscar.core.loading import get_class, get_classes, get_model
 from oscar.views.generic import BulkEditMixin
@@ -74,7 +73,7 @@ class IndexView(BulkEditMixin, FormMixin, SingleTableView):
         Function is split out to allow customisation with little boilerplate.
         """
         if data['email']:
-            email = normalise_email(data['email'])
+            email = data['email']
             queryset = queryset.filter(email__istartswith=email)
             self.desc_ctx['email_filter'] \
                 = _(" with email matching '%s'") % email

--- a/tests/functional/dashboard/test_user.py
+++ b/tests/functional/dashboard/test_user.py
@@ -115,30 +115,31 @@ class SearchTests(WebTestCase):
         )
         super().setUp()
 
-    def _search_by_user_name(self, name):
+    def _search_by_form_args(self, form_args):
         response = self.get(self.url)
         search_form = response.forms[0]
-        search_form['name'] = name
+        for field_name, val in form_args.items():
+            search_form[field_name] = val
         search_response = search_form.submit('search')
         data = search_response.context['users'].data
         return data
 
     def test_user_name_2_parts(self):
-        data = self._search_by_user_name('Owen Davies')
+        data = self._search_by_form_args({'name': 'Owen Davies'})
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0].email, 'owen@example.org')
         self.assertEqual(data[0].first_name, 'Owen')
         self.assertEqual(data[0].last_name, 'Davies')
 
     def test_user_name_3_parts(self):
-        data = self._search_by_user_name('Rob Alan Lewis')
+        data = self._search_by_form_args({'name': 'Rob Alan Lewis'})
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0].email, 'robalan@example.org')
         self.assertEqual(data[0].first_name, 'Rob Alan')
         self.assertEqual(data[0].last_name, 'Lewis')
 
     def test_user_name_4_parts(self):
-        data = self._search_by_user_name('Lars van der Berg')
+        data = self._search_by_form_args({'name': 'Lars van der Berg'})
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0].email, 'lars@example.org')
         self.assertEqual(data[0].first_name, 'Lars')


### PR DESCRIPTION
Possible fix for #2872 
Some opinion:
1. I put fix to normalise_email because the purpose of this func is to normalize given value not validate.
2. Also possible fix can be do not use normalise_email for search form.