### PR TITLE
Only try to serialize PhoneNumber instances

### DIFF
--- a/src/oscar/apps/checkout/utils.py
+++ b/src/oscar/apps/checkout/utils.py
@@ -1,3 +1,6 @@
+from phonenumber_field.phonenumber import PhoneNumber
+
+
 class CheckoutSessionData(object):
     """
     Responsible for marshalling all the checkout session data
@@ -167,7 +170,7 @@ class CheckoutSessionData(object):
         """
         self._unset('billing', 'new_address_fields')
         phone_number = address_fields.get('phone_number')
-        if phone_number:
+        if phone_number and isinstance(phone_number, PhoneNumber):
             # Phone number is stored as a PhoneNumber instance. As we store
             # strings in the session, we need to serialize it.
             address_fields = address_fields.copy()


### PR DESCRIPTION
Dear team, I stumbled upon a small issue in my project, and am proposing a fix below.

AbstractBillingAddress has no `phone_number` field. For reasons I'm not sure about, Oscar has code dealing with it's existence. I suppose because it's common to add the field? The existing code assumed that a `PhoneNumberField` model field would be added, which might not always be the case.
I stumbled upon this in a project of mine where `phone_number` was a CharField (for reasons...). That would break with an `AttributeError`. The fix is easy enough, we check if we're indeed dealing with a `PhoneNumber` instance before calling `as_international` on it.

Note that this fix does not need to be applied to shipping addresses, because there we actually define a `PhoneNumberField`, so our assumptions hold.
