### PR TITLE
Upgrade django-phonenumber-field for Django 2.2 support

### DIFF
--- a/docs/source/releases/v2.1.rst
+++ b/docs/source/releases/v2.1.rst
@@ -34,7 +34,7 @@ Removal of deprecated features
 Dependency changes
 ~~~~~~~~~~~~~~~~~~
 
-
+- Upgraded ``django-phonenumber-field`` to use the latest in the 3.x series.
 
 .. _deprecated_features_in_2.1:
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ install_requires = [
     'purl>=0.7',
     # For phone number field
     'phonenumbers',
-    'django-phonenumber-field>=2.0,<2.1',
+    'django-phonenumber-field>=3.0.0,<4.0.0',
     # Used for oscar.test.newfactories
     'factory-boy>=2.4.1,<3.0',
     # Used for automatically building larger HTML tables

--- a/src/oscar/test/factories/order.py
+++ b/src/oscar/test/factories/order.py
@@ -37,7 +37,7 @@ class ShippingAddressFactory(factory.DjangoModelFactory):
     line2 = '1a'
     line4 = 'City'
     postcode = '1000 AA'
-    phone_number = '06-12345678'
+    phone_number = '+12125555555'
 
     class Meta:
         model = get_model('order', 'ShippingAddress')


### PR DESCRIPTION
``django-phonenumber-field`` supports the same versions of Python and Django that django-oscar supports, so this should be a safe upgrade.
Fixed failing test due to invalid phone number in fixtures.
Fixes #3144