### PR TITLE
Display order-status link in order-placed email, for logged-in users

### DIFF
--- a/src/oscar/apps/checkout/mixins.py
+++ b/src/oscar/apps/checkout/mixins.py
@@ -310,19 +310,21 @@ class OrderPlacementMixin(CheckoutSessionMixin):
             'lines': order.lines.all()
         }
 
-        if not self.request.user.is_authenticated:
-            # Attempt to add the anon order status URL to the email template
-            # ctx.
-            try:
+        # Attempt to add the order status URL to the email template ctx.
+        try:
+            if self.request.user.is_authenticated:
+                path = reverse('customer:order',
+                               kwargs={'order_number': order.number})
+            else:
                 path = reverse('customer:anon-order',
                                kwargs={'order_number': order.number,
                                        'hash': order.verification_hash()})
-            except NoReverseMatch:
-                # We don't care that much if we can't resolve the URL
-                pass
-            else:
-                site = Site.objects.get_current()
-                ctx['status_url'] = 'http://%s%s' % (site.domain, path)
+        except NoReverseMatch:
+            # We don't care that much if we can't resolve the URL
+            pass
+        else:
+            site = Site.objects.get_current()
+            ctx['status_url'] = 'http://%s%s' % (site.domain, path)
         return ctx
 
     # Basket helpers

--- a/src/oscar/templates/oscar/customer/order/order_detail.html
+++ b/src/oscar/templates/oscar/customer/order/order_detail.html
@@ -11,6 +11,12 @@
 {% endblock %}
 
 {% block tabcontent %}
+    {% if order.status %}
+    <h2>{% trans 'Status' %}</h2>
+    <p>{{ order.status }}</p>
+    <hr>
+    {% endif %}
+
     <table class="table table-striped table-bordered">
         <thead>
             <tr>


### PR DESCRIPTION
The `customer/order/order_detail.html` template (unlike `customer/anon_order.html`) does not currently display the order status, so this is also added.