### PR TITLE
Restore voucher set URLs

### DIFF
--- a/src/oscar/apps/dashboard/vouchers/apps.py
+++ b/src/oscar/apps/dashboard/vouchers/apps.py
@@ -41,5 +41,16 @@ class VouchersDashboardConfig(OscarDashboardConfig):
                 name='voucher-delete'),
             url(r'^stats/(?P<pk>\d+)/$', self.stats_view.as_view(),
                 name='voucher-stats'),
+
+            url(r'^sets$', self.set_list_view.as_view(),
+                name='voucher-set-list'),
+            url(r'^sets/create/$', self.set_create_view.as_view(),
+                name='voucher-set-create'),
+            url(r'^sets/update/(?P<pk>\d+)/$', self.set_update_view.as_view(),
+                name='voucher-set-update'),
+            url(r'^sets/(?P<pk>\d+)/$', self.set_detail_view.as_view(),
+                name='voucher-set'),
+            url(r'^sets/(?P<pk>\d+)/download$', self.set_download_view.as_view(),
+                name='voucher-set-download'),
         ]
         return self.post_process_urls(urls)


### PR DESCRIPTION
As part of https://github.com/django-oscar/django-oscar/commit/fbf8bac4c5061657879f3f3baa1c1e7078cffb60, the Voucher set URLs disappeared.

The following exception is logged on every Dashboard page:
`Reverse for 'voucher-set-list' not found. 'voucher-set-list' is not a valid view function or pattern name.`