### PR TITLE
Restore basket if order placement fails for any reason.

### DIFF
--- a/src/oscar/apps/checkout/views.py
+++ b/src/oscar/apps/checkout/views.py
@@ -608,9 +608,9 @@ class PaymentDetailsView(OrderPlacementMixin, generic.TemplateView):
         except Exception as e:
             # Unhandled exception - hopefully, you will only ever see this in
             # development...
-            logger.error(
+            logger.exception(
                 "Order #%s: unhandled exception while taking payment (%s)",
-                order_number, e, exc_info=True)
+                order_number, e)
             self.restore_frozen_basket()
             return self.render_preview(
                 self.request, error=error_msg, **payment_kwargs)
@@ -635,6 +635,12 @@ class PaymentDetailsView(OrderPlacementMixin, generic.TemplateView):
             self.restore_frozen_basket()
             return self.render_preview(
                 self.request, error=msg, **payment_kwargs)
+        except Exception as e:
+            # Hopefully you only ever reach this in development
+            logger.exception("Order #%s: unhandled exception while placing order (%s)", order_number, e)
+            error_msg = _("A problem occurred while placing this order. Please contact customer services.")
+            self.restore_frozen_basket()
+            return self.render_preview(self.request, error=error_msg, **payment_kwargs)
 
     def get_template_names(self):
         return [self.template_name_preview] if self.preview else [

--- a/tests/functional/checkout/test_guest_checkout.py
+++ b/tests/functional/checkout/test_guest_checkout.py
@@ -399,7 +399,7 @@ class TestPaymentDetailsView(CheckoutMixin, WebTestCase):
         preview = self.ready_to_place_an_order(is_guest=True)
         response = preview.forms['place_order_form'].submit()
         self.assertIsOk(response)
-        self.assertTrue(mock_logger.error.called)
+        self.assertTrue(mock_logger.exception.called)
         basket = Basket.objects.get()
         self.assertEqual(basket.status, Basket.OPEN)
 
@@ -413,6 +413,17 @@ class TestPaymentDetailsView(CheckoutMixin, WebTestCase):
         response = preview.forms['place_order_form'].submit()
         self.assertIsOk(response)
         self.assertTrue(mock_logger.error.called)
+        basket = Basket.objects.get()
+        self.assertEqual(basket.status, Basket.OPEN)
+
+    @mock.patch('oscar.apps.checkout.views.logger')
+    @mock.patch('oscar.apps.checkout.views.PaymentDetailsView.handle_order_placement')
+    def test_handles_all_other_exceptions_gracefully(self, mock_method, mock_logger):
+        mock_method.side_effect = Exception()
+        preview = self.ready_to_place_an_order(is_guest=True)
+        response = preview.forms['place_order_form'].submit()
+        self.assertIsOk(response)
+        self.assertTrue(mock_logger.exception.called)
         basket = Basket.objects.get()
         self.assertEqual(basket.status, Basket.OPEN)
 


### PR DESCRIPTION
Fixes #3382. Also changes the log level for all unhandled exceptions that reach this method to `exception`, which seems to be a more appropriate level since something has gone terribly wrong if you reach there.