### PR TITLE
Upgrade sphinx and use Python 3.7 to build docs on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
       env: TOXENV=lint
     - python: 3.5
       env: TOXENV=sandbox
-    - python: 3.6
+    - python: 3.7
       env: TOXENV=docs
   allow_failures:
     - env: TOXENV=py36-djangomaster

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ sorl_thumbnail_version = 'sorl-thumbnail>=12.4.1,<12.5'
 easy_thumbnails_version = 'easy-thumbnails==2.5'
 
 docs_requires = [
-    'Sphinx==2.0.1',
+    'Sphinx==2.2.2',
     'sphinxcontrib-napoleon==0.7',
     'sphinxcontrib-spelling==4.3.0',
     'sphinx_rtd_theme==0.4.3',

--- a/tox.ini
+++ b/tox.ini
@@ -47,9 +47,10 @@ commands =
     make build_sandbox
 
 [testenv:docs]
-basepython = python3.6
+basepython = python3.7
 whitelist_externals = make
 changedir = {toxinidir}/docs
+pip_pre = false
 deps =
     -r{toxinidir}/docs/requirements.txt
 commands =


### PR DESCRIPTION
I was attempting to fix the build error that is happening on master - turns out that is a different upstream issue (https://github.com/sphinx-doc/sphinx/issues/6887) which I've fixed for now by disabling installation of beta packages when building docs.