### PR TITLE
Version bump and release notes for 2.0.1

### DIFF
--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -11,6 +11,7 @@ Release notes for each version of Oscar published to PyPI.
     :maxdepth: 1
 
     v2.0
+    v2.0.1
 
 
 1.6 release branch

--- a/docs/source/releases/v2.0.1.rst
+++ b/docs/source/releases/v2.0.1.rst
@@ -1,0 +1,20 @@
+=======================
+Oscar 2.0.1 release notes
+=======================
+
+:release: 2019-08-09
+
+This is Oscar 2.0.1, a bugfix release.
+
+Bug fixes
+=========
+
+- Fixed ``oscar.dashboard.nav.default_access_fn`` to properly check permissions
+  configured on forked dashboard apps.
+- Refactored ``ProductQuerySet.base_queryset()`` to avoid making an expensive
+  database query when checking for product options. Queryset items are no
+  longer annotated with ``num_product_class_options`` and
+  ``num_product_options``(counts of the number of options associated with a
+  product and product class, respectively. Instead are annotated with
+  ``has_product_class_options`` and ``has_product_options``.
+- Fixed display of start and end dates in the dashboard offer list template.

--- a/docs/source/releases/v2.0.rst
+++ b/docs/source/releases/v2.0.rst
@@ -6,7 +6,7 @@
 Oscar 2.0 release notes
 =======================
 
-:release: 2019-04-04
+:release: 2019-07-04
 
 Welcome to Oscar 2.0. This is a significant release which includes a number of
 new features and backwards incompatible changes. In particular the way Oscar

--- a/src/oscar/__init__.py
+++ b/src/oscar/__init__.py
@@ -1,5 +1,5 @@
 # Use 'alpha', 'beta', 'rc' or 'final' as the 4th element to indicate release type.
-VERSION = (2, 0, 0, 'final')
+VERSION = (2, 0, 1, 'final')
 
 
 def get_short_version():


### PR DESCRIPTION
Also fixing the release date on the 2.0 release notes - July, not April.