### PR TITLE
Prepare 2.1 beta release

### DIFF
--- a/docs/source/howto/how_to_configure_surcharges.rst
+++ b/docs/source/howto/how_to_configure_surcharges.rst
@@ -1,3 +1,5 @@
+.. _how_to_surcharges:
+
 =========================
 How to configure surcharges
 =========================
@@ -25,7 +27,7 @@ This method is called in several places:
 
 * To give the applicable surcharges to the order total calculator so wo can show the correct price breakdown.
 
-The ``get_applicable_surcharges`` method takes the basket and any other kwargs. 
+The ``get_applicable_surcharges`` method takes the basket and any other kwargs.
 These kwargs can later be determined when setting up your own surcharges.
 
 Note that you can also implement surcharges as models just like shipping methods.
@@ -33,7 +35,7 @@ Note that you can also implement surcharges as models just like shipping methods
 Custom applicators
 -------------------
 
-If the available surcharges are the same for all customers and payment 
+If the available surcharges are the same for all customers and payment
 methods, then override the ``get_surcharges`` method of the repository:
 
 .. code-block:: python
@@ -62,7 +64,7 @@ For more complex logic, override the ``is_applicable`` method:
                return True
            else:
                return False
-               
+
 
 Surcharges
 ----------------
@@ -72,8 +74,8 @@ following properties which define the metadata about the surcharge:
 
 * ``name`` - The name of the surcharges. This will be visible to the
   customer during checkout and is translatable
-  
-* ``code`` - The code of the surcharge. This could be the slugified name or anything else. 
+
+* ``code`` - The code of the surcharge. This could be the slugified name or anything else.
   The code is used as a non-translatable identifier for a charge.
 
 Further, each surcharge must implement a ``calculate`` method which accepts the
@@ -91,7 +93,7 @@ subclassed and customised:
 * :class:`~oscar.apps.checkout.surcharges.PercentageCharge` - percentage based charge
 
 * :class:`~oscar.apps.checkout.surcharges.FlatCharge` - flat surcharge
-  
+
   Example usage:
 
 .. code-block:: python

--- a/docs/source/internals/contributing/development-environment.rst
+++ b/docs/source/internals/contributing/development-environment.rst
@@ -38,7 +38,7 @@ As the sandbox is a vanilla Oscar site, it is what we use to build migrations
 against::
 
     $ make sandbox
-    $ sites/sandbox/manage.py schemamigration $YOURAPP --auto
+    $ sandbox/manage.py makemigrations
 
 Writing LESS/CSS
 ----------------
@@ -52,7 +52,7 @@ If you want to develop the LESS files, set::
 
     OSCAR_USE_LESS = True
 
-in ``sites/sandbox/settings_local.py``.  This will include the on-the-fly
+in ``sandbox/settings_local.py``.  This will include the on-the-fly
 ``less`` pre-processor. That will allow you to see changes to the LESS
 files after a page reload.
 

--- a/docs/source/internals/getting_started.rst
+++ b/docs/source/internals/getting_started.rst
@@ -25,7 +25,7 @@ project:
 
     $ mkvirtualenv oscar
     $ pip install django-oscar
-    $ django-admin.py startproject frobshop
+    $ django-admin startproject frobshop
 
 If you do not have :command:`mkvirtualenv`, then replace that line with::
 
@@ -241,18 +241,18 @@ you will also need to include Django's i18n URLs:
 .. code-block:: django
 
     from django.apps import apps
-    from django.urls import include, path  
+    from django.urls import include, path
     from django.contrib import admin
 
     urlpatterns = [
-        path('i18n/', include('django.conf.urls.i18n')),  
+        path('i18n/', include('django.conf.urls.i18n')),
 
         # The Django admin is not officially supported; expect breakage.
         # Nonetheless, it's often useful for debugging.
 
-        path('admin/', admin.site.urls),  
+        path('admin/', admin.site.urls),
 
-        path('', include(apps.get_app_config('oscar').urls[0])),  
+        path('', include(apps.get_app_config('oscar').urls[0])),
     ]
 
 

--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -5,6 +5,14 @@ Release notes
 Release notes for each version of Oscar published to PyPI.
 
 
+2.1 release branch
+
+.. toctree::
+    :maxdepth: 1
+
+    v2.1
+
+
 2.0 release branch
 
 .. toctree::

--- a/docs/source/releases/v0.7.rst
+++ b/docs/source/releases/v0.7.rst
@@ -192,7 +192,7 @@ Minor changes
 * Experimental support for having a language prefix in the URL has been added,
   and enabled for the sandbox. This can be achieved by using Django's
   `i18n_patterns`_ function in your ``urls.py``. for the sandbox.
-  See ``sites/sandbox/urls.py`` for an example.
+  See ``sandbox/urls.py`` for an example.
 
 * A basic example for a multi-language sitemap has been added to the sandbox.
 

--- a/docs/source/releases/v2.1.rst
+++ b/docs/source/releases/v2.1.rst
@@ -1,10 +1,11 @@
-========================================
-Oscar 2.1 release notes (in development)
-========================================
+=======================
+Oscar 2.1 release notes
+=======================
 
 :release: tbd
 
-Welcome to Oscar 2.1.
+Welcome to Oscar 2.1! This is a significant release which includes a number of
+new features and performance improvements.
 
 .. contents::
     :local:
@@ -15,11 +16,19 @@ Welcome to Oscar 2.1.
 Compatibility
 ~~~~~~~~~~~~~
 
+Oscar 2.1 is compatible with Django versions 2.2 and 3.0, and Python versions 3.5, 3.6, 3.7 and 3.8.
+
+Support for Django versions 1.11 and 2.0 has been dropped.
 
 .. _new_in_2.1:
 
 What's new in Oscar 2.1?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- The ability to add arbitrary surcharges to orders (e.g., a processing fee for
+  a particular payment method) was introduced.
+  See :ref:`how_to_surcharges` for details on how to configure this.
+  This change requires a database migration.
 
 - The database performance of ``offer.Range.all_products()`` was substantially
   improved. The internals of that method have changed and specifically
@@ -30,12 +39,13 @@ What's new in Oscar 2.1?
   ``ProductAttributeValue`` models was changed to use a callable, so that
   Django doesn't generate migrations if a project modifies the ``OSCAR_IMAGE_FOLDER``
   to specify a custom directory structure for uploaded images.
+  This change requires a database migration.
 
 - ``catalogue.Category`` now has an ``is_public`` boolean field that serves a
-  similar purpose to ``catalogue.Product.is_public`` - i.e., hides them from
+  similar purpose to ``catalogue.Product.is_public`` - i.e., to hide categories
   public views. The ``Category`` model also now has a custom manager
   that provides a ``browsable()`` queryset method that excludes non-public
-  categories. This changes requires a database migration.
+  categories. This change requires a database migration.
 
   Category hierarchy implies that the children of any non-public category are
   also non-public. This is enforced through an ``ancestors_are_public`` field
@@ -58,7 +68,7 @@ as follows:
   moved from the ``customer`` app to the ``communication`` app. In order to
   preserve existing data, the table names for these models are unchanged.
 
-  This is a change that requires database migration.
+  This change requires a database migration.
 
 - The ``Dispatcher`` class moved from ``customer.utils`` to
   ``communication.utils``. ``Dispatcher`` is now responsible for sending
@@ -148,6 +158,11 @@ Removal of deprecated features
   URLs that are not provided by a subclass of ``oscar.core.application.OscarDashboardConfig``
   will result in a ``KeyError``.
 
+- ``customer.forms.PasswordResetForm.get_reset_url`` has been removed.
+
+- The internal and undocumented class ``oscar.core.compat.UnicodeCSVReader``
+  has been removed. Use ``csv.reader`` instead.
+
 Minor changes
 ~~~~~~~~~~~~~
 
@@ -176,12 +191,32 @@ Minor changes
 
 - Fixed the ``brand_title`` block in ``partials/brand.html`` so that it doesn't span unclosed HTML tags.
 
+- ``customer.views.ProfileUpdateView.form_valid`` was modified
+  to use a new ``send_email_changed_email`` method.
+
+- ``customer.views.ChangePasswordView.form_valid`` was modified
+  to use a new ``send_password_changed_email`` method.
+
 Dependency changes
 ~~~~~~~~~~~~~~~~~~
 
-- Upgraded ``django-phonenumber-field`` to use the latest in the 3.x series.
-- Upgraded ``select2`` to version 4.0.10.
-- Upgraded ``inputmask`` to version 4.0.8.
+Python package dependencies:
+
+- Upgraded ``pillow`` to version 6.0.0 or higher.
+- Upgraded ``django-extra-views`` to version 0.13.
+- Upgraded ``django-haystack`` to version 3.0 or higher.
+- Upgraded ``django-phonenumber-field`` to version 3.0.
+- Upgraded ``django-tables2`` to version 2.2.
+- Upgraded ``sorl-thumbnail`` (optional requirement) to version 12.6.
+- Upgraded ``easy-thumbnails`` (optional requirement) to version 2.7.
+
+
+Javascript dependencies:
+
+- Upgraded ``jquery`` to version 3.5.
+- Upgraded ``inputmask`` to version 5.0.
+- Upgraded ``select2`` to version 4.0.
+- Upgraded ``tinymce`` to version 5.2.
 
 .. _deprecated_features_in_2.1:
 
@@ -203,14 +238,3 @@ Deprecated features
 
 - ``customer.notifications.services.notify_users`` is deprecated.
   Use ``Dispatcher.notify_users`` instead.
-
-- ``customer.forms.PasswordResetForm.get_reset_url`` has been removed.
-
-- ``customer.views.ProfileUpdateView.form_valid`` was modified
-  to use a new ``send_email_changed_email`` method.
-
-- ``customer.views.ChangePasswordView.form_valid`` was modified
-  to use a new ``send_password_changed_email`` method.
-
-- The internal class ``oscar.core.compat.UnicodeSCVReader`` has been removed.
-  Use ``csv.reader`` instead.

--- a/src/oscar/__init__.py
+++ b/src/oscar/__init__.py
@@ -1,5 +1,5 @@
 # Use 'alpha', 'beta', 'rc' or 'final' as the 4th element to indicate release type.
-VERSION = (2, 0, 1, 'final')
+VERSION = (2, 1, 0, 'beta')
 
 
 def get_short_version():


### PR DESCRIPTION
Prepare for 2.1 beta release and clean up the release notes and a couple of other errors in the docs.

Closes #3338, closes #3358.

We also need to update the translations, but that is a huge diff so I'll do that after this has been merged.