### PR TITLE
Update transifex-client used in CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,8 @@ matrix:
 
 env:
   global:
-    # $TRANSIFEX_PASSWORD for oscar_bot (used in transifex.sh)
-    - secure: FuIlzEsGJiAwhaIRBmRNsq9eXmuzs25fX6BChknW4lDyVAySWMp0+Zps9Bd0JgfFYUG3Ip+OTmksYIoTUsG25ZJS9cq1IFt3QKUAN70YCI/4ZBLeIdICPEyxq+Km179+NeEXmBUug17RLMLxh3MWfO+RKUHK9yHIPNNpq0dNyoo=
+    # $TRANSIFEX_PASSWORD - Transifex API key (used in transifex.sh)
+    - secure: fFOuN7cZxN74zVN6tkxwr9Kby4qxC0AxV+jvcT5HVaQ1sSl0L5SxRA7EzgCSTbkz3QjCVFrQfEvGflqTWCFqtF4ou2S9ip7Nhhs+TjsDqErhyAOodqwacp0DSzjlvPBx7AVyajdzV9iHtHrcLHyS9v5aaeCGQ4RXIqRntcM4l/c=
 
     # These two environment variables could be set by Travis itself, or Travis
     # could configure itself in /etc/, ~/, or inside of the virtual

--- a/transifex.sh
+++ b/transifex.sh
@@ -11,12 +11,12 @@ if [ $? -eq 0 ] && [ $TRAVIS_BRANCH == master ]
 then
     echo "Submitting translation files to Transifex"
     make messages
-    pip install "transifex-client==0.10"
+    pip install "transifex-client>=0.13,<0.14"
     # Write .transifexrc file
     echo "[https://www.transifex.com]
+api_hostname = https://www.transifex.com
 hostname = https://www.transifex.com
 password = $TRANSIFEX_PASSWORD
-token = 
-username = oscar_bot" > ~/.transifexrc
+username = api" > ~/.transifexrc
     tx push --source --no-interactive
 fi


### PR DESCRIPTION
The version we are currently using is out of date, and the Transifex API has changed to use API keys instead of username and password. I've generated a new API key and this PR updates the command to push translations to transifex.