### PR TITLE
Ignore expired vouchers because basket also ignores them.

### DIFF
--- a/src/oscar/apps/order/utils.py
+++ b/src/oscar/apps/order/utils.py
@@ -66,9 +66,12 @@ class OrderCreator(object):
                 self.update_stock_records(line)
 
             for voucher in basket.vouchers.select_for_update():
-                available_to_user, msg = voucher.is_available_to_user(user=user)
-                if not voucher.is_active() or not available_to_user:
-                    raise ValueError(msg)
+                if not voucher.is_active():  # basket ignores inactive vouchers
+                    basket.vouchers.remove(voucher)
+                else:
+                    available_to_user, msg = voucher.is_available_to_user(user=user)
+                    if not available_to_user:
+                        raise ValueError(msg)
 
             # Record any discounts associated with this order
             for application in basket.offer_applications:

--- a/tests/integration/order/test_creator.py
+++ b/tests/integration/order/test_creator.py
@@ -1,5 +1,6 @@
-import threading
+import datetime
 import time
+import threading
 from decimal import Decimal as D
 
 import pytest
@@ -7,6 +8,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.http import HttpRequest
 from django.test import TestCase, TransactionTestCase
 from django.test.utils import override_settings
+from django.utils import timezone
 
 from oscar.apps.catalogue.models import Product, ProductClass
 from oscar.apps.checkout import calculators
@@ -265,6 +267,19 @@ class TestPlaceOrderWithVoucher(TestCase):
         # Make sure the voucher usage is rechecked
         with pytest.raises(ValueError):
             place_order(creator, basket=basket, order_number='12347', user=user)
+
+    def test_expired_voucher(self):
+        user = AnonymousUser()
+        basket = factories.create_basket()
+        creator = OrderCreator()
+
+        voucher = factories.VoucherFactory(usage=Voucher.SINGLE_USE)
+        voucher.offers.add(factories.create_offer(offer_type='Voucher'))
+        basket.vouchers.add(voucher)
+        voucher.end_datetime = timezone.now() - datetime.timedelta(days=100)
+        voucher.save()
+        place_order(creator, basket=basket, order_number='12346', user=user)
+        assert voucher.applications.count() == 0
 
 
 class TestConcurrentOrderPlacement(TransactionTestCase):

--- a/tests/integration/order/test_creator.py
+++ b/tests/integration/order/test_creator.py
@@ -1,6 +1,6 @@
 import datetime
-import time
 import threading
+import time
 from decimal import Decimal as D
 
 import pytest


### PR DESCRIPTION
If not the order placement fails with an empty error message.

fixes #3216