### PR TITLE
Pass child to availability_policy instead of parent because it has all the data

### DIFF
--- a/docs/source/releases/v2.1.rst
+++ b/docs/source/releases/v2.1.rst
@@ -42,6 +42,9 @@ Minor changes
   an order (instead of raising an exception), for consistency with how
   the basket flows handle inactive vouchers.
 
+- Fixed the logic of ``StockRequired.parent_availability_policy`` to use
+  child products to determine availability of children, rather than the parent.
+
 
 Dependency changes
 ~~~~~~~~~~~~~~~~~~

--- a/src/oscar/apps/partner/strategy.py
+++ b/src/oscar/apps/partner/strategy.py
@@ -220,7 +220,7 @@ class StockRequired(object):
     def parent_availability_policy(self, product, children_stock):
         # A parent product is available if one of its children is
         for child, stockrecord in children_stock:
-            policy = self.availability_policy(product, stockrecord)
+            policy = self.availability_policy(child, stockrecord)
             if policy.is_available_to_buy:
                 return Available()
         return Unavailable()


### PR DESCRIPTION
This could be up for interpretation, but doesn't it make more sence to pass the child to availability_policy instead of the parent?