### PR TITLE
Doc Fix: Link to stable documents in front README page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Contents:
     :target: http://oscarcommerce.com
 
 .. image:: https://github.com/django-oscar/django-oscar/raw/master/docs/images/screenshots/readthedocs.thumb.png
-    :target: https://django-oscar.readthedocs.io/en/latest/
+    :target: https://django-oscar.readthedocs.io/en/stable/
 
 Further reading:
 
@@ -68,7 +68,7 @@ Docs status:
 .. _`Official homepage`: http://oscarcommerce.com
 .. _`Sandbox site`: http://latest.oscarcommerce.com
 .. _`Docker image`: https://hub.docker.com/r/oscarcommerce/django-oscar-sandbox/
-.. _`Documentation`: https://django-oscar.readthedocs.io/en/latest/
+.. _`Documentation`: https://django-oscar.readthedocs.io/en/stable/
 .. _`readthedocs.org`: http://readthedocs.org
 .. _`Continuous integration homepage`: http://travis-ci.org/#!/django-oscar/django-oscar
 .. _`travis-ci.org`: http://travis-ci.org/
@@ -130,8 +130,8 @@ The sandbox site can be set-up locally `in 5 commands`_.  Want to
 make changes?  Check out the `contributing guidelines`_.
 
 .. _`this gateway page`: http://latest.oscarcommerce.com/gateway/
-.. _`in 5 commands`: https://django-oscar.readthedocs.io/en/latest/internals/sandbox.html#running-the-sandbox-locally
-.. _`contributing guidelines`: https://django-oscar.readthedocs.io/en/latest/internals/contributing/index.html
+.. _`in 5 commands`: https://django-oscar.readthedocs.io/en/stable/internals/sandbox.html#running-the-sandbox-locally
+.. _`contributing guidelines`: https://django-oscar.readthedocs.io/en/stable/internals/contributing/index.html
 
 
 Extensions


### PR DESCRIPTION
Naive users can waste a lot of time trying to follow latest official documentation as it might only work for beta versions which are not install via pip install as per the instructions.

This is currently the case with v2.0b1 being latest and official installation steps do not work yet.