### PR TITLE
Perform only 1 query to determine if options exist.

### DIFF
--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -503,7 +503,7 @@ class AbstractProduct(models.Model):
         has_product_options = getattr(self, 'has_product_options', None)
         if has_product_class_options is not None and has_product_options is not None:
             return has_product_class_options or has_product_options
-        return self.get_product_class().options.exists() or self.product_options.exists()
+        return self.options.exists()
 
     @property
     def is_shipping_required(self):


### PR DESCRIPTION
The self.options property query performs only 1 query. The query in has_options performs 2 queries in the current worst case scenario because it first queries for product class options and next for product options. the options property retrives both in 1 query so it is cheaper to use that together with exists to determine if there are any options.