### PR TITLE
Delete both valid and invalid basket lines marked for deletion

### DIFF
--- a/docs/source/releases/v2.1.rst
+++ b/docs/source/releases/v2.1.rst
@@ -120,6 +120,10 @@ Bug fixes
   in a discount being applied for all items in the basket rather than the
   cheapest one.
 
+- Fixed a bug where a line could not be deleted from the basket, if the basket
+  had another line with a validation error - i.e. its product was out of stock
+  (see :issue:`2791` and :issue:`1654`).
+
 Removal of deprecated features
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/functional/test_basket.py
+++ b/tests/functional/test_basket.py
@@ -318,6 +318,7 @@ class BasketFormSetTests(WebTestCase):
         management_form = formset.management_form
         data = {
             formset.add_prefix('INITIAL_FORMS'): management_form.initial['INITIAL_FORMS'],
+            formset.add_prefix('MIN_NUM_FORMS'): management_form.initial['MIN_NUM_FORMS'],
             formset.add_prefix('MAX_NUM_FORMS'): management_form.initial['MAX_NUM_FORMS'],
             formset.add_prefix('TOTAL_FORMS'): management_form.initial['TOTAL_FORMS'],
             'form-0-quantity': 1,
@@ -330,7 +331,151 @@ class BasketFormSetTests(WebTestCase):
         response = self.post(reverse('basket:summary'), params=data)
         self.assertEqual(response.status_code, 200)
         formset = response.context['formset']
-        self.assertEqual(len(formset.forms), 3)
+        self.assertEqual(len(formset.forms), 2)
         self.assertEqual(len(formset.forms_with_instances), 2)
         self.assertEqual(basket.lines.all()[0].quantity, 1)
         self.assertEqual(basket.lines.all()[1].quantity, 1)
+
+    def test_deleting_valid_line_with_other_valid_line(self):
+        product_1 = create_product()
+        product_2 = create_product()
+
+        basket = factories.create_basket(empty=True)
+        basket.owner = self.user
+        basket.save()
+        add_product(basket, product=product_1)
+        add_product(basket, product=product_2)
+
+        response = self.get(reverse('basket:summary'))
+        formset = response.context['formset']
+        self.assertEqual(len(formset.forms), 2)
+
+        data = {
+            formset.add_prefix('TOTAL_FORMS'): formset.management_form.initial['TOTAL_FORMS'],
+            formset.add_prefix('INITIAL_FORMS'): formset.management_form.initial['INITIAL_FORMS'],
+            formset.add_prefix('MIN_NUM_FORMS'): formset.management_form.initial['MIN_NUM_FORMS'],
+            formset.add_prefix('MAX_NUM_FORMS'): formset.management_form.initial['MAX_NUM_FORMS'],
+            formset.forms[0].add_prefix('id'): formset.forms[0].instance.pk,
+            formset.forms[0].add_prefix('quantity'): formset.forms[0].instance.quantity,
+            formset.forms[0].add_prefix('DELETE'): 'on',
+            formset.forms[1].add_prefix('id'): formset.forms[1].instance.pk,
+            formset.forms[1].add_prefix('quantity'): formset.forms[1].instance.quantity,
+        }
+        response = self.post(reverse('basket:summary'), params=data, xhr=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context['formset'].forms), 1)
+        self.assertFalse(response.context['formset'].is_bound)  # new formset is rendered
+        self.assertEqual(basket.lines.count(), 1)
+        self.assertEqual(basket.lines.all()[0].quantity, 1)
+
+    def test_deleting_valid_line_with_other_invalid_line(self):
+        product_1 = create_product()
+        product_2 = create_product()
+
+        basket = factories.create_basket(empty=True)
+        basket.owner = self.user
+        basket.save()
+        add_product(basket, product=product_1)
+        add_product(basket, product=product_2)
+
+        response = self.get(reverse('basket:summary'))
+        formset = response.context['formset']
+        self.assertEqual(len(formset.forms), 2)
+
+        # Render product for other line out of stock
+        product_2.stockrecords.update(num_in_stock=0)
+
+        data = {
+            formset.add_prefix('TOTAL_FORMS'): formset.management_form.initial['TOTAL_FORMS'],
+            formset.add_prefix('INITIAL_FORMS'): formset.management_form.initial['INITIAL_FORMS'],
+            formset.add_prefix('MIN_NUM_FORMS'): formset.management_form.initial['MIN_NUM_FORMS'],
+            formset.add_prefix('MAX_NUM_FORMS'): formset.management_form.initial['MAX_NUM_FORMS'],
+            formset.forms[0].add_prefix('id'): formset.forms[0].instance.pk,
+            formset.forms[0].add_prefix('quantity'): formset.forms[0].instance.quantity,
+            formset.forms[0].add_prefix('DELETE'): 'on',
+            formset.forms[1].add_prefix('id'): formset.forms[1].instance.pk,
+            formset.forms[1].add_prefix('quantity'): formset.forms[1].instance.quantity,
+        }
+        response = self.post(reverse('basket:summary'), params=data, xhr=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context['formset'].forms), 1)
+        self.assertTrue(response.context['formset'].is_bound)  # formset with errors is rendered
+        self.assertFalse(response.context['formset'].forms[0].is_valid())
+        self.assertEqual(basket.lines.count(), 1)
+        self.assertEqual(basket.lines.all()[0].quantity, 1)
+
+    def test_deleting_invalid_line_with_other_valid_line(self):
+        product_1 = create_product()
+        product_2 = create_product()
+
+        basket = factories.create_basket(empty=True)
+        basket.owner = self.user
+        basket.save()
+        add_product(basket, product=product_1)
+        add_product(basket, product=product_2)
+
+        response = self.get(reverse('basket:summary'))
+        formset = response.context['formset']
+        self.assertEqual(len(formset.forms), 2)
+
+        # Render product for to-be-deleted line out of stock
+        product_1.stockrecords.update(num_in_stock=0)
+
+        data = {
+            formset.add_prefix('TOTAL_FORMS'): formset.management_form.initial['TOTAL_FORMS'],
+            formset.add_prefix('INITIAL_FORMS'): formset.management_form.initial['INITIAL_FORMS'],
+            formset.add_prefix('MIN_NUM_FORMS'): formset.management_form.initial['MIN_NUM_FORMS'],
+            formset.add_prefix('MAX_NUM_FORMS'): formset.management_form.initial['MAX_NUM_FORMS'],
+            formset.forms[0].add_prefix('id'): formset.forms[0].instance.pk,
+            formset.forms[0].add_prefix('quantity'): formset.forms[0].instance.quantity,
+            formset.forms[0].add_prefix('DELETE'): 'on',
+            formset.forms[1].add_prefix('id'): formset.forms[1].instance.pk,
+            formset.forms[1].add_prefix('quantity'): formset.forms[1].instance.quantity,
+        }
+        response = self.post(reverse('basket:summary'), params=data, xhr=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context['formset'].forms), 1)
+        self.assertFalse(response.context['formset'].is_bound)  # new formset is rendered
+        self.assertEqual(basket.lines.count(), 1)
+        self.assertEqual(basket.lines.all()[0].quantity, 1)
+
+    def test_deleting_invalid_line_with_other_invalid_line(self):
+        product_1 = create_product()
+        product_2 = create_product()
+
+        basket = factories.create_basket(empty=True)
+        basket.owner = self.user
+        basket.save()
+        add_product(basket, product=product_1)
+        add_product(basket, product=product_2)
+
+        response = self.get(reverse('basket:summary'))
+        formset = response.context['formset']
+        self.assertEqual(len(formset.forms), 2)
+
+        # Render products for both lines out of stock
+        product_1.stockrecords.update(num_in_stock=0)
+        product_2.stockrecords.update(num_in_stock=0)
+
+        data = {
+            formset.add_prefix('TOTAL_FORMS'): formset.management_form.initial['TOTAL_FORMS'],
+            formset.add_prefix('INITIAL_FORMS'): formset.management_form.initial['INITIAL_FORMS'],
+            formset.add_prefix('MIN_NUM_FORMS'): formset.management_form.initial['MIN_NUM_FORMS'],
+            formset.add_prefix('MAX_NUM_FORMS'): formset.management_form.initial['MAX_NUM_FORMS'],
+            formset.forms[0].add_prefix('id'): formset.forms[0].instance.pk,
+            formset.forms[0].add_prefix('quantity'): formset.forms[0].instance.quantity,
+            formset.forms[0].add_prefix('DELETE'): 'on',
+            formset.forms[1].add_prefix('id'): formset.forms[1].instance.pk,
+            formset.forms[1].add_prefix('quantity'): formset.forms[1].instance.quantity,
+        }
+        response = self.post(reverse('basket:summary'), params=data, xhr=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context['formset'].forms), 1)
+        self.assertTrue(response.context['formset'].is_bound)  # formset with errors is rendered
+        self.assertFalse(response.context['formset'].forms[0].is_valid())
+        self.assertEqual(basket.lines.count(), 1)
+        self.assertEqual(basket.lines.all()[0].quantity, 1)


### PR DESCRIPTION
Currently, if a valid basket line is marked for deletion, any other
invalid basket lines on the formset prevent it from being deleted.