### PR TITLE
Add support for Django 3, drop support for Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,19 +11,19 @@ matrix:
   fast_finish: true
   include:
     - python: 3.5
-      env: TOXENV=py35-django111
-    - python: 3.6
-      env: TOXENV=py36-django111
-    - python: 3.7
-      env: TOXENV=py37-django111
-    - python: 3.5
       env: TOXENV=py35-django22
     - python: 3.6
       env: TOXENV=py36-django22
     - python: 3.7
       env: TOXENV=py37-django22
+    - python: 3.8
+      env: TOXENV=py38-django22
+    - python: 3.6
+      env: TOXENV=py36-django30
     - python: 3.7
-      env: TOXENV=py37-djangomaster
+      env: TOXENV=py37-django30
+    - python: 3.8
+      env: TOXENV=py38-django30
 
     - python: 3.7
       env: TOXENV=lint
@@ -31,8 +31,6 @@ matrix:
       env: TOXENV=sandbox
     - python: 3.7
       env: TOXENV=docs
-  allow_failures:
-    - env: TOXENV=py37-djangomaster
 
 branches:
   only:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ import os
 import sys
 
 import django
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.html import strip_tags
 
 from oscar import get_version, get_short_version
@@ -290,11 +290,11 @@ def process_docstring(app, what, name, obj, options, lines):
 
         for field in fields:
             # Decode and strip any html out of the field's help text
-            help_text = strip_tags(force_text(field.help_text))
+            help_text = strip_tags(force_str(field.help_text))
 
             # Decode and capitalize the verbose name, for use if there isn't
             # any help text
-            verbose_name = force_text(field.verbose_name).capitalize()
+            verbose_name = force_str(field.verbose_name).capitalize()
 
             if help_text:
                 # Add the model field to the end of the docstring as a param

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 # These requirements are only necessary when developing on Oscar.
 
 # development
-Werkzeug==0.16.1
-django-debug-toolbar==2.1
-django-extensions==2.2.6
+Werkzeug>=1.0,<1.1
+django-debug-toolbar>=2.2,<2.3
+django-extensions>=2.2,<2.3
 psycopg2-binary>=2.8,<2.9
 
 # Sandbox
@@ -26,7 +26,7 @@ isort==4.3.21
 # Helpers
 pyprof2calltree==1.4.4
 ipdb==0.12.3
-ipython==7.11.1
+ipython>=7.12,<7.13
 
 # Country data
-pycountry==19.8.18
+pycountry>=19.8,<19.9

--- a/setup.py
+++ b/setup.py
@@ -18,13 +18,13 @@ sys.path.append(os.path.join(PROJECT_DIR, 'src'))
 from oscar import get_version  # noqa isort:skip
 
 install_requires = [
-    'django>=1.11,<2.3',
+    'django>=2.2,<3.1',
     # PIL is required for image fields, Pillow is the "friendly" PIL fork
-    'pillow>=4.0',
+    'pillow>=6.0',
     # We use the ModelFormSetView from django-extra-views for the basket page
-    'django-extra-views>=0.11,<0.12',
+    'django-extra-views>=0.13,<0.14',
     # Search support
-    'django-haystack>=2.5.0,<3.0.0',
+    'django-haystack>=3.0b1',
     # Treebeard is used for categories
     'django-treebeard>=4.3.0',
     # Babel is used for currency formatting
@@ -37,14 +37,14 @@ install_requires = [
     # Used for oscar.test.newfactories
     'factory-boy>=2.4.1,<3.0',
     # Used for automatically building larger HTML tables
-    'django-tables2>=1.19,<2.0',
+    'django-tables2>=2.2,<2.3',
     # Used for manipulating form field attributes in templates (eg: add
     # a css class)
     'django-widget-tweaks>=1.4.1',
 ]
 
-sorl_thumbnail_version = 'sorl-thumbnail>=12.4.1,<12.5'
-easy_thumbnails_version = 'easy-thumbnails==2.5'
+sorl_thumbnail_version = 'sorl-thumbnail>=12.6,<12.7'
+easy_thumbnails_version = 'easy-thumbnails>=2.7,<2.8'
 
 docs_requires = [
     'Sphinx==2.2.2',
@@ -98,8 +98,8 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: Unix',

--- a/src/oscar/apps/basket/abstract_models.py
+++ b/src/oscar/apps/basket/abstract_models.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.db import models
 from django.db.models import Sum
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
 
@@ -875,7 +875,7 @@ class AbstractLine(models.Model):
 
     @property
     def description(self):
-        d = smart_text(self.product)
+        d = smart_str(self.product)
         ops = []
         for attribute in self.attributes.all():
             ops.append("%s = '%s'" % (attribute.option.name, attribute.value))

--- a/src/oscar/apps/basket/views.py
+++ b/src/oscar/apps/basket/views.py
@@ -5,7 +5,6 @@ from django.http import JsonResponse
 from django.shortcuts import redirect
 from django.template.loader import render_to_string
 from django.urls import reverse
-from django.utils.http import is_safe_url
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView, View
 from extra_views import ModelFormSetView
@@ -13,6 +12,7 @@ from extra_views import ModelFormSetView
 from oscar.apps.basket.signals import (
     basket_addition, voucher_addition, voucher_removal)
 from oscar.core import ajax
+from oscar.core.compat import url_has_allowed_host_and_scheme
 from oscar.core.loading import get_class, get_classes, get_model
 from oscar.core.utils import redirect_to_referrer, safe_referrer
 
@@ -302,7 +302,7 @@ class BasketAddView(FormView):
 
     def get_success_url(self):
         post_url = self.request.POST.get('next')
-        if post_url and is_safe_url(post_url, self.request.get_host()):
+        if post_url and url_has_allowed_host_and_scheme(post_url, self.request.get_host()):
             return post_url
         return safe_referrer(self.request, 'basket:summary')
 

--- a/src/oscar/apps/catalogue/views.py
+++ b/src/oscar/apps/catalogue/views.py
@@ -1,8 +1,9 @@
+from urllib.parse import quote
+
 from django.contrib import messages
 from django.core.paginator import InvalidPage
 from django.http import Http404, HttpResponsePermanentRedirect
 from django.shortcuts import get_object_or_404, redirect
-from django.utils.http import urlquote
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import DetailView, TemplateView
 
@@ -66,7 +67,7 @@ class ProductDetailView(DetailView):
 
         if self.enforce_paths:
             expected_path = product.get_absolute_url()
-            if expected_path != urlquote(current_path):
+            if expected_path != quote(current_path):
                 return HttpResponsePermanentRedirect(expected_path)
 
     def get_context_data(self, **kwargs):
@@ -188,7 +189,7 @@ class ProductCategoryView(TemplateView):
             # Categories are fetched by primary key to allow slug changes.
             # If the slug has changed, issue a redirect.
             expected_path = category.get_absolute_url()
-            if expected_path != urlquote(current_path):
+            if expected_path != quote(current_path):
                 return HttpResponsePermanentRedirect(expected_path)
 
     def get_search_handler(self, *args, **kwargs):

--- a/src/oscar/apps/checkout/views.py
+++ b/src/oscar/apps/checkout/views.py
@@ -1,11 +1,11 @@
 import logging
+from urllib.parse import quote
 
 from django import http
 from django.contrib import messages
 from django.contrib.auth import login
 from django.shortcuts import redirect
 from django.urls import reverse, reverse_lazy
-from django.utils.http import urlquote
 from django.utils.translation import gettext as _
 from django.views import generic
 
@@ -84,7 +84,7 @@ class IndexView(CheckoutSessionMixin, generic.FormView):
                 self.success_url = "%s?next=%s&email=%s" % (
                     reverse('customer:register'),
                     reverse('checkout:shipping-address'),
-                    urlquote(email)
+                    quote(email)
                 )
         else:
             user = form.get_user()

--- a/src/oscar/apps/communication/notifications/views.py
+++ b/src/oscar/apps/communication/notifications/views.py
@@ -3,7 +3,7 @@ from django.contrib import messages
 from django.utils.html import strip_tags
 from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
-from django.utils.translation import ungettext
+from django.utils.translation import ngettext
 from django.views import generic
 
 from oscar.core.loading import get_class, get_model
@@ -86,7 +86,7 @@ class UpdateView(BulkEditMixin, generic.RedirectView):
     def archive(self, request, notifications):
         for notification in notifications:
             notification.archive()
-        msg = ungettext(
+        msg = ngettext(
             '%(count)d notification archived',
             '%(count)d notifications archived', len(notifications)) \
             % {'count': len(notifications)}
@@ -96,7 +96,7 @@ class UpdateView(BulkEditMixin, generic.RedirectView):
     def delete(self, request, notifications):
         for notification in notifications:
             notification.delete()
-        msg = ungettext(
+        msg = ngettext(
             '%(count)d notification deleted',
             '%(count)d notifications deleted', len(notifications)) \
             % {'count': len(notifications)}

--- a/src/oscar/apps/customer/forms.py
+++ b/src/oscar/apps/customer/forms.py
@@ -8,12 +8,12 @@ from django.contrib.auth.password_validation import validate_password
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import ValidationError
 from django.utils.crypto import get_random_string
-from django.utils.http import is_safe_url
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import pgettext_lazy
 
 from oscar.apps.customer.utils import get_password_reset_url, normalise_email
-from oscar.core.compat import existing_user_fields, get_user_model
+from oscar.core.compat import (
+    existing_user_fields, get_user_model, url_has_allowed_host_and_scheme)
 from oscar.core.loading import get_class, get_model, get_profile_class
 from oscar.forms import widgets
 
@@ -74,7 +74,7 @@ class EmailAuthenticationForm(AuthenticationForm):
 
     def clean_redirect_url(self):
         url = self.cleaned_data['redirect_url'].strip()
-        if url and is_safe_url(url, self.host):
+        if url and url_has_allowed_host_and_scheme(url, self.host):
             return url
 
 
@@ -147,7 +147,7 @@ class EmailUserCreationForm(forms.ModelForm):
 
     def clean_redirect_url(self):
         url = self.cleaned_data['redirect_url'].strip()
-        if url and is_safe_url(url, self.host):
+        if url and url_has_allowed_host_and_scheme(url, self.host):
             return url
         return settings.LOGIN_REDIRECT_URL
 

--- a/src/oscar/apps/dashboard/catalogue/tables.py
+++ b/src/oscar/apps/dashboard/catalogue/tables.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
-from django.utils.translation import ungettext_lazy
+from django.utils.translation import ngettext_lazy
 from django_tables2 import A, Column, LinkColumn, TemplateColumn
 
 from oscar.core.loading import get_class, get_model
@@ -67,7 +67,7 @@ class CategoryTable(DashboardTable):
         orderable=False)
 
     icon = "sitemap"
-    caption = ungettext_lazy("%s Category", "%s Categories")
+    caption = ngettext_lazy("%s Category", "%s Categories")
 
     class Meta(DashboardTable.Meta):
         model = Category
@@ -89,7 +89,7 @@ class AttributeOptionGroupTable(DashboardTable):
         orderable=False)
 
     icon = "sitemap"
-    caption = ungettext_lazy("%s Attribute Option Group", "%s Attribute Option Groups")
+    caption = ngettext_lazy("%s Attribute Option Group", "%s Attribute Option Groups")
 
     class Meta(DashboardTable.Meta):
         model = AttributeOptionGroup
@@ -109,7 +109,7 @@ class OptionTable(DashboardTable):
         orderable=False)
 
     icon = "reorder"
-    caption = ungettext_lazy("%s Option", "%s Options")
+    caption = ngettext_lazy("%s Option", "%s Options")
 
     class Meta(DashboardTable.Meta):
         model = Option

--- a/src/oscar/apps/dashboard/ranges/views.py
+++ b/src/oscar/apps/dashboard/ranges/views.py
@@ -9,7 +9,7 @@ from django.shortcuts import HttpResponse, get_object_or_404
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
-from django.utils.translation import ungettext
+from django.utils.translation import ngettext
 from django.views.generic import (
     CreateView, DeleteView, ListView, UpdateView, View)
 
@@ -128,9 +128,10 @@ class RangeProductListView(BulkEditMixin, ListView):
         for product in products:
             range.remove_product(product)
         num_products = len(products)
-        messages.success(request, ungettext("Removed %d product from range",
-                                            "Removed %d products from range",
-                                            num_products) % num_products)
+        messages.success(
+            request,
+            ngettext("Removed %d product from range", "Removed %d products from range", num_products) % num_products
+        )
         return HttpResponseRedirect(self.get_success_url(request))
 
     def add_products(self, request):
@@ -154,9 +155,10 @@ class RangeProductListView(BulkEditMixin, ListView):
             range.add_product(product)
 
         num_products = len(products)
-        messages.success(request, ungettext("%d product added to range",
-                                            "%d products added to range",
-                                            num_products) % num_products)
+        messages.success(
+            request,
+            ngettext("%d product added to range", "%d products added to range", num_products) % num_products
+        )
         dupe_skus = form.get_duplicate_skus()
         if dupe_skus:
             messages.warning(

--- a/src/oscar/apps/dashboard/tables.py
+++ b/src/oscar/apps/dashboard/tables.py
@@ -1,9 +1,9 @@
-from django.utils.translation import ungettext_lazy
+from django.utils.translation import ngettext_lazy
 from django_tables2 import Table
 
 
 class DashboardTable(Table):
-    caption = ungettext_lazy('%d Row', '%d Rows')
+    caption = ngettext_lazy('%d Row', '%d Rows')
 
     def get_caption_display(self):
         # Allow overriding the caption with an arbitrary string that we cannot

--- a/src/oscar/apps/dashboard/users/tables.py
+++ b/src/oscar/apps/dashboard/users/tables.py
@@ -17,7 +17,7 @@ class UserTable(DashboardTable):
     active = Column(accessor='is_active')
     staff = Column(accessor='is_staff')
     date_registered = Column(accessor='date_joined')
-    num_orders = Column(accessor='orders.count', orderable=False, verbose_name=_('Number of Orders'))
+    num_orders = Column(accessor='orders__count', orderable=False, verbose_name=_('Number of Orders'))
     actions = TemplateColumn(
         template_name='oscar/dashboard/users/user_row_actions.html',
         verbose_name=' ')

--- a/src/oscar/apps/dashboard/users/views.py
+++ b/src/oscar/apps/dashboard/users/views.py
@@ -25,7 +25,6 @@ User = get_user_model()
 
 class IndexView(BulkEditMixin, FormMixin, SingleTableView):
     template_name = 'oscar/dashboard/users/index.html'
-    table_pagination = True
     model = User
     actions = ('make_active', 'make_inactive', )
     form_class = UserSearchForm
@@ -38,6 +37,9 @@ class IndexView(BulkEditMixin, FormMixin, SingleTableView):
         form_class = self.get_form_class()
         self.form = self.get_form(form_class)
         return super().dispatch(request, *args, **kwargs)
+
+    def get_table_pagination(self, table):
+        return dict(per_page=settings.OSCAR_DASHBOARD_ITEMS_PER_PAGE)
 
     def get_form_kwargs(self):
         """

--- a/src/oscar/apps/offer/conditions.py
+++ b/src/oscar/apps/offer/conditions.py
@@ -2,7 +2,7 @@ from decimal import ROUND_UP
 from decimal import Decimal as D
 
 from django.utils.translation import gettext_lazy as _
-from django.utils.translation import ungettext
+from django.utils.translation import ngettext
 
 from oscar.core.loading import get_classes, get_model
 from oscar.templatetags.currency_filters import currency
@@ -70,8 +70,8 @@ class CountCondition(Condition):
     def get_upsell_message(self, offer, basket):
         num_matches = self._get_num_matches(basket, offer)
         delta = self.value - num_matches
-        return ungettext('Buy %(delta)d more product from %(range)s',
-                         'Buy %(delta)d more products from %(range)s', delta) \
+        return ngettext('Buy %(delta)d more product from %(range)s',
+                        'Buy %(delta)d more products from %(range)s', delta) \
             % {'delta': delta, 'range': self.range}
 
     def consume_items(self, offer, basket, affected_lines):
@@ -158,8 +158,8 @@ class CoverageCondition(Condition):
 
     def get_upsell_message(self, offer, basket):
         delta = self.value - self._get_num_covered_products(basket, offer)
-        return ungettext('Buy %(delta)d more product from %(range)s',
-                         'Buy %(delta)d more products from %(range)s', delta) \
+        return ngettext('Buy %(delta)d more product from %(range)s',
+                        'Buy %(delta)d more products from %(range)s', delta) \
             % {'delta': delta, 'range': self.range}
 
     def is_partially_satisfied(self, offer, basket):

--- a/src/oscar/core/application.py
+++ b/src/oscar/core/application.py
@@ -1,15 +1,8 @@
 from django.apps import AppConfig
 from django.core.exceptions import ImproperlyConfigured
-from django.urls import reverse_lazy
+from django.urls import URLPattern, reverse_lazy
 
 from oscar.core.loading import feature_hidden
-
-try:
-    # Django 2
-    from django.urls import URLPattern
-except ImportError:
-    # Django 1.11
-    from django.urls.resolvers import RegexURLPattern as URLPattern
 
 
 class OscarConfigMixin(object):

--- a/src/oscar/core/compat.py
+++ b/src/oscar/core/compat.py
@@ -17,6 +17,14 @@ except ValueError:
                                " 'app_label.model_name'")
 
 
+# Backward-compatible import for url_has_allowed_host_and_scheme.
+try:
+    # Django 3.0 and above
+    from django.utils.http import url_has_allowed_host_and_scheme       # noqa F401
+except ImportError:
+    from django.utils.http import is_safe_url as url_has_allowed_host_and_scheme    # noqa F401
+
+
 def get_user_model():
     """
     Return the User model. Doesn't require the app cache to be fully

--- a/src/oscar/core/loading.py
+++ b/src/oscar/core/loading.py
@@ -1,13 +1,13 @@
 import sys
 import traceback
 import warnings
+from functools import lru_cache
 from importlib import import_module
 
 from django.apps import apps
 from django.apps.config import MODELS_MODULE_NAME
 from django.conf import settings
 from django.core.exceptions import AppRegistryNotReady
-from django.utils.lru_cache import lru_cache
 from django.utils.module_loading import import_string
 
 from oscar.core.exceptions import (

--- a/src/oscar/core/utils.py
+++ b/src/oscar/core/utils.py
@@ -8,11 +8,12 @@ from babel.dates import format_timedelta as format_td
 from django.conf import settings
 from django.shortcuts import redirect, resolve_url
 from django.template.defaultfilters import date as date_filter
-from django.utils.http import is_safe_url
 from django.utils.module_loading import import_string
 from django.utils.text import slugify as django_slugify
 from django.utils.timezone import get_current_timezone, is_naive, make_aware
 from django.utils.translation import get_language, to_locale
+
+from oscar.core.compat import url_has_allowed_host_and_scheme
 
 SLUGIFY_RE = re.compile(r'[^\w\s-]', re.UNICODE)
 
@@ -140,7 +141,7 @@ def safe_referrer(request, default):
     or a regular URL
     """
     referrer = request.META.get('HTTP_REFERER')
-    if referrer and is_safe_url(referrer, request.get_host()):
+    if referrer and url_has_allowed_host_and_scheme(referrer, request.get_host()):
         return referrer
     if default:
         # Try to resolve. Can take a model instance, Django URL name or URL.

--- a/src/oscar/forms/widgets.py
+++ b/src/oscar/forms/widgets.py
@@ -5,7 +5,7 @@ from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.forms.models import ModelChoiceIterator
 from django.forms.widgets import FileInput
 from django.utils import formats
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 
 class ImageInput(FileInput):
@@ -208,12 +208,12 @@ class AdvancedSelect(forms.Select):
     """
 
     def __init__(self, attrs=None, choices=(), disabled_values=()):
-        self.disabled_values = set(force_text(v) for v in disabled_values)
+        self.disabled_values = set(force_str(v) for v in disabled_values)
         super().__init__(attrs, choices)
 
     def create_option(self, name, value, label, selected, index, subindex=None, attrs=None):
         option = super().create_option(name, value, label, selected, index, subindex, attrs)
-        if force_text(value) in self.disabled_values:
+        if force_str(value) in self.disabled_values:
             option['attrs']['disabled'] = True
         return option
 
@@ -254,7 +254,7 @@ class RemoteSelect(forms.Select):
         default = (None, [], 0)
         groups = [default]
         has_selected = False
-        selected_choices = {force_text(v) for v in value}
+        selected_choices = {force_str(v) for v in value}
         if not self.is_required and not self.allow_multiple_selected:
             default[1].append(self.create_option(name, '', '', False, 0))
 
@@ -266,7 +266,7 @@ class RemoteSelect(forms.Select):
             c for c in selected_choices if c not in self.choices.field.empty_values
         }
         choices = (
-            (obj.pk, force_text(obj))
+            (obj.pk, force_str(obj))
             for obj in self.choices.queryset.filter(pk__in=selected_choices)
         )
         for option_value, option_label in choices:

--- a/src/oscar/models/fields/autoslugfield.py
+++ b/src/oscar/models/fields/autoslugfield.py
@@ -27,15 +27,11 @@ THE SOFTWARE.
 import re
 
 from django.conf import settings
+from django.utils.encoding import force_str
 
 from oscar.core.utils import slugify
 
 from .slugfield import SlugField
-
-try:
-    from django.utils.encoding import force_unicode  # NOQA
-except ImportError:
-    from django.utils.encoding import force_text as force_unicode  # NOQA
 
 
 class AutoSlugField(SlugField):
@@ -169,7 +165,7 @@ class AutoSlugField(SlugField):
         return slug
 
     def pre_save(self, model_instance, add):
-        value = force_unicode(self.create_slug(model_instance, add))
+        value = force_str(self.create_slug(model_instance, add))
         setattr(model_instance, self.attname, value)
         return value
 

--- a/src/oscar/templatetags/image_tags.py
+++ b/src/oscar/templatetags/image_tags.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from django.db.models.fields.files import ImageFieldFile
 from django.utils.encoding import smart_str
 from django.utils.html import escape
-from django.utils.six import text_type
 
 from oscar.core.thumbnails import get_thumbnailer
 
@@ -120,7 +119,7 @@ class ThumbnailNode(template.Node):
         source = self.source_var.resolve(context)
         options = self.get_thumbnail_options(context)
         for key, expr in self.options:
-            value = self.no_resolve.get(text_type(expr), expr.resolve(context))
+            value = self.no_resolve.get(str(expr), expr.resolve(context))
             options[key] = value
 
         thumbnailer = get_thumbnailer()

--- a/tests/functional/checkout/test_guest_checkout.py
+++ b/tests/functional/checkout/test_guest_checkout.py
@@ -1,12 +1,13 @@
 import sys
 from http import client as http_client
+from imp import reload
 from importlib import import_module
 from unittest import mock
+from urllib.parse import quote
 
 from django.conf import settings
 from django.test.utils import override_settings
 from django.urls import clear_url_caches, reverse
-from django.utils.http import urlquote
 
 from oscar.apps.shipping import methods
 from oscar.core.compat import get_user_model
@@ -26,12 +27,6 @@ UnableToPlaceOrder = get_class('order.exceptions', 'UnableToPlaceOrder')
 Basket = get_model('basket', 'Basket')
 Order = get_model('order', 'Order')
 User = get_user_model()
-
-# Python 3 compat
-try:
-    from imp import reload
-except ImportError:
-    pass
 
 
 def reload_url_conf():
@@ -77,7 +72,7 @@ class TestIndexView(CheckoutMixin, WebTestCase):
         expected_url = '{register_url}?next={forward}&email={email}'.format(
             register_url=reverse('customer:register'),
             forward='/checkout/shipping-address/',
-            email=urlquote(new_user_email))
+            email=quote(new_user_email))
         self.assertRedirects(response, expected_url)
 
     def test_redirects_existing_customers_to_shipping_address_page(self):

--- a/tests/integration/core/test_compat.py
+++ b/tests/integration/core/test_compat.py
@@ -6,7 +6,7 @@ import os
 from tempfile import NamedTemporaryFile
 
 from django.test import TestCase, override_settings
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 
 from oscar.core.compat import UnicodeCSVWriter, existing_user_fields
 
@@ -51,7 +51,7 @@ class TestUnicodeCSVWriter(TestCase):
             writer.writerows([row])
 
         with open(tmp_file.name, 'r') as read_file:
-            content = smart_text(read_file.read(), encoding='utf-8').strip()
+            content = smart_str(read_file.read(), encoding='utf-8').strip()
             self.assertEqual(content, 'ünįcodē,123,foo-bar')
 
         # Clean up

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    py{35,36,37}-django{111,22}
-    py36-djangomaster
+    py{35,36,37,38}-django{22,30}
     lint
     sandbox
     docs
@@ -12,15 +11,8 @@ commands = coverage run --parallel -m pytest {posargs}
 extras = test
 pip_pre = true
 deps =
-    django111: django>=1.11,<2
     django22: django>=2.2,<2.3
-
-
-[testenv:py36-djangomaster]
-commands =
-    # Can't specify this in deps - see https://github.com/tox-dev/tox/issues/513
-    pip install https://github.com/django/django/archive/master.tar.gz#egg=django
-    pytest {posargs}
+    django30: django>=3.0,<3.1
 
 
 [testenv:lint]


### PR DESCRIPTION
Add support for Django 3 and drop support for Django 1.11 which reaches end of life in April.

~This is currently blocked by https://github.com/django-haystack/django-haystack/pull/1689 which has been merged but is awaiting a release on PyPi.~