### PR TITLE
Drop transifex push from travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,4 +73,3 @@ script:
 after_success:
   - tox -e coverage-report
   - codecov
-  - ./transifex.sh


### PR DESCRIPTION
This temporarily removes the transifex push from the travis build - there are several issues with it that we need to resolve:

1. The current transifex.sh script doesn't do what was intended. `$TRAVIS_BRANCH` is the **target branch** for PRs, and not the branch on which the build is running. This means we are pushing to transifex every time a PR is submitted, which we definitely don't want to do.

2. Travis encryption of the API key doesn't seem to be correct, so it asks for API key again. I need to look at why this is happening - probably an escaping issue.

3. Running makemessages in the build without committing those changes feels like a bad idea, because the repo itself is still out of date. We need a better workflow for this - I want to look at what other projects do here.

Because of these issues I think it's better we push to transifex manually for now, and come up with a better workflow for this. I'm happy to push manually - it's not like we have frequent string changes.