### PR TITLE
Update whitenoise to 4.1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ pysolr==3.7.0
 redis==3.3.4
 requests==2.22.0
 uWSGI==2.0.17.1
-whitenoise==4.1.2
+whitenoise==4.1.3
 
 # Linting
 flake8==3.6.0


### PR DESCRIPTION
For some reason pyup-bot has missed this one - and there's a security issue with 4.1.2