### PR TITLE
Fix the brand_title block in brand.html so as not to span unclosed HTML tags

### DIFF
--- a/docs/source/releases/v2.1.rst
+++ b/docs/source/releases/v2.1.rst
@@ -170,6 +170,8 @@ Minor changes
 - When a voucher that was created through the Oscar dashboard is deleted, the
   auto-generated offer that was created with the voucher is also deleted.
 
+- Fixed the ``brand_title`` block in ``partials/brand.html`` so that it doesn't span unclosed HTML tags.
+
 Dependency changes
 ~~~~~~~~~~~~~~~~~~
 

--- a/src/oscar/templates/oscar/partials/brand.html
+++ b/src/oscar/templates/oscar/partials/brand.html
@@ -1,1 +1,3 @@
-<div class="col-sm-7 h1"><a href="{{ homepage_url }}">{% block brand_title %}{{ shop_name }}</a><small> {{ shop_tagline }}</small>{% endblock %}</div>
+<div class="col-sm-7 h1">
+    <a href="{{ homepage_url }}">{% block brand_title %}{{ shop_name }}{% endblock %}</a><small> {{ shop_tagline }}</small>
+</div>


### PR DESCRIPTION
Fixes #3354. 

(Clearly nobody uses that block because this has been unchanged for over 8 years!).