### PR TITLE
Replaced deprecated assertEquals with assertEqual

### DIFF
--- a/tests/integration/basket/test_views.py
+++ b/tests/integration/basket/test_views.py
@@ -103,7 +103,7 @@ class TestBasketSummaryView(TestCase):
         )
         request = RequestFactory().get(self.url, user=self.user)
         view = views.BasketView(request=request)
-        self.assertEquals(view.get_default_shipping_address(), user_address)
+        self.assertEqual(view.get_default_shipping_address(), user_address)
 
     def test_default_shipping_address_for_anonymous_user(self):
         request = RequestFactory().get(self.url)

--- a/tests/integration/catalogue/test_options.py
+++ b/tests/integration/catalogue/test_options.py
@@ -43,7 +43,7 @@ class ProductOptionTests(TestCase):
         self.test_product_has_options_per_product_class()
         self.test_product_has_options_per_product()
         self.assertTrue(self.product.has_options, "Options should be present")
-        self.assertEquals(
+        self.assertEqual(
             self.product.options.count(), 1,
             "options attribute should not contain duplicates"
         )
@@ -58,12 +58,12 @@ class ProductOptionTests(TestCase):
             "has_product_options should indicate the number of product options"
         )
         self.product_class.options.add(factories.OptionFactory(code="henk"))
-        self.assertEquals(
+        self.assertEqual(
             self.product.options.count(), 2,
             "New product_class options should be immediately visible"
         )
         self.product.product_options.add(factories.OptionFactory(code="klaas"))
-        self.assertEquals(
+        self.assertEqual(
             self.product.options.count(), 3,
             "New product options should be immediately visible"
         )

--- a/tests/integration/catalogue/test_product_image.py
+++ b/tests/integration/catalogue/test_product_image.py
@@ -53,18 +53,18 @@ class TestProductImages(ThumbnailMixin, TestCase):
         variant = factories.create_product(parent=parent)
         factories.create_product_image(product=variant, caption='Variant Image')
         all_images = variant.get_all_images()
-        self.assertEquals(all_images.count(), 1)
+        self.assertEqual(all_images.count(), 1)
         product_image = all_images.first()
-        self.assertEquals(product_image.caption, 'Variant Image')
+        self.assertEqual(product_image.caption, 'Variant Image')
 
     def test_variant_images_fallback_to_parent(self):
         parent = factories.ProductFactory(structure='parent')
         variant = factories.create_product(parent=parent)
         factories.create_product_image(product=parent, caption='Parent Product Image')
         all_images = variant.get_all_images()
-        self.assertEquals(all_images.count(), 1)
+        self.assertEqual(all_images.count(), 1)
         product_image = all_images.first()
-        self.assertEquals(product_image.caption, 'Parent Product Image')
+        self.assertEqual(product_image.caption, 'Parent Product Image')
 
 
 class TestMissingProductImage(StaticLiveServerTestCase):

--- a/tests/integration/offer/test_custom.py
+++ b/tests/integration/offer/test_custom.py
@@ -11,7 +11,7 @@ class TestCustomBenefit(TestCase):
             custom.create_benefit(CustomBenefitModel), custom.create_benefit(CustomBenefitWithoutName)]
 
     def test_name(self):
-        self.assertEquals(self.custom_benefits[0].name, 'Test benefit')
+        self.assertEqual(self.custom_benefits[0].name, 'Test benefit')
 
     def test_raises_assert_on_missing_name(self):
         with self.assertRaisesMessage(AssertionError, 'Name property is not defined on proxy class.'):
@@ -24,7 +24,7 @@ class TestCustomCondition(TestCase):
             custom.create_condition(CustomConditionModel), custom.create_condition(CustomConditionWithoutName)]
 
     def test_name(self):
-        self.assertEquals(self.custom_conditions[0].name, 'Test condition')
+        self.assertEqual(self.custom_conditions[0].name, 'Test condition')
 
     def test_raises_assert_on_missing_name(self):
         with self.assertRaisesMessage(AssertionError, 'Name property is not defined on proxy class.'):


### PR DESCRIPTION
Since `assertEquals` is deprecated. So I've replaced it with `assertEqual`