### PR TITLE
Fixes offers failing on child products for ranges that include all products

### DIFF
--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -949,8 +949,8 @@ class AbstractRange(models.Model):
         Product = self.included_products.model
 
         if self.includes_all_products:
-            # Filter out child products and blacklisted products
-            return Product.objects.browsable().exclude(
+            # Filter out blacklisted products
+            return Product.objects.all().exclude(
                 id__in=self.excluded_products.values("id")
             )
 

--- a/tests/integration/offer/test_range.py
+++ b/tests/integration/offer/test_range.py
@@ -15,9 +15,9 @@ class TestWholeSiteRange(TestCase):
     def test_all_products_range(self):
         self.assertTrue(self.range.contains_product(self.prod))
 
-    def test_all_products_excludes_child_products(self):
+    def test_all_products_includes_child_products(self):
         child_product = create_product(structure='child', parent=self.prod)
-        self.assertTrue(child_product not in self.range.all_products())
+        self.assertTrue(child_product in self.range.all_products())
 
     def test_whitelisting(self):
         self.range.add_product(self.prod)


### PR DESCRIPTION
Leaving out child products from ranges causes offers to not work on child products.
Let's include them and make all products really mean all products.