### PR TITLE
Update `Meta` of dashboard tables

### DIFF
--- a/src/oscar/apps/dashboard/tables.py
+++ b/src/oscar/apps/dashboard/tables.py
@@ -15,5 +15,5 @@ class DashboardTable(Table):
         return self.caption
 
     class Meta:
-        template = 'oscar/dashboard/table.html'
+        template_name = 'oscar/dashboard/table.html'
         attrs = {'class': 'table table-striped table-bordered'}

--- a/src/oscar/apps/dashboard/users/tables.py
+++ b/src/oscar/apps/dashboard/users/tables.py
@@ -25,4 +25,4 @@ class UserTable(DashboardTable):
     icon = "group"
 
     class Meta(DashboardTable.Meta):
-        template = 'oscar/dashboard/users/table.html'
+        template_name = 'oscar/dashboard/users/table.html'


### PR DESCRIPTION
`Table.Meta.template` is deprecated. `template_name` should be used instead.

Ref: https://github.com/jieter/django-tables2/blob/master/CHANGELOG.md#1180-2018-01-27