### PR TITLE
Fix time-dependent tests.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ test_requires = [
     'pytest-django>=3.7,<3.8',
     'pytest-xdist>=1.31,<1.32',
     'tox>=3.14,<3.15',
+    'freezegun>=0.3,<0.4',
     sorl_thumbnail_version,
     easy_thumbnails_version,
 ]

--- a/tests/integration/payment/test_forms.py
+++ b/tests/integration/payment/test_forms.py
@@ -3,6 +3,7 @@ import datetime
 from django.core.exceptions import ImproperlyConfigured
 from django.forms import ValidationError
 from django.test import TestCase
+from freezegun import freeze_time
 
 from oscar.apps.payment import forms, models
 
@@ -45,6 +46,7 @@ class TestBankcardNumberField(TestCase):
             self.field.clean(None)
 
 
+@freeze_time('2016-01-01')      # BankcardStartingMonthField limits date to last 5 years
 class TestStartingMonthField(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Switch to using freezegun for tests that depend on date.