### PR TITLE
Fix: warning messages of UppercaseCharField and NullCharField

### DIFF
--- a/src/oscar/models/fields/__init__.py
+++ b/src/oscar/models/fields/__init__.py
@@ -78,7 +78,6 @@ class UppercaseCharField(CharField):
             cls, name, **kwargs)
         setattr(cls, self.name, Creator(self))
 
-    # I fix it!
     # Django 2.0 updates the signature of from_db_value.
     # https://docs.djangoproject.com/en/2.0/releases/2.0/#context-argument-of-field-from-db-value-and-expression-convert-value
     if django.VERSION < (2,):
@@ -100,9 +99,6 @@ class UppercaseCharField(CharField):
                 value = self.to_python(value)
             return value
 
-    # Previous code
-    # def from_db_value(self, value, expression, connection, context):
-    #     return self.to_python(value)
 
     def to_python(self, value):
         val = super().to_python(value)
@@ -132,7 +128,6 @@ class NullCharField(CharField):
         super().contribute_to_class(cls, name, **kwargs)
         setattr(cls, self.name, Creator(self))
 
-    # I fix it!
     # Django 2.0 updates the signature of from_db_value.
     # https://docs.djangoproject.com/en/2.0/releases/2.0/#context-argument-of-field-from-db-value-and-expression-convert-value
     if django.VERSION < (2,):
@@ -152,11 +147,6 @@ class NullCharField(CharField):
             value = self.to_python(value)
             return value if value is not None else ''
 
-    # Previous code
-    # def from_db_value(self, value, expression, connection, context):
-    #     value = self.to_python(value)
-    #     # If the value was stored as null, return empty string instead
-    #     return value if value is not None else ''
 
     def get_prep_value(self, value):
         prepped = super().get_prep_value(value)

--- a/src/oscar/models/fields/__init__.py
+++ b/src/oscar/models/fields/__init__.py
@@ -1,3 +1,4 @@
+import django
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models.fields import CharField, DecimalField
 from django.utils.translation import gettext_lazy as _

--- a/src/oscar/models/fields/__init__.py
+++ b/src/oscar/models/fields/__init__.py
@@ -82,7 +82,7 @@ class UppercaseCharField(CharField):
     # Django 2.0 updates the signature of from_db_value.
     # https://docs.djangoproject.com/en/2.0/releases/2.0/#context-argument-of-field-from-db-value-and-expression-convert-value
     if django.VERSION < (2,):
-        def from_db_value(self, value, expression, connection, context):  # noqa
+        def from_db_value(self, value, expression, connection, context):
             """
             Converts a value as returned by the database to a Python object. It is
             the reverse of get_prep_value(). - New in Django 1.8
@@ -99,7 +99,6 @@ class UppercaseCharField(CharField):
             if value:
                 value = self.to_python(value)
             return value
-
 
     def to_python(self, value):
         val = super().to_python(value)
@@ -132,7 +131,7 @@ class NullCharField(CharField):
     # Django 2.0 updates the signature of from_db_value.
     # https://docs.djangoproject.com/en/2.0/releases/2.0/#context-argument-of-field-from-db-value-and-expression-convert-value
     if django.VERSION < (2,):
-        def from_db_value(self, value, expression, connection, context):  # noqa
+        def from_db_value(self, value, expression, connection, context):
             """
             Converts a value as returned by the database to a Python object. It is
             the reverse of get_prep_value(). - New in Django 1.8
@@ -147,7 +146,6 @@ class NullCharField(CharField):
             """
             value = self.to_python(value)
             return value if value is not None else ''
-
 
     def get_prep_value(self, value):
         prepped = super().get_prep_value(value)

--- a/tests/integration/core/test_nullcharfield.py
+++ b/tests/integration/core/test_nullcharfield.py
@@ -8,7 +8,7 @@ class NullCharFieldTest(TestCase):
 
     def test_from_db_value_converts_null_to_string(self):
         field = NullCharField()
-        self.assertEqual('', field.from_db_value(None, expression=None, connection=None))
+        self.assertEqual('', field.from_db_value(None, expression=None, connection=None, context=None))
 
     def test_get_prep_value_converts_empty_string_to_null(self):
         field = NullCharField()

--- a/tests/integration/core/test_nullcharfield.py
+++ b/tests/integration/core/test_nullcharfield.py
@@ -8,7 +8,7 @@ class NullCharFieldTest(TestCase):
 
     def test_from_db_value_converts_null_to_string(self):
         field = NullCharField()
-        self.assertEqual('', field.from_db_value(None, expression=None, connection=None, context=None))
+        self.assertEqual('', field.from_db_value(None, expression=None, connection=None))
 
     def test_get_prep_value_converts_empty_string_to_null(self):
         field = NullCharField()


### PR DESCRIPTION
I fixed deprecation warning.
change Nullcharfield and UppeercaseCharField class in oscar/models/fields.