### PR TITLE
Prepare for 2.0b1 release

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,13 +1,13 @@
 David Winterbottom
 Maik Hoepfel
 Michael van Tellingen
-Alexander Gaevsky
 Samir Shah
+Alexander Gaevsky
 Sebastian Vetter
 Jon Price
 Markus Bertheau
-Andrew Ingram
 pyup-bot
+Andrew Ingram
 Asia Biega
 Xavier Ordoquy
 Oliver Randell
@@ -22,3 +22,267 @@ Patryk Zawadzki
 Jonathan Moss
 andysellick
 Paweł Kowalski
+Dawid Lorenz
+Michael
+Janusz Harkot
+Craig Loftus
+st4lk
+Martijn Jacobs
+Federico Marani
+Diederik van der Boor
+Davi Vidal
+itbabu
+Alex Crawley
+Pete Graham
+Paul J Stevens
+Matus Moravcik
+Łukasz Lechowicz
+Jannis Leidel
+Aliaksei Urbanski
+Vladimir Bolshakov
+Victor Munene
+Monika Sulik
+Kees Hink
+dfirst
+Costas Basdekis
+Srdjan Cosic
+Skirmantas Jurgaitis
+Kaveh
+Valery Masiutsin
+Moose
+Michael Kutý
+Marco Badan
+John Papanastasiou
+Goran Rakic
+andrefsp
+Vedran Karačić
+Nitish Rathi
+Mike Dingjan
+Anton
+Anentropic
+pyup.io bot
+Piper Merriam
+Nathan Staines
+Lijo Antony
+Lars van de Kerkhof
+Joseph Wayodi
+Francis Reyes
+Edvinas Jurevicius
+danyilmaz
+Bojan Mihelac
+Basil Dubyk
+Alex Moon
+Piotr Jakimiak
+Pierre Dulac
+Mohammad Abbas
+Moayad Mardini
+Marek Brzóska
+Leonardo
+kinygos
+Juan Madurga
+Gump
+Geekfish
+Fish
+erickmk
+Ashia Zawaduk
+Alexander Pugachev
+aamir
+Tobias Englert
+Sergey Maranchuk
+Roel Bruggink
+Rachel Willmer
+Paolo Donadeo
+Mike de Bock
+Matthew Wilkes
+Matt George
+Marshall Bannan
+Highbiza migration experts
+Georgiy Kutsurua
+Éric Araujo
+elliotthill
+Dmitry Voronin
+Denis Darii
+Craig Weber
+Andrea Grandi
+Alexander Clausen
+aibon
+Adrien Delhorme
+Ziyad Soobhan
+Yuriy Vaskin
+Wu Jiang
+Tuna Vargi
+Tim Jacobi
+SrdjanCosicPrica
+Shafique Jamal
+rsp2k
+Rob Moorman
+Róbert Čerňanský
+PaulO
+Matt Moran
+Mads Jensen
+Lex Berezhny
+Krzysiek Szularz
+Jay Modi
+Jason Cater
+Jan Klapuch
+James Eddison
+Ignat
+Florian Haas
+fish
+dimka665
+David Caplan
+Clinton Blackburn
+chenull
+Brandon R. Stoner
+Arthur Case
+Andrey Martyanov
+Alexander
+Adam Endicott
+Zachary B. Mott
+yn-coder
+yn_coder
+xyzzy
+Will Daly
+WeJie
+vkaracic
+v1kku
+Tom Hendrikx
+Tomasz Wysocki
+Tobias
+TiendaPaisa
+tiberiuichim
+Teemu Heikkilä
+Tarashish Mishra
+Tadas Dailyda
+Sylvain Fankhauser
+Sun Song
+Sudhir Mishra
+Steven Maggs
+Stefano Brentegani
+Sergey Fedoseev
+Sergei G
+Seppo Erviälä
+Selim
+ryneeverett
+Richard
+resteve
+Rachel Graves
+qjiang
+pythonpro
+Przemek Łada
+podados
+PlayDay
+Philip Kazmeier
+Peter Brooks
+pabu
+Pablo
+Osvaldo Santana Neto
+orf
+Oleg Rybkin
+Oleg Fish
+Nicola Marangon
+Nando Davis
+mvdwaeter
+mostafa-anm
+monikasulik
+M O Faruque Sarker
+Mirek Mencel
+Miloud Belarbi
+Michal Raška
+Matt Miller
+Matthew O'Loughlin
+Matt Drayer
+Mathieu Richardoz
+Matas Dailyda
+Marek Matulka
+marcustas
+marco
+marangonico
+Lysergia
+Lukasz Kryger
+lucaippo
+Krystian Cybulski
+Kristi
+Konstantinos Metaxas
+Klaus Weiss
+Kit La Touche
+kisiel
+kemar
+Kai-Chu Chung
+Kaarle Ritvanen
+Julien Maupetit
+jsa
+Josh Kalderimis
+josh@halfnibble.com
+José Luis
+Jose Guedez
+José Duarte
+Joris Vankerschaver
+Jon Aylard
+Jonathan Fiebelkorn
+Jonas Borges
+John-Scott Atlakson
+John Franey
+johndt6
+John Carter
+Johannes Schneider
+joaoxsouls
+jiangqijiong
+jeddison
+Javier Wilson
+Jan Chęć
+James Osgood
+Jacek Bzdak
+Ido Rosen
+ibrmora
+gogobook
+Gleber Diniz
+Giulio De Donato
+giacomo
+George Tantiras
+Gabriele Alese
+Frédéric Montet
+Florian C
+Fatih Erikli
+Fakhar
+Euan Lau
+endgame
+dzxs5741
+dragonjun
+discort
+Developers
+Denis Proskurin
+Darian Moody
+Daniel Hepper
+Daniel DUONG
+Daniel
+Dan Helyar
+Dan Atkinson
+Dan
+Chris McKinnel
+Carlos Ramirez
+Bonza-Times
+Bogdan I. Bursuc
+Blake Griffith
+bharathwaaj
+benvand
+Ben Burry
+Becky Lewis
+Bart
+ayub-khan
+Ayub
+astyfx
+Artёm Skvira
+Art Skvira
+Ariel Kaplan
+anywhim
+anentropic
+André Ericson
+amirrpp
+Alexander Kaidalov
+Aleksandr Panteleymonov
+Adrien Saladin
+Adrian Fedoreanu
+Adam Chainz
+Aamir Khan
+김정환

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ with open(os.path.join(PROJECT_DIR, 'README.rst')) as fh:
 
 setup(
     name='django-oscar',
-    version=get_version().replace(' ', '-'),
+    version=get_version(),
     url='https://github.com/django-oscar/django-oscar',
     author="David Winterbottom",
     author_email="david.winterbottom@gmail.com",
@@ -94,7 +94,7 @@ setup(
         'easy-thumbnails': [easy_thumbnails_version],
     },
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
+        'Development Status :: 4 - Beta',
         'Environment :: Web Environment',
         'Framework :: Django',
         'Framework :: Django :: 1.11',

--- a/src/oscar/__init__.py
+++ b/src/oscar/__init__.py
@@ -1,5 +1,5 @@
-# Use 'dev', 'beta', or 'final' as the 4th element to indicate release type.
-VERSION = (2, 0, 0, 'dev')
+# Use 'alpha', 'beta', 'rc' or 'final' as the 4th element to indicate release type.
+VERSION = (2, 0, 0, 'beta', 1)
 
 
 def get_short_version():
@@ -12,9 +12,10 @@ def get_version():
     if VERSION[2]:
         version = '%s.%s' % (version, VERSION[2])
     elif VERSION[3] != 'final':
-        version = '%s %s' % (version, VERSION[3])
+        mapping = {'alpha': 'a', 'beta': 'b', 'rc': 'c'}
+        version = '%s%s' % (version, mapping[VERSION[3]])
         if len(VERSION) == 5:
-            version = '%s %s' % (version, VERSION[4])
+            version = '%s%s' % (version, VERSION[4])
     return version
 
 


### PR DESCRIPTION
This also changes the version identifier used in setup.py to be compliant with [PEP 386](https://www.python.org/dev/peps/pep-0386/#the-new-versioning-algorithm).