### PR TITLE
Use get_model instead of get_class for all model loading.

### DIFF
--- a/src/oscar/apps/analytics/receivers.py
+++ b/src/oscar/apps/analytics/receivers.py
@@ -8,11 +8,12 @@ from oscar.apps.basket.signals import basket_addition
 from oscar.apps.catalogue.signals import product_viewed
 from oscar.apps.order.signals import order_placed
 from oscar.apps.search.signals import user_search
-from oscar.core.loading import get_classes
+from oscar.core.loading import get_model
 
-UserSearch, UserRecord, ProductRecord, UserProductView = get_classes(
-    'analytics.models', ['UserSearch', 'UserRecord', 'ProductRecord',
-                         'UserProductView'])
+ProductRecord = get_model('analytics', 'ProductRecord')
+UserProductView = get_model('analytics', 'UserProductView')
+UserRecord = get_model('analytics', 'UserRecord')
+UserSearch = get_model('analytics', 'UserSearch')
 
 # Helpers
 

--- a/src/oscar/apps/partner/importers.py
+++ b/src/oscar/apps/partner/importers.py
@@ -5,14 +5,17 @@ from django.db.transaction import atomic
 from django.utils.translation import gettext_lazy as _
 
 from oscar.core.compat import UnicodeCSVReader
-from oscar.core.loading import get_class, get_classes
+from oscar.core.loading import get_class, get_model
 
 ImportingError = get_class('partner.exceptions', 'ImportingError')
-Partner, StockRecord = get_classes('partner.models', ['Partner',
-                                                      'StockRecord'])
-ProductClass, Product, Category, ProductCategory = get_classes(
-    'catalogue.models', ('ProductClass', 'Product', 'Category',
-                         'ProductCategory'))
+
+Category = get_model('catalogue', 'Category')
+Partner = get_model('partner', 'Partner')
+Product = get_model('catalogue', 'Product')
+ProductCategory = get_model('catalogue', 'ProductCategory')
+ProductClass = get_model('catalogue', 'ProductClass')
+StockRecord = get_model('partner', 'StockRecord')
+
 create_from_breadcrumbs = get_class('catalogue.categories', 'create_from_breadcrumbs')
 
 

--- a/src/oscar/apps/partner/receivers.py
+++ b/src/oscar/apps/partner/receivers.py
@@ -1,10 +1,10 @@
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from oscar.core.loading import get_classes
+from oscar.core.loading import get_model
 
-StockRecord, StockAlert = get_classes('partner.models', ['StockRecord',
-                                                         'StockAlert'])
+StockAlert = get_model('partner', 'StockAlert')
+StockRecord = get_model('partner', 'StockRecord')
 
 
 @receiver(post_save, sender=StockRecord)


### PR DESCRIPTION
The two are functionally equivalent, but we should be consistent.

Closes #3266.