### PR TITLE
Fix unnecessary writing to disk of range CSV uploaded files.

### DIFF
--- a/docs/source/ref/settings.rst
+++ b/docs/source/ref/settings.rst
@@ -407,13 +407,6 @@ Default: ``image_not_found.jpg``
 Copy this image from ``oscar/static/img`` to your ``MEDIA_ROOT`` folder. It needs to
 be there so the thumbnailer can resize it.
 
-``OSCAR_UPLOAD_ROOT``
----------------------
-
-Default: ``/tmp``
-
-The folder is used to temporarily hold uploaded files until they are processed.
-Such files should always be deleted afterwards.
 
 ``OSCAR_THUMBNAILER``
 ---------------------

--- a/src/oscar/defaults.py
+++ b/src/oscar/defaults.py
@@ -32,7 +32,6 @@ OSCAR_DELETE_IMAGE_FILES = True
 # Copy this image from oscar/static/img to your MEDIA_ROOT folder.
 # It needs to be there so Sorl can resize it.
 OSCAR_MISSING_IMAGE_URL = 'image_not_found.jpg'
-OSCAR_UPLOAD_ROOT = '/tmp'
 
 # Address settings
 OSCAR_REQUIRED_ADDRESS_FIELDS = ('first_name', 'last_name', 'line1',

--- a/src/oscar/templates/oscar/dashboard/ranges/messages/range_products_saved.html
+++ b/src/oscar/templates/oscar/dashboard/ranges/messages/range_products_saved.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% blocktrans with range_name=range.name filename=upload.filename %}
+{% blocktrans with range_name=range.name filename=upload.filepath %}
     <p>File <strong>{{ filename }}</strong> processed.</p>
 {% endblocktrans %}
 

--- a/src/oscar/templates/oscar/dashboard/ranges/range_product_list.html
+++ b/src/oscar/templates/oscar/dashboard/ranges/range_product_list.html
@@ -65,7 +65,7 @@
                         <tbody>
                             {% for upload in uploads %}
                                 <tr>
-                                    <td>{{ upload.filename }}</td>
+                                    <td>{{ upload.filepath }}</td>
                                     <td>{{ upload.num_new_skus }}</td>
                                     <td>{{ upload.num_duplicate_skus }}</td>
                                     <td>{{ upload.num_unknown_skus }}</td>


### PR DESCRIPTION
I would propose to backport this same fix to 2.x, even though it is altering behaviour, as I don't think we should be writing this file to persistent storage at all. Proposed release notes:

> The file handling behaviour of uploaded CSV files for ranges (handled by
  `RangeProductListView`) has been modified to address a potential security
  risk when invalid files are uploaded, as these would previously be left on disk.
>
 > Uploaded files are no longer written to disk by Oscar, but processed directly.
  This means that `RangeProductFileUpload.filepath` no longer stores a
  reference to the stored path of an uploaded file, but only its file name for
  reporting purposes.
>
 > The `OSCAR_UPLOAD_ROOT` setting which was used exclusively by this feature has been
  removed.