### PR TITLE
Docs Fix: Updated urls.py.  Added missing promotions app

### DIFF
--- a/docs/source/internals/getting_started.rst
+++ b/docs/source/internals/getting_started.rst
@@ -96,6 +96,7 @@ depends on. Also set ``SITE_ID``:
         'oscar.apps.search',
         'oscar.apps.voucher',
         'oscar.apps.wishlists',
+        'oscar.apps.promotions',
         'oscar.apps.dashboard',
         'oscar.apps.dashboard.reports',
         'oscar.apps.dashboard.users',
@@ -181,23 +182,23 @@ you will also need to include Django's i18n URLs:
 
 .. code-block:: django
 
-    from django.apps import apps
-    from django.conf.urls import include, url  # < Django-2.0
-    # from django.urls import include, path  # > Django-2.0
+    # from django.conf.urls import include, url  # < Django-2.0
     from django.contrib import admin
+    from django.urls import include, path  # >= Django-2.0
+    from oscar.app import application
 
     urlpatterns = [
-        url(r'^i18n/', include('django.conf.urls.i18n')),
-        # path('i18n/', include('django.conf.urls.i18n')),  # > Django-2.0
+        # url(r'^i18n/', include('django.conf.urls.i18n')), # < Django-2.0
+        path('i18n/', include('django.conf.urls.i18n')),
 
         # The Django admin is not officially supported; expect breakage.
         # Nonetheless, it's often useful for debugging.
 
-        url(r'^admin/', admin.site.urls),
-        # path('admin/', admin.site.urls),  # > Django-2.0
+        # url(r'^admin/', admin.site.urls), # < Django-2.0
+        path('admin/', admin.site.urls),
 
-        url(r'^', include(apps.get_app_config('oscar').urls[0])),
-        # path('', include(apps.get_app_config('oscar').urls[0])),  # > Django-2.0
+        # url(r'^', application.urls), # < Django-2.0
+        path('', application.urls),
     ]
 
 


### PR DESCRIPTION
Fixes https://github.com/django-oscar/django-oscar/issues/2958

Changes required to make application run using official docs.  Made Django 2.0 the default example url pattern.