### PR TITLE
Retrieving product options now performs only 1 query.

### DIFF
--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -493,7 +493,7 @@ class AbstractProduct(models.Model):
         It's possible to have options product class-wide, and per product.
         """
         pclass_options = self.get_product_class().options.all()
-        return set(pclass_options) or set(self.product_options.all())
+        return pclass_options | self.product_options.all()
 
     @cached_property
     def has_options(self):

--- a/tests/integration/catalogue/test_options.py
+++ b/tests/integration/catalogue/test_options.py
@@ -34,3 +34,26 @@ class ProductOptionTests(TestCase):
         product = qs.first()
         self.assertTrue(product.has_options)
         self.assertEquals(product.num_product_options, 1)
+
+    def test_queryset_both(self):
+        "The options attribute on a product should return a queryset containing "
+        "both the product class options and any extra options defined on the"
+        "product"
+        # set up the options on product and product_class
+        self.test_product_has_options_per_product_class()
+        self.test_product_has_options_per_product()
+        self.assertTrue(self.product.has_options, "Options should be present")
+        self.assertEquals(self.product.options.count(), 1,
+            "options attribute should not contain duplicates")
+        qs = Product.objects.browsable().base_queryset().filter(id=self.product.id)
+        product = qs.first()
+        self.assertEquals(product.num_product_class_options, 1,
+            "num_product_class_options should indicate the product_class option")
+        self.assertEquals(product.num_product_options, 1,
+            "num_product_options should indicate the number of product options")
+        self.product_class.options.add(factories.OptionFactory(code="henk"))
+        self.assertEquals(self.product.options.count(), 2,
+            "New product_class options should be immediately visible")
+        self.product.product_options.add(factories.OptionFactory(code="klaas"))
+        self.assertEquals(self.product.options.count(), 3,
+            "New product options should be immediately visible")

--- a/tests/integration/catalogue/test_options.py
+++ b/tests/integration/catalogue/test_options.py
@@ -43,17 +43,27 @@ class ProductOptionTests(TestCase):
         self.test_product_has_options_per_product_class()
         self.test_product_has_options_per_product()
         self.assertTrue(self.product.has_options, "Options should be present")
-        self.assertEquals(self.product.options.count(), 1,
-            "options attribute should not contain duplicates")
+        self.assertEquals(
+            self.product.options.count(), 1,
+            "options attribute should not contain duplicates"
+        )
         qs = Product.objects.browsable().base_queryset().filter(id=self.product.id)
         product = qs.first()
-        self.assertEquals(product.num_product_class_options, 1,
-            "num_product_class_options should indicate the product_class option")
-        self.assertEquals(product.num_product_options, 1,
-            "num_product_options should indicate the number of product options")
+        self.assertEquals(
+            product.num_product_class_options, 1,
+            "num_product_class_options should indicate the product_class option"
+        )
+        self.assertEquals(
+            product.num_product_options, 1,
+            "num_product_options should indicate the number of product options"
+        )
         self.product_class.options.add(factories.OptionFactory(code="henk"))
-        self.assertEquals(self.product.options.count(), 2,
-            "New product_class options should be immediately visible")
+        self.assertEquals(
+            self.product.options.count(), 2,
+            "New product_class options should be immediately visible"
+        )
         self.product.product_options.add(factories.OptionFactory(code="klaas"))
-        self.assertEquals(self.product.options.count(), 3,
-            "New product options should be immediately visible")
+        self.assertEquals(
+            self.product.options.count(), 3,
+            "New product options should be immediately visible"
+        )


### PR DESCRIPTION
Also it returns all the product options combined. This makes more sense because
as the existing tests prove, there is allready a way to retrieve the product_class
options and the product options separately.