### PR TITLE
enforce max_affected_items during offer application

### DIFF
--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -661,8 +661,6 @@ class AbstractBenefit(BaseOfferMixin, models.Model):
             if not price:
                 # Avoid zero price products
                 continue
-            if line.quantity_without_offer_discount(offer) == 0:
-                continue
             line_tuples.append((price, line))
 
         # We sort lines to be cheapest first to ensure consistent applications

--- a/src/oscar/apps/offer/conditions.py
+++ b/src/oscar/apps/offer/conditions.py
@@ -46,9 +46,8 @@ class CountCondition(Condition):
         """
         num_matches = 0
         for line in basket.all_lines():
-            if (self.can_apply_condition(line)
-                    and line.quantity_without_offer_discount(offer) > 0):
-                num_matches += line.quantity_without_offer_discount(offer)
+            if self.can_apply_condition(line):
+                num_matches += line.quantity_without_offer_discount(None)
             if num_matches >= self.value:
                 return True
         return False

--- a/tests/integration/offer/test_absolute_benefit.py
+++ b/tests/integration/offer/test_absolute_benefit.py
@@ -202,22 +202,22 @@ class TestAnAbsoluteDiscountWithMaxItemsSetAppliedWithCountCondition(TestCase):
         add_product(self.basket, D('12.00'), 2)
         result = self.benefit.apply(self.basket, self.condition, self.offer)
         self.assertEqual(D('3.00'), result.discount)
-        self.assertEqual(2, self.basket.num_items_with_discount)
-        self.assertEqual(0, self.basket.num_items_without_discount)
+        self.assertEqual(1, self.basket.num_items_with_discount)
+        self.assertEqual(1, self.basket.num_items_without_discount)
 
     def test_applies_correctly_to_basket_which_exceeds_condition(self):
         add_products(self.basket, [(D('12.00'), 2), (D('10.00'), 2)])
         result = self.benefit.apply(self.basket, self.condition, self.offer)
         self.assertEqual(D('3.00'), result.discount)
-        self.assertEqual(2, self.basket.num_items_with_discount)
-        self.assertEqual(2, self.basket.num_items_without_discount)
+        self.assertEqual(1, self.basket.num_items_with_discount)
+        self.assertEqual(3, self.basket.num_items_without_discount)
 
     def test_applies_correctly_to_basket_which_exceeds_condition_but_with_smaller_prices_than_discount(self):
         add_products(self.basket, [(D('2.00'), 2), (D('1.00'), 2)])
         result = self.benefit.apply(self.basket, self.condition, self.offer)
         self.assertEqual(D('1.00'), result.discount)
-        self.assertEqual(2, self.basket.num_items_with_discount)
-        self.assertEqual(2, self.basket.num_items_without_discount)
+        self.assertEqual(1, self.basket.num_items_with_discount)
+        self.assertEqual(3, self.basket.num_items_without_discount)
 
 
 class TestAnAbsoluteDiscountAppliedWithValueCondition(TestCase):
@@ -305,29 +305,29 @@ class TestAnAbsoluteDiscountWithMaxItemsSetAppliedWithValueCondition(TestCase):
         add_products(self.basket, [(D('5.00'), 2)])
         result = self.benefit.apply(self.basket, self.condition, self.offer)
         self.assertEqual(D('3.00'), result.discount)
-        self.assertEqual(2, self.basket.num_items_with_discount)
-        self.assertEqual(0, self.basket.num_items_without_discount)
+        self.assertEqual(1, self.basket.num_items_with_discount)
+        self.assertEqual(1, self.basket.num_items_without_discount)
 
     def test_applies_correctly_to_multi_item_basket_which_exceeds_condition(self):
         add_products(self.basket, [(D('4.00'), 3)])
         result = self.benefit.apply(self.basket, self.condition, self.offer)
         self.assertEqual(D('3.00'), result.discount)
-        self.assertEqual(3, self.basket.num_items_with_discount)
-        self.assertEqual(0, self.basket.num_items_without_discount)
+        self.assertEqual(1, self.basket.num_items_with_discount)
+        self.assertEqual(2, self.basket.num_items_without_discount)
 
     def test_applies_correctly_to_multi_item_basket_which_exceeds_condition_but_matches_boundary(self):
         add_products(self.basket, [(D('5.00'), 3)])
         result = self.benefit.apply(self.basket, self.condition, self.offer)
         self.assertEqual(D('3.00'), result.discount)
-        self.assertEqual(2, self.basket.num_items_with_discount)
-        self.assertEqual(1, self.basket.num_items_without_discount)
+        self.assertEqual(1, self.basket.num_items_with_discount)
+        self.assertEqual(2, self.basket.num_items_without_discount)
 
     def test_applies_correctly_to_multi_item_basket_which_matches_condition_but_with_lower_prices_than_discount(self):
         add_products(self.basket, [(D('2.00'), 6)])
         result = self.benefit.apply(self.basket, self.condition, self.offer)
         self.assertEqual(D('2.00'), result.discount)
-        self.assertEqual(5, self.basket.num_items_with_discount)
-        self.assertEqual(1, self.basket.num_items_without_discount)
+        self.assertEqual(1, self.basket.num_items_with_discount)
+        self.assertEqual(5, self.basket.num_items_without_discount)
 
 
 class TestAnAbsoluteDiscountBenefit(TestCase):

--- a/tests/integration/offer/test_applicator.py
+++ b/tests/integration/offer/test_applicator.py
@@ -24,15 +24,16 @@ class TestOfferApplicator(TestCase):
             value=D('100'), proxy_class=None)
         self.benefit = BenefitFactory(
             range=rng, type=BenefitFactory._meta.model.FIXED,
-            value=D('10'), max_affected_items=1)
+            value=D('10'))
 
     def test_applies_offer_multiple_times_by_default(self):
         add_product(self.basket, D('100'), 5)
         offer = ConditionalOfferFactory(
             pk=1, condition=self.condition, benefit=self.benefit)
+        self.applicator.apply
         self.applicator.apply_offers(self.basket, [offer])
-        applications = self.basket.offer_applications.applications
-        self.assertEqual(5, applications[1]['freq'])
+        line = self.basket.all_lines()[0]
+        self.assertTrue(line.quantity_with_offer_discount(offer) == 5)
 
     def test_respects_maximum_applications_field(self):
         add_product(self.basket, D('100'), 5)
@@ -40,8 +41,10 @@ class TestOfferApplicator(TestCase):
             pk=1, condition=self.condition, benefit=self.benefit,
             max_basket_applications=1)
         self.applicator.apply_offers(self.basket, [offer])
+        line = self.basket.all_lines()[0]
+        self.assertTrue(line.quantity_with_offer_discount(offer) == 5)
         applications = self.basket.offer_applications.applications
-        self.assertEqual(1, applications[1]['freq'])
+        self.assertTrue(applications[1]['freq'] == 1)
 
     def test_uses_offers_in_order_of_descending_priority(self):
         self.applicator.get_site_offers = Mock(

--- a/tests/integration/offer/test_combination.py
+++ b/tests/integration/offer/test_combination.py
@@ -34,8 +34,8 @@ class TestACountConditionWithPercentageDiscount(TestCase):
         self.assertTrue(self.offer.is_condition_satisfied(basket))
         discount = self.offer.apply_benefit(basket)
         self.assertTrue(discount.discount > 0)
-        self.assertEqual(3, basket.num_items_with_discount)
-        self.assertEqual(0, basket.num_items_without_discount)
+        self.assertEqual(1, basket.num_items_with_discount)
+        self.assertEqual(2, basket.num_items_without_discount)
         self.assertFalse(self.offer.is_condition_satisfied(basket))
 
     def test_consumes_correct_number_of_products_for_4_product_basket(self):
@@ -45,21 +45,22 @@ class TestACountConditionWithPercentageDiscount(TestCase):
         self.assertTrue(self.offer.is_condition_satisfied(basket))
         discount = self.offer.apply_benefit(basket)
         self.assertTrue(discount.discount > 0)
-        self.assertEqual(3, basket.num_items_with_discount)
-        self.assertEqual(1, basket.num_items_without_discount)
-        self.assertFalse(self.offer.is_condition_satisfied(basket))
+        self.assertEqual(1, basket.num_items_with_discount)
+        self.assertEqual(3, basket.num_items_without_discount)
+        self.assertTrue(self.offer.is_condition_satisfied(basket))
 
     def test_consumes_correct_number_of_products_for_6_product_basket(self):
         basket = factories.create_basket(empty=True)
         add_products(basket, [(D('1'), 3), (D('1'), 3)])
-
+        self.assertTrue(self.offer.is_condition_satisfied(basket))
         # First application
         discount = self.offer.apply_benefit(basket)
         self.assertTrue(discount.discount > 0)
-        self.assertEqual(3, basket.num_items_with_discount)
-        self.assertEqual(3, basket.num_items_without_discount)
+        self.assertEqual(1, basket.num_items_with_discount)
+        self.assertEqual(5, basket.num_items_without_discount)
 
-        # Second application
+        # Second application (no additional discounts)
         discount = self.offer.apply_benefit(basket)
-        self.assertTrue(discount.discount > 0)
-        self.assertEqual(6, basket.num_items_with_discount)
+        self.assertFalse(discount.discount > 0)
+        self.assertEqual(1, basket.num_items_with_discount)
+        self.assertEqual(5, basket.num_items_without_discount)

--- a/tests/integration/offer/test_condition.py
+++ b/tests/integration/offer/test_condition.py
@@ -12,207 +12,9 @@ from oscar.test.basket import add_product
 from tests._site.model_tests_app.models import BasketOwnerCalledBarry
 
 
-class TestCountCondition(TestCase):
-
-    def setUp(self):
-        self.range = models.Range.objects.create(
-            name="All products range", includes_all_products=True)
-        self.basket = factories.create_basket(empty=True)
-        self.condition = models.CountCondition(
-            range=self.range, type="Count", value=2)
-        self.offer = mock.Mock()
-
-    def test_is_not_satisfied_by_empty_basket(self):
-        self.assertFalse(self.condition.is_satisfied(self.offer, self.basket))
-
-    def test_not_discountable_product_fails_condition(self):
-        prod1, prod2 = factories.create_product(), factories.create_product()
-        prod2.is_discountable = False
-        prod2.save()
-        add_product(self.basket, product=prod1)
-        add_product(self.basket, product=prod2)
-        self.assertFalse(self.condition.is_satisfied(self.offer, self.basket))
-
-    def test_empty_basket_fails_partial_condition(self):
-        self.assertFalse(self.condition.is_partially_satisfied(self.offer, self.basket))
-
-    def test_smaller_quantity_basket_passes_partial_condition(self):
-        add_product(self.basket)
-        self.assertTrue(self.condition.is_partially_satisfied(self.offer, self.basket))
-
-    def test_smaller_quantity_basket_upsell_message(self):
-        add_product(self.basket)
-        self.assertTrue('Buy 1 more product from ' in
-                        self.condition.get_upsell_message(self.offer, self.basket))
-
-    def test_matching_quantity_basket_fails_partial_condition(self):
-        add_product(self.basket, quantity=2)
-        self.assertFalse(self.condition.is_partially_satisfied(self.offer, self.basket))
-
-    def test_matching_quantity_basket_passes_condition(self):
-        add_product(self.basket, quantity=2)
-        self.assertTrue(self.condition.is_satisfied(self.offer, self.basket))
-
-    def test_greater_quantity_basket_passes_condition(self):
-        add_product(self.basket, quantity=3)
-        self.assertTrue(self.condition.is_satisfied(self.offer, self.basket))
-
-    def test_consumption(self):
-        add_product(self.basket, quantity=3)
-        self.condition.consume_items(self.offer, self.basket, [])
-        self.assertEqual(1, self.basket.all_lines()[0].quantity_without_discount)
-
-    def test_is_satisfied_accounts_for_consumed_items(self):
-        add_product(self.basket, quantity=3)
-        self.condition.consume_items(self.offer, self.basket, [])
-        self.assertFalse(self.condition.is_satisfied(self.offer, self.basket))
-
-
-class TestValueCondition(TestCase):
-
-    def setUp(self):
-        self.range = models.Range.objects.create(
-            name="All products range", includes_all_products=True)
-        self.basket = factories.create_basket(empty=True)
-        self.condition = models.ValueCondition(
-            range=self.range, type="Value", value=D('10.00'))
-        self.offer = mock.Mock()
-        self.item = factories.create_product(price=D('5.00'))
-        self.expensive_item = factories.create_product(price=D('15.00'))
-
-    def test_empty_basket_fails_condition(self):
-        self.assertFalse(self.condition.is_satisfied(self.offer, self.basket))
-
-    def test_empty_basket_fails_partial_condition(self):
-        self.assertFalse(self.condition.is_partially_satisfied(self.offer, self.basket))
-
-    def test_less_value_basket_fails_condition(self):
-        add_product(self.basket, D('5'))
-        self.assertFalse(self.condition.is_satisfied(self.offer, self.basket))
-
-    def test_not_discountable_item_fails_condition(self):
-        product = factories.create_product(is_discountable=False)
-        add_product(self.basket, D('15'), product=product)
-        self.assertFalse(self.condition.is_satisfied(self.offer, self.basket))
-
-    def test_upsell_message(self):
-        add_product(self.basket, D('5'))
-        self.assertTrue('Spend' in self.condition.get_upsell_message(self.offer, self.basket))
-
-    def test_matching_basket_fails_partial_condition(self):
-        add_product(self.basket, D('5'), 2)
-        self.assertFalse(self.condition.is_partially_satisfied(self.offer, self.basket))
-
-    def test_less_value_basket_passes_partial_condition(self):
-        add_product(self.basket, D('5'), 1)
-        self.assertTrue(self.condition.is_partially_satisfied(self.offer, self.basket))
-
-    def test_matching_basket_passes_condition(self):
-        add_product(self.basket, D('5'), 2)
-        self.assertTrue(self.condition.is_satisfied(self.offer, self.basket))
-
-    def test_greater_than_basket_passes_condition(self):
-        add_product(self.basket, D('5'), 3)
-        self.assertTrue(self.condition.is_satisfied(self.offer, self.basket))
-
-    def test_consumption(self):
-        add_product(self.basket, D('5'), 3)
-        self.condition.consume_items(self.offer, self.basket, [])
-        self.assertEqual(1, self.basket.all_lines()[0].quantity_without_discount)
-
-    def test_consumption_with_high_value_product(self):
-        add_product(self.basket, D('15'), 1)
-        self.condition.consume_items(self.offer, self.basket, [])
-        self.assertEqual(0, self.basket.all_lines()[0].quantity_without_discount)
-
-    def test_is_consumed_respects_quantity_consumed(self):
-        add_product(self.basket, D('15'), 1)
-        self.assertTrue(self.condition.is_satisfied(self.offer, self.basket))
-        self.condition.consume_items(self.offer, self.basket, [])
-        self.assertFalse(self.condition.is_satisfied(self.offer, self.basket))
-
-
-class TestCoverageCondition(TestCase):
-
-    def setUp(self):
-        self.products = [factories.create_product(), factories.create_product()]
-        self.range = models.Range.objects.create(name="Some products")
-        for product in self.products:
-            self.range.add_product(product)
-            self.range.add_product(product)
-        self.basket = factories.create_basket(empty=True)
-        self.condition = models.CoverageCondition(
-            range=self.range, type="Coverage", value=2)
-        self.offer = mock.Mock()
-
-    def test_empty_basket_fails(self):
-        self.assertFalse(self.condition.is_satisfied(self.offer, self.basket))
-
-    def test_empty_basket_fails_partial_condition(self):
-        self.assertFalse(self.condition.is_partially_satisfied(self.offer, self.basket))
-
-    def test_single_item_fails(self):
-        add_product(self.basket, product=self.products[0])
-        self.assertFalse(self.condition.is_satisfied(self.offer, self.basket))
-
-    def test_not_discountable_item_fails(self):
-        self.products[0].is_discountable = False
-        self.products[0].save()
-        add_product(self.basket, product=self.products[0])
-        add_product(self.basket, product=self.products[1])
-        self.assertFalse(self.condition.is_satisfied(self.offer, self.basket))
-
-    def test_single_item_passes_partial_condition(self):
-        add_product(self.basket, product=self.products[0])
-        self.assertTrue(self.condition.is_partially_satisfied(self.offer, self.basket))
-
-    def test_upsell_message(self):
-        add_product(self.basket, product=self.products[0])
-        self.assertTrue(
-            'Buy 1 more' in self.condition.get_upsell_message(self.offer, self.basket))
-
-    def test_duplicate_item_fails(self):
-        add_product(self.basket, quantity=2, product=self.products[0])
-        self.assertFalse(self.condition.is_satisfied(self.offer, self.basket))
-
-    def test_duplicate_item_passes_partial_condition(self):
-        add_product(self.basket, quantity=2, product=self.products[0])
-        self.assertTrue(self.condition.is_partially_satisfied(self.offer, self.basket))
-
-    def test_covering_items_pass(self):
-        add_product(self.basket, product=self.products[0])
-        add_product(self.basket, product=self.products[1])
-        self.assertTrue(self.condition.is_satisfied(self.offer, self.basket))
-
-    def test_covering_items_fail_partial_condition(self):
-        add_product(self.basket, product=self.products[0])
-        add_product(self.basket, product=self.products[1])
-        self.assertFalse(self.condition.is_partially_satisfied(self.offer, self.basket))
-
-    def test_covering_items_are_consumed(self):
-        add_product(self.basket, product=self.products[0])
-        add_product(self.basket, product=self.products[1])
-        self.condition.consume_items(self.offer, self.basket, [])
-        self.assertEqual(0, self.basket.num_items_without_discount)
-
-    def test_consumed_items_checks_affected_items(self):
-        # Create new offer
-        range = models.Range.objects.create(name="All products", includes_all_products=True)
-        cond = models.CoverageCondition(range=range, type="Coverage", value=2)
-
-        # Get 4 distinct products in the basket
-        self.products.extend(
-            [factories.create_product(), factories.create_product()])
-        for product in self.products:
-            add_product(self.basket, product=product)
-
-        self.assertTrue(cond.is_satisfied(self.offer, self.basket))
-        cond.consume_items(self.offer, self.basket, [])
-        self.assertEqual(2, self.basket.num_items_without_discount)
-
-        self.assertTrue(cond.is_satisfied(self.offer, self.basket))
-        cond.consume_items(self.offer, self.basket, [])
-        self.assertEqual(0, self.basket.num_items_without_discount)
+@pytest.fixture
+def products_some():
+    return [factories.create_product(), factories.create_product()]
 
 
 @pytest.fixture()
@@ -220,9 +22,282 @@ def range():
     return factories.RangeFactory()
 
 
+@pytest.fixture
+def range_all():
+    return factories.RangeFactory(
+        name="All products range", includes_all_products=True
+    )
+
+
+@pytest.fixture
+def range_some(products_some):
+    return factories.RangeFactory(
+        name="Some products", products=products_some
+    )
+
+
+@pytest.fixture
+def count_condition(range_all):
+    return models.CountCondition(range=range_all, type="Count", value=2)
+
+
+@pytest.fixture
+def value_condition(range_all):
+    return models.ValueCondition(range=range_all, type="Value", value=D("10.00"))
+
+
+@pytest.fixture
+def coverage_condition(range_some):
+    return models.CoverageCondition(range=range_some, type="Coverage", value=2)
+
+
+@pytest.fixture
+def empty_basket():
+    return factories.create_basket(empty=True)
+
+
+@pytest.fixture
+def partial_basket(empty_basket):
+    basket = empty_basket
+    add_product(basket)
+    return basket
+
+
+@pytest.fixture
+def mock_offer():
+    return mock.Mock()
+
+
+@pytest.mark.django_db
+class TestCountCondition:
+
+    @pytest.fixture(autouse=True)
+    def setUp(self, mock_offer):
+        self.offer = mock_offer
+
+    def test_description(self, count_condition):
+        assert count_condition.description
+
+    def test_is_not_satisfied_by_empty_basket(self, count_condition, empty_basket):
+        assert count_condition.is_satisfied(self.offer, empty_basket) is False
+
+    def test_not_discountable_product_fails_condition(
+        self, count_condition, empty_basket
+    ):
+        basket = empty_basket
+        prod1, prod2 = factories.create_product(), factories.create_product()
+        prod2.is_discountable = False
+        prod2.save()
+        add_product(basket, product=prod1)
+        add_product(basket, product=prod2)
+        assert count_condition.is_satisfied(self.offer, basket) is False
+
+    def test_empty_basket_fails_partial_condition(self, count_condition, empty_basket):
+        assert count_condition.is_partially_satisfied(self.offer, empty_basket) is False
+
+    def test_smaller_quantity_basket_passes_partial_condition(
+        self, count_condition, empty_basket
+    ):
+        basket = empty_basket
+        add_product(basket)
+        assert count_condition.is_partially_satisfied(self.offer, basket)
+        assert count_condition._num_matches == 1
+
+    def test_smaller_quantity_basket_upsell_message(
+        self, count_condition, empty_basket
+    ):
+        basket = empty_basket
+        add_product(basket)
+        assert "Buy 1 more product from " in count_condition.get_upsell_message(
+            self.offer, basket
+        )
+
+    def test_matching_quantity_basket_fails_partial_condition(
+        self, count_condition, empty_basket
+    ):
+        basket = empty_basket
+        add_product(basket, quantity=2)
+        assert count_condition.is_partially_satisfied(self.offer, basket) is False
+
+    def test_matching_quantity_basket_passes_condition(
+        self, count_condition, empty_basket
+    ):
+        basket = empty_basket
+        add_product(basket, quantity=2)
+        assert count_condition.is_satisfied(self.offer, basket)
+
+    def test_greater_quantity_basket_passes_condition(
+        self, count_condition, empty_basket
+    ):
+        basket = empty_basket
+        add_product(basket, quantity=3)
+        assert count_condition.is_satisfied(self.offer, basket)
+
+    def test_consumption(self, count_condition, empty_basket):
+        basket = empty_basket
+        add_product(basket, quantity=3)
+        count_condition.consume_items(self.offer, basket, [])
+        assert 1 == basket.all_lines()[0].quantity_without_discount
+
+    def test_is_satisfied_accounts_for_consumed_items(
+        self, count_condition, empty_basket
+    ):
+        basket = empty_basket
+        add_product(basket, quantity=3)
+        count_condition.consume_items(self.offer, basket, [])
+        assert count_condition.is_satisfied(self.offer, basket) is False
+
+
+@pytest.mark.django_db
+class TestValueCondition:
+    @pytest.fixture(autouse=True)
+    def setUp(self, empty_basket, value_condition, mock_offer):
+        self.basket = empty_basket
+        self.condition = value_condition
+        self.offer = mock_offer
+        self.item = factories.create_product(price=D("5.00"))
+        self.expensive_item = factories.create_product(price=D("15.00"))
+
+    def test_description(self, value_condition):
+        assert value_condition.description
+
+    def test_empty_basket_fails_condition(self):
+        assert self.condition.is_satisfied(self.offer, self.basket) is False
+
+    def test_empty_basket_fails_partial_condition(self):
+        assert self.condition.is_partially_satisfied(self.offer, self.basket) is False
+
+    def test_less_value_basket_fails_condition(self):
+        add_product(self.basket, D("5"))
+        assert self.condition.is_satisfied(self.offer, self.basket) is False
+
+    def test_not_discountable_item_fails_condition(self):
+        product = factories.create_product(is_discountable=False)
+        add_product(self.basket, D("15"), product=product)
+        assert self.condition.is_satisfied(self.offer, self.basket) is False
+
+    def test_upsell_message(self):
+        add_product(self.basket, D("5"))
+        assert "Spend" in self.condition.get_upsell_message(self.offer, self.basket)
+
+    def test_matching_basket_fails_partial_condition(self):
+        add_product(self.basket, D("5"), 2)
+        assert self.condition.is_partially_satisfied(self.offer, self.basket) is False
+
+    def test_less_value_basket_passes_partial_condition(self):
+        add_product(self.basket, D("5"), 1)
+        assert self.condition.is_partially_satisfied(self.offer, self.basket)
+
+    def test_matching_basket_passes_condition(self):
+        add_product(self.basket, D("5"), 2)
+        assert self.condition.is_satisfied(self.offer, self.basket)
+
+    def test_greater_than_basket_passes_condition(self):
+        add_product(self.basket, D("5"), 3)
+        assert self.condition.is_satisfied(self.offer, self.basket)
+
+    def test_consumption(self):
+        add_product(self.basket, D("5"), 3)
+        self.condition.consume_items(self.offer, self.basket, [])
+        assert 1 == self.basket.all_lines()[0].quantity_without_discount
+
+    def test_consumption_with_high_value_product(self):
+        add_product(self.basket, D("15"), 1)
+        self.condition.consume_items(self.offer, self.basket, [])
+        assert 0 == self.basket.all_lines()[0].quantity_without_discount
+
+    def test_is_consumed_respects_quantity_consumed(self):
+        add_product(self.basket, D("15"), 1)
+        assert self.condition.is_satisfied(self.offer, self.basket)
+        self.condition.consume_items(self.offer, self.basket, [])
+        assert self.condition.is_satisfied(self.offer, self.basket) is False
+
+
+@pytest.mark.django_db
+class TestCoverageCondition:
+
+    @pytest.fixture(autouse=True)
+    def setUp(self, range_some, products_some, empty_basket, coverage_condition):
+        self.products = products_some
+        self.range = range_some
+        self.basket = empty_basket
+        self.condition = coverage_condition
+        self.offer = mock.Mock()
+
+    def test_empty_basket_fails(self):
+        assert self.condition.is_satisfied(self.offer, self.basket) is False
+
+    def test_empty_basket_fails_partial_condition(self):
+        assert self.condition.is_partially_satisfied(self.offer, self.basket) is False
+
+    def test_single_item_fails(self):
+        add_product(self.basket, product=self.products[0])
+        assert self.condition.is_satisfied(self.offer, self.basket) is False
+
+    def test_not_discountable_item_fails(self):
+        self.products[0].is_discountable = False
+        self.products[0].save()
+        add_product(self.basket, product=self.products[0])
+        add_product(self.basket, product=self.products[1])
+        assert self.condition.is_satisfied(self.offer, self.basket) is False
+
+    def test_single_item_passes_partial_condition(self):
+        add_product(self.basket, product=self.products[0])
+        assert self.condition.is_partially_satisfied(self.offer, self.basket)
+
+    def test_upsell_message(self):
+        add_product(self.basket, product=self.products[0])
+        assert "Buy 1 more" in self.condition.get_upsell_message(
+            self.offer, self.basket
+        )
+
+    def test_duplicate_item_fails(self):
+        add_product(self.basket, quantity=2, product=self.products[0])
+        assert self.condition.is_satisfied(self.offer, self.basket) is False
+
+    def test_duplicate_item_passes_partial_condition(self):
+        add_product(self.basket, quantity=2, product=self.products[0])
+        assert self.condition.is_partially_satisfied(self.offer, self.basket)
+
+    def test_covering_items_pass(self):
+        add_product(self.basket, product=self.products[0])
+        add_product(self.basket, product=self.products[1])
+        assert self.condition.is_satisfied(self.offer, self.basket)
+
+    def test_covering_items_fail_partial_condition(self):
+        add_product(self.basket, product=self.products[0])
+        add_product(self.basket, product=self.products[1])
+        assert self.condition.is_partially_satisfied(self.offer, self.basket) is False
+
+    def test_covering_items_are_consumed(self):
+        add_product(self.basket, product=self.products[0])
+        add_product(self.basket, product=self.products[1])
+        self.condition.consume_items(self.offer, self.basket, [])
+        assert 0 == self.basket.num_items_without_discount
+
+    def test_consumed_items_checks_affected_items(self):
+        # Create new offer
+        range = models.Range.objects.create(
+            name="All products", includes_all_products=True
+        )
+        cond = models.CoverageCondition(range=range, type="Coverage", value=2)
+
+        # Get 4 distinct products in the basket
+        self.products.extend([factories.create_product(), factories.create_product()])
+        for product in self.products:
+            add_product(self.basket, product=product)
+
+        assert cond.is_satisfied(self.offer, self.basket)
+        cond.consume_items(self.offer, self.basket, [])
+        assert 2 == self.basket.num_items_without_discount
+
+        assert cond.is_satisfied(self.offer, self.basket)
+        cond.consume_items(self.offer, self.basket, [])
+        assert 0 == self.basket.num_items_without_discount
+
+
 @pytest.mark.django_db
 class TestConditionProxyModels(object):
-
     def test_name_and_description(self, range):
         """
         Tests that the condition proxy classes all return a name and
@@ -231,10 +306,7 @@ class TestConditionProxyModels(object):
         """
         for type, __ in models.Condition.TYPE_CHOICES:
             condition = models.Condition(type=type, range=range, value=5)
-            assert all([
-                condition.name,
-                condition.description,
-                str(condition)])
+            assert all([condition.name, condition.description, str(condition)])
 
     def test_proxy(self, range):
         for type, __ in models.Condition.TYPE_CHOICES:
@@ -246,7 +318,6 @@ class TestConditionProxyModels(object):
 
 
 class TestCustomCondition(TestCase):
-
     def setUp(self):
         self.condition = custom.create_condition(BasketOwnerCalledBarry)
         self.offer = models.ConditionalOffer(condition=self.condition)
@@ -254,8 +325,8 @@ class TestCustomCondition(TestCase):
 
     def test_is_not_satisfied_by_non_match(self):
         self.basket.owner = factories.UserFactory(first_name="Alan")
-        self.assertFalse(self.offer.is_condition_satisfied(self.basket))
+        assert self.offer.is_condition_satisfied(self.basket) is False
 
     def test_is_satisfied_by_match(self):
         self.basket.owner = factories.UserFactory(first_name="Barry")
-        self.assertTrue(self.offer.is_condition_satisfied(self.basket))
+        assert self.offer.is_condition_satisfied(self.basket)

--- a/tests/integration/offer/test_percentage_benefit.py
+++ b/tests/integration/offer/test_percentage_benefit.py
@@ -1,5 +1,4 @@
 from decimal import Decimal as D
-from unittest import mock
 
 from django.core.exceptions import ValidationError
 from django.test import TestCase
@@ -22,7 +21,11 @@ class TestAPercentageDiscountAppliedWithCountCondition(TestCase):
             range=range,
             type=models.Benefit.PERCENTAGE,
             value=20)
-        self.offer = mock.Mock()
+        self.offer = models.ConditionalOffer(
+            offer_type=models.ConditionalOffer.SITE,
+            condition=self.condition,
+            benefit=self.benefit
+        )
         self.basket = factories.create_basket(empty=True)
 
     def test_applies_correctly_to_empty_basket(self):
@@ -68,7 +71,11 @@ class TestAPercentageDiscountWithMaxItemsSetAppliedWithCountCondition(TestCase):
             type=models.Benefit.PERCENTAGE,
             value=20,
             max_affected_items=1)
-        self.offer = mock.Mock()
+        self.offer = models.ConditionalOffer(
+            offer_type=models.ConditionalOffer.SITE,
+            condition=self.condition,
+            benefit=self.benefit
+        )
         self.basket = factories.create_basket(empty=True)
 
     def test_applies_correctly_to_empty_basket(self):
@@ -81,16 +88,16 @@ class TestAPercentageDiscountWithMaxItemsSetAppliedWithCountCondition(TestCase):
         add_product(self.basket, D('12.00'), 2)
         result = self.benefit.apply(self.basket, self.condition, self.offer)
         self.assertEqual(1 * D('12.00') * D('0.2'), result.discount)
-        self.assertEqual(2, self.basket.num_items_with_discount)
-        self.assertEqual(0, self.basket.num_items_without_discount)
+        self.assertEqual(1, self.basket.num_items_with_discount)
+        self.assertEqual(1, self.basket.num_items_without_discount)
 
     def test_applies_correctly_to_basket_which_exceeds_condition(self):
         add_products(self.basket, [(D('12.00'), 2), (D('20.00'), 2)])
         result = self.benefit.apply(self.basket, self.condition, self.offer)
         self.assertEqual(1 * D('12.00') * D('0.2'), result.discount)
         # Should only consume the condition products
-        self.assertEqual(2, self.basket.num_items_with_discount)
-        self.assertEqual(2, self.basket.num_items_without_discount)
+        self.assertEqual(1, self.basket.num_items_with_discount)
+        self.assertEqual(3, self.basket.num_items_without_discount)
 
 
 class TestAPercentageDiscountAppliedWithValueCondition(TestCase):
@@ -106,7 +113,12 @@ class TestAPercentageDiscountAppliedWithValueCondition(TestCase):
             range=range,
             type=models.Benefit.PERCENTAGE,
             value=20)
-        self.offer = mock.Mock()
+        self.offer = models.ConditionalOffer(
+            offer_type=models.ConditionalOffer.SITE,
+            condition=self.condition,
+            benefit=self.benefit
+        )
+
         self.basket = factories.create_basket(empty=True)
 
     def test_applies_correctly_to_empty_basket(self):
@@ -151,7 +163,11 @@ class TestAPercentageDiscountWithMaxItemsSetAppliedWithValueCondition(TestCase):
             type=models.Benefit.PERCENTAGE,
             value=20,
             max_affected_items=1)
-        self.offer = mock.Mock()
+        self.offer = models.ConditionalOffer(
+            offer_type=models.ConditionalOffer.SITE,
+            condition=self.condition,
+            benefit=self.benefit
+        )
         self.basket = factories.create_basket(empty=True)
 
     def test_applies_correctly_to_empty_basket(self):
@@ -164,22 +180,22 @@ class TestAPercentageDiscountWithMaxItemsSetAppliedWithValueCondition(TestCase):
         add_product(self.basket, D('5.00'), 2)
         result = self.benefit.apply(self.basket, self.condition, self.offer)
         self.assertEqual(1 * D('5.00') * D('0.2'), result.discount)
-        self.assertEqual(2, self.basket.num_items_with_discount)
-        self.assertEqual(0, self.basket.num_items_without_discount)
+        self.assertEqual(1, self.basket.num_items_with_discount)
+        self.assertEqual(1, self.basket.num_items_without_discount)
 
     def test_applies_correctly_to_basket_which_exceeds_condition_but_matches_on_boundary(self):
         add_product(self.basket, D('5.00'), 3)
         result = self.benefit.apply(self.basket, self.condition, self.offer)
         self.assertEqual(1 * D('5.00') * D('0.2'), result.discount)
-        self.assertEqual(2, self.basket.num_items_with_discount)
-        self.assertEqual(1, self.basket.num_items_without_discount)
+        self.assertEqual(1, self.basket.num_items_with_discount)
+        self.assertEqual(2, self.basket.num_items_without_discount)
 
     def test_applies_correctly_to_basket_which_exceeds_condition(self):
         add_product(self.basket, D('4.00'), 3)
         result = self.benefit.apply(self.basket, self.condition, self.offer)
         self.assertEqual(1 * D('4.00') * D('0.2'), result.discount)
-        self.assertEqual(3, self.basket.num_items_with_discount)
-        self.assertEqual(0, self.basket.num_items_without_discount)
+        self.assertEqual(1, self.basket.num_items_with_discount)
+        self.assertEqual(2, self.basket.num_items_without_discount)
 
 
 class TestAPercentageDiscountBenefit(TestCase):


### PR DESCRIPTION
also restrict the usage of offer consumption to line.consume()

fixes #2788 