### PR TITLE
Add back sorl-thumbnail as a dependency of Oscar.

### DIFF
--- a/docs/source/ref/settings.rst
+++ b/docs/source/ref/settings.rst
@@ -330,7 +330,7 @@ The time to live for the basket cookie in seconds.
 
 Default: ``10000``
 
-The maximum number of products that can be added to a basket at once. Set to 
+The maximum number of products that can be added to a basket at once. Set to
 ``None`` to disable the basket threshold limitation.
 
 
@@ -421,10 +421,10 @@ Such files should always be deleted afterwards.
 Default: ``'oscar.core.thumbnails.SorlThumbnail'``
 
 Thumbnailer class that will be used to generate thumbnails. Available options:
-``SorlThumbnail`` and ``EasyThumbnails``. To use them ``sorl-thumbnail`` or
-``easy-thumbnails`` must be installed manually or with ``pip install django-oscar[sorl-thumbnail]`` or
-``pip install django-oscar[easy-thumbnails]``. Custom thumbnailer class (based on
-``oscar.core.thumbnails.AbstractThumbnailer``) can be used as well.
+``SorlThumbnail`` (default) and ``EasyThumbnails``. To use them Easy Thumbnails,
+``easy-thumbnails`` must be installed manually or with
+``pip install django-oscar[easy-thumbnails]``. A custom thumbnailer class
+(based on ``oscar.core.thumbnails.AbstractThumbnailer``) can be used as well.
 
 Slug settings
 =============

--- a/docs/source/releases/v2.0.rst
+++ b/docs/source/releases/v2.0.rst
@@ -60,11 +60,6 @@ What's new in Oscar 2.0?
   thumbnails in templates.  All uses of Sorl's ``thumbnail`` template tag in
   the shipped templates have been replaced with ``oscar_thumbnail``.
 
-- ``sorl-thumbnail`` has been dropped as a dependency. Use
-  ``pip install django-oscar[sorl-thumbnail]`` or
-  ``pip install django-oscar[easy-thumbnails]`` to explicitly install the
-  dependencies for either of the two supported thumbnailers.
-
 - Added the ability to manage ``catalogue.Option`` objects from the dashboard.
 
 .. _`#2875`: https://github.com/django-oscar/django-oscar/pull/2875

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ install_requires = [
     # Used for manipulating form field attributes in templates (eg: add
     # a css class)
     'django-widget-tweaks>=1.4.1',
+    'sorl-thumbnail>=12.4.1,<12.5',
 ]
 
 docs_requires = [
@@ -50,7 +51,6 @@ docs_requires = [
     'sphinx-issues==1.2.0',
 ]
 
-sorl_thumbnail_version = 'sorl-thumbnail>=12.4.1,<12.5'
 easy_thumbnails_version = 'easy-thumbnails==2.5'
 
 test_requires = [
@@ -64,7 +64,6 @@ test_requires = [
     'pytest-django==3.4.8',
     'pytest-xdist>=1.25,<1.28',
     'tox>=3.0,<3.9',
-    sorl_thumbnail_version,
     easy_thumbnails_version,
 ]
 
@@ -90,7 +89,6 @@ setup(
     extras_require={
         'docs': docs_requires,
         'test': test_requires,
-        'sorl-thumbnail': [sorl_thumbnail_version],
         'easy-thumbnails': [easy_thumbnails_version],
     },
     classifiers=[


### PR DESCRIPTION
I think we made a mistake by dropping the default thumbnailer as a dependency. It means that `pip install django-oscar` doesn't give you a working setup, which is going to trip up a lot of newcomers. Since the default is still sorl I think we should keep it as a dependency.

Also fixes #3023.