### PR TITLE
Drop Django 2.0 from test matrix and update supported versions in several places

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,6 @@ matrix:
     - python: 3.7
       env: TOXENV=py37-django111
     - python: 3.5
-      env: TOXENV=py35-django20
-    - python: 3.6
-      env: TOXENV=py36-django20
-    - python: 3.7
-      env: TOXENV=py37-django20
-    - python: 3.5
       env: TOXENV=py35-django21
     - python: 3.6
       env: TOXENV=py36-django21

--- a/docs/source/releases/v2.0.rst
+++ b/docs/source/releases/v2.0.rst
@@ -19,8 +19,8 @@ Table of contents:
 Compatibility
 -------------
 
-Oscar 2.0 is compatible with Django 1.11, Django 2.0, Django 2.1 and Django 2.2
-as well as Python 3.5 and 3.6.
+Oscar 2.0 is compatible with Django 1.11, Django 2.1 and Django 2.2
+as well as Python 3.5, 3.6 and 3.7.
 
 Support for Python 2.7 and Python 3.4 has been dropped.
 
@@ -52,10 +52,10 @@ What's new in Oscar 2.0?
 
 - Added an ``OSCAR_THUMBNAILER`` setting which is used to indicate thumbnailer class
   used to generate thumbnail. This defaults to ``'oscar.core.thumbnails.SorlThumbnail'``.
-  
+
 - Added ``oscar_thumbnail`` template tag (to ``image_tags``) to generate thumbnails in templates.
   Sorl's ``thumbnail`` template tag replaced by ``oscar_thumbnail`` in all related templates.
-  
+
 - ``sorl-thumbnail`` removed from ``install_requires``. Desirable thumbnailer (``sorl-thumbnail`` or ``easy-thumbnails``) now
   must be installed manually or with ``pip install django-oscar[sorl-thumbnail]`` or ``pip install django-oscar[easy-thumbnails]``.
 
@@ -185,7 +185,7 @@ Minor changes
 - Oscar's 500 error template no longer inherits other templates and
   does not use any template template tags and
   styling to avoid potential errors caused by the template itself (see :issue:`2971`).
-  
+
 - Line discounts are now capped to a minimum of zero - i.e., negative discounts will not be reported.
 
 .. _incompatible_in_2.0:

--- a/setup.py
+++ b/setup.py
@@ -98,8 +98,8 @@ setup(
         'Environment :: Web Environment',
         'Framework :: Django',
         'Framework :: Django :: 1.11',
-        'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
+        'Framework :: Django :: 2.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: Unix',
@@ -107,6 +107,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Libraries :: Application Frameworks']
 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{35,36,37}-django{111,20,21,22}
+    py{35,36,37}-django{111,21,22}
     py36-djangomaster
     lint
     sandbox
@@ -13,7 +13,6 @@ extras = test
 pip_pre = true
 deps =
     django111: django>=1.11,<2
-    django20: django>=2.0,<2.1
     django21: django>=2.1,<2.2
     django22: django>=2.2,<2.3
 
@@ -51,7 +50,7 @@ commands =
 basepython = python3.5
 deps =
     -r{toxinidir}/requirements.txt
-    django>=1.11,<2
+    django>=2.2,<2.3
 whitelist_externals = make
 commands =
     make build_sandbox


### PR DESCRIPTION
Django 2.0 reached end of life in April 2019.