### PR TITLE
Remove collections ABC deprecation warning

### DIFF
--- a/src/oscar/views/decorators.py
+++ b/src/oscar/views/decorators.py
@@ -1,4 +1,4 @@
-import collections
+from collections.abc import Callable
 from functools import wraps
 
 from django.contrib.auth.decorators import user_passes_test
@@ -33,7 +33,7 @@ def check_permissions(user, permissions):
         attributes = [getattr(user, perm) for perm in conditions]
         # evaluates methods, explicitly casts properties to booleans
         passes_conditions = all([
-            attr() if isinstance(attr, collections.Callable) else bool(attr) for attr in attributes])
+            attr() if isinstance(attr, Callable) else bool(attr) for attr in attributes])
         return passes_conditions and user.has_perms(regular_permissions)
 
     if not permissions:


### PR DESCRIPTION
`DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working`