### PR TITLE
remove end_datetime from conditionaloffer fixture

### DIFF
--- a/tests/unit/fixtures/offer.json
+++ b/tests/unit/fixtures/offer.json
@@ -39,7 +39,7 @@
         "benefit": 2,
         "priority": 0,
         "start_datetime": "2018-08-20T00:00:00Z",
-        "end_datetime": "2019-03-06T16:45:00Z",
+        "end_datetime": null,
         "max_global_applications": null,
         "max_user_applications": null,
         "max_basket_applications": null,


### PR DESCRIPTION
Lars created a fixture for a conditionalOffer with an end_datetime that is in the past (now).