### PR TITLE
Use ci instead of install for tox lint environment.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     flake8
     isort
 commands =
-    npm install
+    npm ci
     flake8 src tests setup.py
     isort -c -q --recursive --diff src/ tests/
     npm run eslint


### PR DESCRIPTION
Use [npm ci](https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable) instead of `npm install` for building the tox environment for linting. This is, as the link explains, much more reliable and faster, and the correct way to run on Travis.