### PR TITLE
Use parent class get_users() method in PasswordResetForm.

### DIFF
--- a/docs/source/releases/v2.1.rst
+++ b/docs/source/releases/v2.1.rst
@@ -115,6 +115,16 @@ Minor changes
 - Fixed the logic of ``StockRequired.parent_availability_policy`` to use
   child products to determine availability of children, rather than the parent.
 
+- ``customer.forms.PasswordResetForm`` now uses the parent class' ``get_users()``
+  method to determine the list of users to send an email to. ``get_users()``
+  filters out users who do not currently have a usable password - which
+  did not happen previously.
+
+  This change was made in response to changes in Django to address
+  CVE-2019-19844. Oscar's ``PasswordResetForm`` was not vulnerable to the issue
+  in Django's form, but it was possible to send a password reset email to
+  unintended recipients because of unicode character collision.
+
 
 Dependency changes
 ~~~~~~~~~~~~~~~~~~

--- a/src/oscar/apps/customer/forms.py
+++ b/src/oscar/apps/customer/forms.py
@@ -46,10 +46,7 @@ class PasswordResetForm(auth_forms.PasswordResetForm):
         site = get_current_site(request)
         if domain_override is not None:
             site.domain = site.name = domain_override
-        email = self.cleaned_data['email']
-        active_users = User._default_manager.filter(
-            email__iexact=email, is_active=True)
-        for user in active_users:
+        for user in self.get_users(self.cleaned_data['email']):
             self.send_password_reset_email(site, user)
 
     def send_password_reset_email(self, site, user):

--- a/tests/unit/customer/test_forms.py
+++ b/tests/unit/customer/test_forms.py
@@ -1,9 +1,11 @@
 from unittest import mock
 
+from django.core import mail
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
-from oscar.apps.customer.forms import EmailUserCreationForm
+from oscar.apps.customer.forms import EmailUserCreationForm, PasswordResetForm
+from oscar.test.factories import UserFactory
 
 
 class TestEmailUserCreationForm(TestCase):
@@ -18,3 +20,17 @@ class TestEmailUserCreationForm(TestCase):
         mocked_validate.assert_called_once_with('terry', form.instance)
         self.assertEqual(mocked_validate.call_args[0][1].email, 'terry@boom.com')
         self.assertEqual(form.errors['password2'], ['That password is rubbish'])
+
+
+class TestPasswordResetForm(TestCase):
+
+    def test_user_email_unicode_collision(self):
+        # Regression test for CVE-2019-19844, which Oscar's PasswordResetForm
+        # was vulnerable to because it had overridden the save() method.
+        UserFactory(username='mike123', email='mike@example.org')
+        UserFactory(username='mike456', email='mıke@example.org')
+        form = PasswordResetForm({'email': 'mıke@example.org'})
+        self.assertTrue(form.is_valid())
+        form.save()
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, ['mıke@example.org'])


### PR DESCRIPTION
Refs CVE-2019-19844 (https://www.djangoproject.com/weblog/2019/dec/18/security-releases/). Oscar had overridden the `save()` method on `PasswordResetForm`, and was querying for users to send reset emails to in a manner that was not safe from unicode collisions.

This fixes the behaviour of the `save()` method to use the parent class' `get_users()` method, which applies the appropriate measures to avoid unicode collisions.

Oscar's handling of this form was more secure than Django, because it was sending the email to the address stored for the user in the database, rather than the address supplied in the form. As such, Oscar's password reset form has always been secure from the issue in CVE-2019-19844. 

The form handling did however allow for emails to be sent to unintended users (i.e., any user whose address collided with the one supplied in the form), which is what this patch fixes.