### PR TITLE
Add less.js to Dashboard Layout

### DIFF
--- a/src/oscar/templates/oscar/dashboard/layout.html
+++ b/src/oscar/templates/oscar/dashboard/layout.html
@@ -121,6 +121,14 @@
 
 {% endblock %}
 
+{% block cdn_scripts %}
+  {{ block.super }}
+  {% if use_less and debug %}
+    {# Load the on-the-fly less compiler. Never do this in production. #}
+    <script src="//cdnjs.cloudflare.com/ajax/libs/less.js/2.5.3/less.min.js"></script>
+  {% endif %}
+{% endblock %}
+
 {# Local scripts #}
 {% block scripts %}
     <!-- Twitter Bootstrap -->

--- a/src/oscar/templates/oscar/dashboard/layout.html
+++ b/src/oscar/templates/oscar/dashboard/layout.html
@@ -125,7 +125,7 @@
   {{ block.super }}
   {% if use_less and debug %}
     {# Load the on-the-fly less compiler. Never do this in production. #}
-    <script src="//cdnjs.cloudflare.com/ajax/libs/less.js/2.5.3/less.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/less.js/3.9.0/less.min.js"></script>
   {% endif %}
 {% endblock %}
 

--- a/src/oscar/templates/oscar/layout.html
+++ b/src/oscar/templates/oscar/layout.html
@@ -61,7 +61,7 @@
   {{ block.super }}
   {% if use_less and debug %}
     {# Load the on-the-fly less compiler. Never do this in production. #}
-    <script src="//cdnjs.cloudflare.com/ajax/libs/less.js/2.5.3/less.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/less.js/3.9.0/less.min.js"></script>
   {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
OSCAR_USE_LESS = True doesn't work in Oscar Dashboard. This commit makes it work by putting less.js on dashboard/layout.html. It resolves #3033 