### PR TITLE
 Improve efficiency of category_tree template tag.

### DIFF
--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -184,7 +184,7 @@ class AbstractCategory(MP_Node):
         cache_key = 'CATEGORY_URL_%s_%s' % (current_locale, self.pk)
         return cache_key
 
-    def get_absolute_url(self, parent_slug=None):
+    def _get_absolute_url(self, parent_slug=None):
         """
         Our URL scheme means we have to look up the category's ancestors. As
         that is a bit more expensive, we cache the generated URL. That is
@@ -196,6 +196,9 @@ class AbstractCategory(MP_Node):
         return reverse('catalogue:category', kwargs={
             'category_slug': self.get_full_slug(parent_slug=parent_slug), 'pk': self.pk
         })
+
+    def get_absolute_url(self):
+        return self._get_absolute_url()
 
     class Meta:
         abstract = True

--- a/src/oscar/templates/oscar/catalogue/browse.html
+++ b/src/oscar/templates/oscar/catalogue/browse.html
@@ -26,9 +26,9 @@
         <h4>{% trans "Show results for" %}</h4>
         <div class="side_categories">
             <ul class="nav nav-list">
-                {% for tree_category, info in tree_categories %}
+                {% for tree_category in tree_categories %}
                     <li>
-                        <a href="{{ tree_category.get_absolute_url }}">
+                        <a href="{{ tree_category.url }}">
                             {% if tree_category.pk == category.pk %}
                                 <strong>{{ tree_category.name }}</strong>
                             {% else %}
@@ -36,8 +36,8 @@
                             {% endif %}
                         </a>
 
-                        {% if info.has_children %}<ul>{% else %}</li>{% endif %}
-                        {% for n in info.num_to_close %}
+                        {% if tree_category.has_children %}<ul>{% else %}</li>{% endif %}
+                        {% for n in tree_category.num_to_close %}
                             </ul></li>
                         {% endfor %}
                 {% endfor %}

--- a/src/oscar/templates/oscar/partials/nav_primary.html
+++ b/src/oscar/templates/oscar/partials/nav_primary.html
@@ -45,8 +45,8 @@
                             <li><a tabindex="-1" href="{% url 'catalogue:index' %}">{% trans "All products" %}</a></li>
                             {% if tree_categories %}
                                 <li class="divider"></li>
-                                {% for tree_category, info in tree_categories %}
-                                    {% if info.has_children %}
+                                {% for tree_category in tree_categories %}
+                                    {% if tree_category.has_children %}
                                         <li class="dropdown-submenu">
                                             <a tabindex="-1" href="{{ tree_category.get_absolute_url }}">{{ tree_category.name }}</a>
                                             <ul class="dropdown-menu">
@@ -54,7 +54,7 @@
                                                 <li><a tabindex="-1" href="{{ tree_category.get_absolute_url }}">{{ tree_category.name }}</a></li>
                                             {% endif %}
 
-                                            {% for close in info.num_to_close %}
+                                            {% for close in tree_category.num_to_close %}
                                                 </ul></li>
                                             {% endfor %}
                                 {% endfor %}

--- a/src/oscar/templatetags/category_tags.py
+++ b/src/oscar/templatetags/category_tags.py
@@ -86,14 +86,15 @@ def get_annotated_list(depth=None, parent=None):
     else:
         categories = Category.get_tree()
 
+    if max_depth is not None:
+        categories = categories.filter(depth__lte=max_depth)
+
     info = CheapCategoryInfo(parent, url="")
 
     for node in categories:
         node_depth = node.get_depth()
         if start_depth is None:
             start_depth = node_depth
-        if max_depth is not None and node_depth > max_depth:
-            continue
 
         # Update previous node's info
         if prev_depth is None or node_depth > prev_depth:

--- a/src/oscar/templatetags/category_tags.py
+++ b/src/oscar/templatetags/category_tags.py
@@ -50,6 +50,10 @@ class CheapCategoryInfo(with_metaclass(CategoryFieldPassThroughMetaClass, dict))
         super(CheapCategoryInfo, self).__init__(info)
         self.category = category
 
+    @property
+    def pk(self):
+        return self.category.pk
+
     def get_absolute_url(self):
         return self["url"]
 

--- a/src/oscar/templatetags/category_tags.py
+++ b/src/oscar/templatetags/category_tags.py
@@ -47,7 +47,7 @@ class CheapCategoryInfo(with_metaclass(CategoryFieldPassThroughMetaClass, dict))
     """
 
     def __init__(self, category, **info):
-        super(CheapCategoryInfo, self).__init__(info)
+        super().__init__(info)
         self.category = category
 
     @property
@@ -117,7 +117,7 @@ def get_annotated_list(depth=None, parent=None):
 
         info = CheapCategoryInfo(
             node,
-            url=node.get_absolute_url(tree_slug),
+            url=node._get_absolute_url(tree_slug),
             num_to_close=[],
             level=node_depth - start_depth,
         )
@@ -127,7 +127,7 @@ def get_annotated_list(depth=None, parent=None):
 
     if prev_depth is not None:
         # close last leaf
-        info["num_to_close"] = list(range(0, prev_depth - start_depth))
-        info["has_children"] = prev_depth > prev_depth
+        info['num_to_close'] = list(range(0, prev_depth - start_depth))
+        info['has_children'] = prev_depth > prev_depth
 
     return annotated_categories

--- a/src/oscar/templatetags/category_tags.py
+++ b/src/oscar/templatetags/category_tags.py
@@ -1,12 +1,69 @@
+from six import with_metaclass
 from django import template
-
 from oscar.core.loading import get_model
 
 register = template.Library()
-Category = get_model('catalogue', 'category')
+Category = get_model("catalogue", "category")
 
 
-@register.simple_tag(name="category_tree")
+class PassThrough(object):
+    def __init__(self, name):
+        self.name = name
+
+    def __get__(self, obj, objtype):
+        if obj is None:
+            return self
+
+        return getattr(obj.category, self.name)
+
+
+class CategoryFieldPassThroughMetaClass(type):
+    """
+    Add accessors for category fields to whichever class is of this type.
+    """
+    def __new__(cls, name, bases, attrs):
+
+        field_accessors = {}
+        for field in Category._meta.get_fields():
+            name = field.name
+            field_accessors[name] = PassThrough(name)
+
+        # attrs win of silly field accessors
+        field_accessors.update(attrs)
+        return type.__new__(cls, name, bases, field_accessors)
+
+
+class CheapCategoryInfo(with_metaclass(CategoryFieldPassThroughMetaClass, dict)):
+    """
+    Wrapper class for Category.
+
+    Besides allowing inclusion of extra info, useful while rendering a template,
+    this class hides any expensive properties people should not use by accident
+    in templates.
+
+    This replaces both the node as the info object returned by the ``category_tree``
+    templatetag, so it mimics a tuple of 2 items (which are the same) for
+    backwards compatibility.
+    """
+
+    def __init__(self, category, **info):
+        super(CheapCategoryInfo, self).__init__(info)
+        self.category = category
+
+    def get_absolute_url(self):
+        return self["url"]
+
+    def __len__(self):
+        "Mimic a tuple of 2 items"
+        return 2
+
+    def __iter__(self):
+        "be an iterable of 2 times the same item"
+        yield self
+        yield self
+
+
+@register.simple_tag(name="category_tree")   # noqa: C901 too complex
 def get_annotated_list(depth=None, parent=None):
     """
     Gets an annotated list from a tree branch.
@@ -18,16 +75,19 @@ def get_annotated_list(depth=None, parent=None):
     max_depth = depth
 
     annotated_categories = []
+    tree_slug = ""
 
     start_depth, prev_depth = (None, None)
     if parent:
         categories = parent.get_descendants()
+        tree_slug = parent.get_full_slug()
         if max_depth is not None:
             max_depth += parent.get_depth()
     else:
         categories = Category.get_tree()
 
-    info = {}
+    info = CheapCategoryInfo(parent, url="")
+
     for node in categories:
         node_depth = node.get_depth()
         if start_depth is None:
@@ -36,18 +96,33 @@ def get_annotated_list(depth=None, parent=None):
             continue
 
         # Update previous node's info
-        info['has_children'] = prev_depth is None or node_depth > prev_depth
-        if prev_depth is not None and node_depth < prev_depth:
-            info['num_to_close'] = list(range(0, prev_depth - node_depth))
+        if prev_depth is None or node_depth > prev_depth:
+            info["has_children"] = True
+            if info.category is not None:
+                tree_slug = info.category.get_full_slug(tree_slug)
 
-        info = {'num_to_close': [],
-                'level': node_depth - start_depth}
-        annotated_categories.append((node, info,))
+        if prev_depth is not None and node_depth < prev_depth:
+            depth_difference = prev_depth - node_depth
+            info["num_to_close"] = list(range(0, depth_difference))
+            tree_slugs = tree_slug.rsplit(node._slug_separator, depth_difference)
+            if tree_slugs:
+                tree_slug = tree_slugs[0]
+            else:
+                tree_slug = node.slug
+
+        info = CheapCategoryInfo(
+            node,
+            url=node.get_absolute_url(tree_slug),
+            num_to_close=[],
+            level=node_depth - start_depth,
+        )
+        annotated_categories.append(info)
+
         prev_depth = node_depth
 
     if prev_depth is not None:
         # close last leaf
-        info['num_to_close'] = list(range(0, prev_depth - start_depth))
-        info['has_children'] = prev_depth > prev_depth
+        info["num_to_close"] = list(range(0, prev_depth - start_depth))
+        info["has_children"] = prev_depth > prev_depth
 
     return annotated_categories

--- a/tests/integration/catalogue/test_category.py
+++ b/tests/integration/catalogue/test_category.py
@@ -51,7 +51,7 @@ class TestCategory(TestCase):
         category = self.products.add_child(name="Fromages français")
         absolute_url = category.get_absolute_url()
         url = cache.get(category.get_url_cache_key())
-        self.assertEqual(url, '/catalogue/category/products/fromages-fran%C3%A7ais_{}/'.format(category.pk))
+        self.assertEqual(url, 'products/fromages-français')
         self.assertEqual(absolute_url, '/catalogue/category/products/fromages-fran%C3%A7ais_{}/'.format(category.pk))
 
 
@@ -222,6 +222,7 @@ class TestCategoryTemplateTags(TestCase):
         """
         annotated_list = get_annotated_list(depth, parent)
         names = [category.name for category, __ in annotated_list]
+
         names_set = set(names)
         # We return a set to ease testing, but need to be sure we're not
         # losing any duplicates through that conversion.


### PR DESCRIPTION
1. cache full_slug instead of get_absolute_url so parent slug info can be re-used
   to create child slugs, instead of having to query all parents for every child slug.
2. do not hit database or cache for get_absolute_url
3. do not allow expensive tree walking in templates.
4. warmup category url cache while we are generating the urls anyway.

These changes will make the category tree use only 1 query, even when the
cache is not warmed up yet. It also prevents people from making really
expensive queries in templates by using mptt methods.

For sites with a lot of categories (300) this change will shave away hundreds of
useless queries. Now we can go back to having short cache durations and shitloads
of categories.