### PR TITLE
Mention about necessity to install Python headers in order to build sandbox site.

### DIFF
--- a/docs/source/internals/contributing/development-environment.rst
+++ b/docs/source/internals/contributing/development-environment.rst
@@ -9,7 +9,7 @@ Fork the repo and run::
     $ mkvirtualenv oscar  # needs virtualenvwrapper
     $ make install
 
-If using Ubuntu, the ``python-dev`` package is required for some packages to
+If using Ubuntu, the ``python3-dev`` package is required for some packages to
 compile.
 
 The :doc:`sandbox </internals/sandbox>` site can be used to examine changes
@@ -23,7 +23,7 @@ JPEG Support
 On Ubuntu, you need to install a few libraries to get JPEG support with
 Pillow::
 
-    $ sudo apt-get install python-dev libjpeg-dev libfreetype6-dev zlib1g-dev
+    $ sudo apt-get install python3-dev libjpeg-dev libfreetype6-dev zlib1g-dev
 
 If you already installed PIL (you did if you ran ``make install`` previously),
 reinstall it::

--- a/docs/source/internals/sandbox.rst
+++ b/docs/source/internals/sandbox.rst
@@ -51,7 +51,12 @@ play around with Oscar.
     While installing Oscar is straightforward, some of Oscar's dependencies
     don't support Windows and are tricky to be properly installed, and therefore
     you might encounter some errors that prevent a successful installation.
-    
+
+In order to compile uWSGI, which is a dependency of the sandbox, you will
+first need to install the Python development headers with:::
+
+    $ sudo apt-get install python3-dev
+
 Install Oscar and its dependencies within a virtualenv:
 
 .. code-block:: bash


### PR DESCRIPTION
Fixes #2816.