### PR TITLE
Remove Bootstrap Datepicker CSS/JS assets from base frontend template.

### DIFF
--- a/src/oscar/templates/oscar/layout.html
+++ b/src/oscar/templates/oscar/layout.html
@@ -12,8 +12,6 @@
     {% else %}
         <link rel="stylesheet" type="text/css" href="{% static "oscar/css/styles.css" %}" />
     {% endif %}
-    <link rel="stylesheet" href="{% static "oscar/js/bootstrap-datetimepicker/bootstrap-datetimepicker.min.css" %}" />
-    <link rel="stylesheet" type="text/css" href="{% static "oscar/css/datetimepicker.css" %}" />
 {% endblock %}
 
 {% block layout %}
@@ -74,9 +72,6 @@
     <script src="{% static "oscar/js/bootstrap3/bootstrap.min.js" %}"></script>
     <!-- Oscar -->
     <script src="{% static "oscar/js/oscar/ui.js" %}"></script>
-
-    <script src="{% static "oscar/js/bootstrap-datetimepicker/bootstrap-datetimepicker.min.js" %}"></script>
-    <script src="{% static "oscar/js/bootstrap-datetimepicker/locales/bootstrap-datetimepicker.all.js" %}"></script>
 {% endblock %}
 
 {% block extrascripts %}


### PR DESCRIPTION
Fixes #2584 