### PR TITLE
Tweak travis config to avoid running redundant push builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,10 @@ matrix:
   allow_failures:
     - env: TOXENV=py36-djangomaster
 
+branches:
+  only:
+  - master
+  - /^releases.*$/
 
 env:
   global:


### PR DESCRIPTION
Currently, when we push to a branch on this repo, that triggers a `push` build on Travis. If we then make a PR from that branch, that triggers another `pr` build. There is not much benefit in running duplicate builds like this, especially given that we now require PRs to merge to master.

This tweaks the config so that `push` builds are only run on master and release branches.