### PR TITLE
Migrate deployed sandbox to heroku

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM python:3.5
 ENV PYTHONUNBUFFERED 1
 
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get install -y nodejs
 
 COPY ./requirements.txt /requirements.txt
-RUN pip3 install -r /requirements.txt raven==5.32.0
+RUN pip3 install -r /requirements.txt
 
 RUN groupadd -r django && useradd -r -g django django
 COPY . /app

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ Docs status:
 .. end-no-pypi
 
 .. _`Official homepage`: http://oscarcommerce.com
-.. _`Sandbox site`: http://latest.oscarcommerce.com
+.. _`Sandbox site`: https://latest.oscarcommerce.com
 .. _`Docker image`: https://hub.docker.com/r/oscarcommerce/django-oscar-sandbox/
 .. _`Documentation`: https://django-oscar.readthedocs.io/en/stable/
 .. _`readthedocs.org`: http://readthedocs.org
@@ -129,7 +129,7 @@ gateway page`_.
 The sandbox site can be set-up locally `in 5 commands`_.  Want to
 make changes?  Check out the `contributing guidelines`_.
 
-.. _`this gateway page`: http://latest.oscarcommerce.com/gateway/
+.. _`this gateway page`: https://latest.oscarcommerce.com/gateway/
 .. _`in 5 commands`: https://django-oscar.readthedocs.io/en/stable/internals/sandbox.html#running-the-sandbox-locally
 .. _`contributing guidelines`: https://django-oscar.readthedocs.io/en/stable/internals/contributing/index.html
 

--- a/app.json
+++ b/app.json
@@ -1,0 +1,22 @@
+{
+  "name": "django-oscar",
+  "description": "Django Oscar sandbox site",
+  "env": {
+    "ALLOWED_HOSTS": {
+      "required": true
+    },
+    "SECRET_KEY": {
+      "required": true
+    },
+    "SECURE_SSL_REDIRECT": {
+      "required": true
+    }
+  },
+  "formation": {
+    "web": {
+      "quantity": 1,
+      "size": "free"
+    }
+  },
+  "stack": "container"
+}

--- a/docs/source/internals/sandbox.rst
+++ b/docs/source/internals/sandbox.rst
@@ -35,8 +35,7 @@ The sandbox is, in effect, the blank canvas upon which you can build your site.
 Browse the external sandbox site
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-An instance of the sandbox site is built hourly from master branch and made
-available at http://latest.oscarcommerce.com
+An instance of the sandbox site is made available at https://latest.oscarcommerce.com
 
 .. warning::
 

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,5 @@
+build:
+  docker:
+    web: Dockerfile
+run:
+  web: uwsgi --ini uwsgi.ini --http 0:$PORT

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 Werkzeug==0.15.4
 django-debug-toolbar==2.0
 django-extensions==2.2.1
-psycopg2>=2.7,<2.8 --no-binary psycopg2
+psycopg2-binary>=2.8,<2.9
 
 # Sandbox
 Pillow==6.1.0

--- a/sandbox/README.rst
+++ b/sandbox/README.rst
@@ -4,7 +4,7 @@ Sandbox site
 
 This site is deployed there:
 
-http://latest.oscarcommerce.com
+https://latest.oscarcommerce.com
 -------------------------------
 
 This is a vanilla install of Oscar with as little customisation as possible to
@@ -17,4 +17,4 @@ It does have a few customisations:
 * A profile model with a few fields, designed to test Oscar's account section
   which should automatically allow the profile fields to be edited.
 
-It is deployed automatically to: http://latest.oscarcommerce.com
+It is deployed automatically to: https://latest.oscarcommerce.com

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -10,22 +10,10 @@ location = lambda x: os.path.join(
 
 DEBUG = env.bool('DEBUG', default=True)
 
-ALLOWED_HOSTS = [
-    'latest.oscarcommerce.com',
-    'master.oscarcommerce.com',
-    'localhost',
-    '127.0.0.1',
-]
+ALLOWED_HOSTS = env.list('ALLOWED_HOSTS', default=['localhost', '127.0.0.1'])
 
-# This is needed for the hosted version of the sandbox
-ADMINS = (
-    ('David Winterbottom', 'david.winterbottom@gmail.com'),
-    ('Michael van Tellingen', 'michaelvantellingen@gmail.com'),
-)
 EMAIL_SUBJECT_PREFIX = '[Oscar sandbox] '
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
-
-MANAGERS = ADMINS
 
 # Use a Sqlite database by default
 DATABASES = {
@@ -119,7 +107,7 @@ STATICFILES_FINDERS = (
 )
 
 # Make this unique, and don't share it with anybody.
-SECRET_KEY = '$)a7n&o80u!6y5t-+jrd3)3!%vh&shg$wqpjpxc!ar&p#!)n1a'
+SECRET_KEY = env.str('SECRET_KEY', default='UajFCuyjDKmWHe29neauXzHi9eZoRXr6RMbT5JyAdPiACBP6Cra2')
 
 TEMPLATES = [
     {
@@ -160,6 +148,7 @@ MIDDLEWARE = [
 
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
@@ -418,20 +407,6 @@ OSCAR_ORDER_STATUS_CASCADE = {
 # on-the-fly less processor.
 OSCAR_USE_LESS = False
 
-
-# Sentry
-# ======
-
-if env('SENTRY_DSN', default=None):
-    RAVEN_CONFIG = {'dsn': env('SENTRY_DSN', default=None)}
-    LOGGING['handlers']['sentry'] = {
-        'level': 'ERROR',
-        'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
-    }
-    LOGGING['root']['handlers'].append('sentry')
-    INSTALLED_APPS.append('raven.contrib.django.raven_compat')
-
-
 # Sorl
 # ====
 
@@ -448,6 +423,12 @@ THUMBNAIL_REDIS_URL = env('THUMBNAIL_REDIS_URL', default=None)
 # django/core/serializers/json.Serializer to have the `dumps` function. Also
 # in tests/config.py
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer'
+
+# Security
+SECURE_SSL_REDIRECT = env.bool('SECURE_SSL_REDIRECT', default=False)
+SECURE_HSTS_SECONDS = env.int('SECURE_HSTS_SECONDS', default=0)
+SECURE_CONTENT_TYPE_NOSNIFF = True
+SECURE_BROWSER_XSS_FILTER = True
 
 # Try and import local settings which can be used to override any of the above.
 try:

--- a/sandbox/uwsgi.ini
+++ b/sandbox/uwsgi.ini
@@ -6,12 +6,12 @@ http = :8080
 http-enable-proxy-protocol = 1
 http-auto-chunked = true
 http-keepalive = 75
-http-timeout = 75  
+http-timeout = 75
 
 log-x-forwarded-for = true
 
 # Handle docker stop
-die-on-term = 1  
+die-on-term = 1
 
 vacuum = 1
 master = true
@@ -30,12 +30,6 @@ harakiri = 30
 harakiri-verbose = true
 
 static-map = /media=./public/media/
-
-# Custom headers
-add-header = X-Content-Type-Options: nosniff
-add-header = X-XSS-Protection: 1; mode=block
-add-header = Strict-Transport-Security: max-age=16070400
-add-header = Connection: Keep-Alive
 
 ; if the client supports gzip encoding goto to the gzipper
 route-if = contains:${HTTP_ACCEPT_ENCODING};gzip goto:_gzip


### PR DESCRIPTION
The sandbox site currently deployed at https://latest.oscarcommerce.com/ is broken, and it seems nobody with the ability to manage/access it is around any more. 

I have set up a new sandbox on Heroku: https://oscar-sandbox.herokuapp.com/, using the configuration that this PR adds. 

Using Heroku for this will also give us the additional advantage of being able to use [review apps](https://devcenter.heroku.com/articles/github-integration-review-apps) for PRs - i.e., to automatically fire up an instance of the sandbox for any PR, to facilitate easy testing.

Because Heroku uses an ephemeral filesystem, any changes made on the deployed sandbox will be cleared periodically without any intervention required.

Fixes #3125.