### PR TITLE
Restore custom datetimepicker CSS.

### DIFF
--- a/src/oscar/static_src/oscar/css/datetimepicker.css
+++ b/src/oscar/static_src/oscar/css/datetimepicker.css
@@ -1,0 +1,14 @@
+.datetimepicker .glyphicon {
+  font-family: FontAwesome;
+  font-weight: normal;
+  font-style: normal;
+  text-decoration: inherit;
+  -webkit-font-smoothing: antialiased;
+  *margin-right: .3em;
+}
+.datetimepicker .glyphicon.glyphicon-arrow-left:before {
+  content: "\f060";
+}
+.datetimepicker .glyphicon.glyphicon-arrow-right:before {
+  content: "\f061";
+}


### PR DESCRIPTION
This was wrongly deleted in #3236 - it doesn't come from the third party package but is Oscar's custom styling.