### PR TITLE
Use static instead of deprecated staticfiles in templates

### DIFF
--- a/src/oscar/templates/oscar/base.html
+++ b/src/oscar/templates/oscar/base.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 <!DOCTYPE html>
 <html lang="{{ LANGUAGE_CODE|default:"en-gb" }}" class="{% block html_class %}no-js{% endblock %}">
     <head>

--- a/src/oscar/templates/oscar/basket/partials/basket_quick.html
+++ b/src/oscar/templates/oscar/basket/partials/basket_quick.html
@@ -3,7 +3,6 @@
 {% load currency_filters %}
 {% load image_tags %}
 {% load i18n %}
-{% load staticfiles %}
 
 <ul class="basket-mini-item list-unstyled">
     {% if request.basket.num_lines %}

--- a/src/oscar/templates/oscar/catalogue/detail.html
+++ b/src/oscar/templates/oscar/catalogue/detail.html
@@ -3,7 +3,6 @@
 {% load history_tags %}
 {% load currency_filters %}
 {% load reviews_tags %}
-{% load staticfiles %}
 {% load product_tags %}
 {% load display_tags %}
 {% load i18n %}

--- a/src/oscar/templates/oscar/catalogue/partials/gallery.html
+++ b/src/oscar/templates/oscar/catalogue/partials/gallery.html
@@ -1,6 +1,5 @@
-{% load image_tags %}
 {% load i18n %}
-{% load staticfiles %}
+{% load image_tags %}
 
 {% with all_images=product.get_all_images %}
     {# use length rather then count as the images get queried anyways #}

--- a/src/oscar/templates/oscar/catalogue/partials/product.html
+++ b/src/oscar/templates/oscar/catalogue/partials/product.html
@@ -1,8 +1,7 @@
-{% load reviews_tags %}
-{% load image_tags %}
-{% load i18n %}
 {% load display_tags %}
-{% load staticfiles %}
+{% load i18n %}
+{% load image_tags %}
+{% load reviews_tags %}
 
 {% block product %}
     <article class="product_pod">

--- a/src/oscar/templates/oscar/catalogue/reviews/review_product.html
+++ b/src/oscar/templates/oscar/catalogue/reviews/review_product.html
@@ -1,5 +1,4 @@
 {% load image_tags %}
-{% load staticfiles %}
 
 <div class="row">
     <div class="col-sm-2">

--- a/src/oscar/templates/oscar/checkout/checkout.html
+++ b/src/oscar/templates/oscar/checkout/checkout.html
@@ -1,9 +1,8 @@
 {% extends "oscar/checkout/layout.html" %}
 {% load currency_filters %}
-{% load image_tags %}
 {% load i18n %}
+{% load image_tags %}
 {% load purchase_info_tags %}
-{% load staticfiles %}
 
 {% block title %}
     {% trans "Checkout" %} | {{ block.super }}

--- a/src/oscar/templates/oscar/checkout/thank_you.html
+++ b/src/oscar/templates/oscar/checkout/thank_you.html
@@ -1,8 +1,7 @@
 {% extends "oscar/checkout/layout.html" %}
 {% load currency_filters %}
-{% load image_tags %}
 {% load i18n %}
-{% load staticfiles %}
+{% load image_tags %}
 
 {% block title %}
     {% blocktrans with number=order.number %}

--- a/src/oscar/templates/oscar/customer/order/order_list.html
+++ b/src/oscar/templates/oscar/customer/order/order_list.html
@@ -1,7 +1,7 @@
 {% extends "oscar/customer/baseaccountpage.html" %}
-{% load i18n %}
 {% load currency_filters %}
-{% load staticfiles %}
+{% load i18n %}
+{% load static %}
 
 {% block styles %}
     {{ block.super }}

--- a/src/oscar/templates/oscar/dashboard/catalogue/product_list.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/product_list.html
@@ -1,8 +1,7 @@
 {% extends 'oscar/dashboard/layout.html' %}
 {% load i18n %}
-{% load staticfiles %}
-{% load sorting_tags %}
 {% load render_table from django_tables2 %}
+{% load sorting_tags %}
 
 {% block body_class %}{{ block.super }} catalogue{% endblock %}
 

--- a/src/oscar/templates/oscar/dashboard/catalogue/product_update.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/product_update.html
@@ -1,8 +1,6 @@
 {% extends 'oscar/dashboard/layout.html' %}
-{% load i18n %}
-{% load staticfiles %}
 {% load form_tags %}
-
+{% load i18n %}
 
 {% block body_class %}{{ block.super }} create-page catalogue{% endblock %}
 

--- a/src/oscar/templates/oscar/dashboard/layout.html
+++ b/src/oscar/templates/oscar/dashboard/layout.html
@@ -3,7 +3,7 @@
 {% load category_tags %}
 {% load dashboard_tags %}
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 
 {% block styles %}
     {% if use_less %}

--- a/src/oscar/templates/oscar/dashboard/offers/restrictions_form.html
+++ b/src/oscar/templates/oscar/dashboard/offers/restrictions_form.html
@@ -1,6 +1,5 @@
 {% extends 'oscar/dashboard/offers/step_form.html' %}
 {% load i18n %}
-{% load staticfiles %}
 
 {% block summary %}
     {% include 'oscar/dashboard/offers/summary.html' %}

--- a/src/oscar/templates/oscar/layout.html
+++ b/src/oscar/templates/oscar/layout.html
@@ -1,5 +1,5 @@
 {% extends "oscar/base.html" %}
-{% load staticfiles %}
+{% load static %}
 
 {% block styles %}
     {% comment %}

--- a/src/oscar/templates/oscar/offer/range.html
+++ b/src/oscar/templates/oscar/offer/range.html
@@ -1,9 +1,8 @@
 {% extends "oscar/layout.html" %}
 {% load basket_tags %}
 {% load category_tags %}
-{% load product_tags %}
 {% load i18n %}
-{% load staticfiles %}
+{% load product_tags %}
 
 {% block title %}
     {{ range.name }} | {{ block.super }}


### PR DESCRIPTION
`staticfiles` is deprecated and slated for removal in Django 3. In a bunch of places it wasn't being used at all.