### PR TITLE
Re-add release notes for 1.6.6 and 1.6.7

### DIFF
--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -36,6 +36,8 @@ Release notes for each version of Oscar published to PyPI.
     v1.6.3
     v1.6.4
     v1.6.5
+    v1.6.6
+    v1.6.7
 
 
 1.5 release branch

--- a/docs/source/releases/v1.6.6.rst
+++ b/docs/source/releases/v1.6.6.rst
@@ -1,0 +1,8 @@
+=========================
+Oscar 1.6.6 release notes
+=========================
+
+:release: 2018-01-18
+
+This is Oscar 1.6.6, a bugfix release that adds updated CSS assets that should
+have been included in Oscar 1.6.5.

--- a/docs/source/releases/v1.6.7.rst
+++ b/docs/source/releases/v1.6.7.rst
@@ -1,0 +1,8 @@
+=========================
+Oscar 1.6.7 release notes
+=========================
+
+:release: 2018-01-31
+
+This is Oscar 1.6.7, a bugfix release that adds updated dashboard CSS assets that should
+have been included in Oscar 1.6.5.


### PR DESCRIPTION
These release notes were created in 6a03a0bc1f and 05b14af8af, but somehow didn't make it into the master branch.

This is why http://docs.oscarcommerce.com/en/latest/releases/index.html currently doesn't mention these releases.