### PR TITLE
Fix Integrity error when deleting and creating a voucher with same name

### DIFF
--- a/docs/source/releases/v2.1.rst
+++ b/docs/source/releases/v2.1.rst
@@ -162,6 +162,9 @@ Minor changes
 - ``catalogue.Product.is_public`` is now an indexed field. This change requires
   a database migration.
 
+- When a voucher that was created through the Oscar dashboard is deleted, the
+  auto-generated offer that was created with the voucher is also deleted.
+
 Dependency changes
 ~~~~~~~~~~~~~~~~~~
 

--- a/src/oscar/apps/dashboard/vouchers/views.py
+++ b/src/oscar/apps/dashboard/vouchers/views.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from django.views import generic
 
+from oscar.apps.voucher.utils import get_offer_name
 from oscar.core.loading import get_class, get_model
 from oscar.core.utils import slugify
 from oscar.views import sort_queryset
@@ -113,7 +114,7 @@ class VoucherCreateView(generic.FormView):
         )
         name = form.cleaned_data['name']
         offer = ConditionalOffer.objects.create(
-            name=_("Offer for voucher '%s'") % name,
+            name=get_offer_name(name),
             offer_type=ConditionalOffer.VOUCHER,
             benefit=benefit,
             condition=condition,
@@ -199,6 +200,7 @@ class VoucherUpdateView(generic.FormView):
         offer.condition.save()
 
         offer.exclusive = form.cleaned_data['exclusive']
+        offer.name = get_offer_name(voucher.name)
         offer.save()
 
         benefit = voucher.benefit
@@ -253,7 +255,7 @@ class VoucherSetCreateView(generic.CreateView):
         )
         name = form.cleaned_data['name']
         offer = ConditionalOffer.objects.create(
-            name=_("Offer for voucher '%s'") % name,
+            name=get_offer_name(name),
             offer_type=ConditionalOffer.VOUCHER,
             benefit=benefit,
             condition=condition,
@@ -322,7 +324,7 @@ class VoucherSetUpdateView(generic.UpdateView):
             )
             name = form.cleaned_data['name']
             offer, __ = ConditionalOffer.objects.update_or_create(
-                name=_("Offer for voucher '%s'") % name,
+                name=get_offer_name(name),
                 defaults=dict(
                     offer_type=ConditionalOffer.VOUCHER,
                     benefit=benefit,

--- a/src/oscar/apps/voucher/apps.py
+++ b/src/oscar/apps/voucher/apps.py
@@ -10,3 +10,4 @@ class VoucherConfig(OscarConfig):
 
     def ready(self):
         from . import receivers  # noqa
+        from . import signals  # noqa

--- a/src/oscar/apps/voucher/signals.py
+++ b/src/oscar/apps/voucher/signals.py
@@ -1,0 +1,25 @@
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
+
+from oscar.apps.voucher.utils import get_offer_name
+from oscar.core.loading import get_model
+
+Voucher = get_model('voucher', 'Voucher')
+ConditionalOffer = get_model('offer', 'ConditionalOffer')
+
+
+@receiver(post_delete, sender=Voucher)
+def delete_unused_related_conditional_offer(instance, **kwargs):
+    voucher = instance  # the object is no longer in the database
+
+    try:
+        conditional_offer = ConditionalOffer.objects.get(
+            name=get_offer_name(voucher.name),
+            offer_type=ConditionalOffer.VOUCHER
+        )
+    except (ConditionalOffer.DoesNotExist, ConditionalOffer.MultipleObjectsReturned):
+        pass
+    else:
+        # Only delete if not used by other vouchers
+        if not conditional_offer.vouchers.exists():
+            conditional_offer.delete()

--- a/src/oscar/apps/voucher/utils.py
+++ b/src/oscar/apps/voucher/utils.py
@@ -2,6 +2,7 @@ from itertools import zip_longest
 
 from django.db import connection
 from django.utils.crypto import get_random_string
+from django.utils.translation import gettext_lazy as _
 
 
 def generate_code(length, chars='ABCDEFGHJKLMNPQRSTUVWXYZ23456789',
@@ -33,3 +34,11 @@ def get_unused_code(length=12, group_length=4, separator='-'):
             "SELECT 1 FROM voucher_voucher WHERE code=%s", [code])
         if not cursor.fetchall():
             return code
+
+
+def get_offer_name(voucher_name):
+    """
+    Return the name used for the auto-generated offer created
+    when a voucher is created through the dashboard.
+    """
+    return _("Offer for voucher '%s'") % voucher_name


### PR DESCRIPTION
Fixes #3279

Deleting a voucher didn't delete the referenced offers so when deleting a voucher and
creating a new one with the same name, there was a unique name error because the name of an offer is "Offer for voucher [voucher name]". This fix deletes all referenced offers when
deleting a voucher.