### PR TITLE
Fix tests on 1.6 branch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ test_requires = [
     'pytest>=3.6,<3.7',
     'pytest-cov==2.5.1',
     'pytest-django==3.1.2',
-    'pytest-xdist>=1.22<1.23',
+    'pytest-xdist==1.22.3',
     'tox>=3.0,<3.1',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ test_requires = [
     'WebTest>=2.0,<2.1',
     'coverage>=4.5,<4.6',
     'django-webtest==1.9.2',
+    'freezegun',
     'py>=1.4.31',
     'psycopg2>=2.7,<2.8',
     'pytest>=3.6,<3.7',

--- a/tests/integration/payment/test_forms.py
+++ b/tests/integration/payment/test_forms.py
@@ -3,7 +3,7 @@ import datetime
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 from django.forms import ValidationError
-
+from freezegun import freeze_time
 
 from oscar.apps.payment import forms, models
 # types=[bankcards.VISA, bankcards.VISA_ELECTRON, bankcards.MASTERCARD,
@@ -45,6 +45,7 @@ class TestBankcardNumberField(TestCase):
             self.field.clean(None)
 
 
+@freeze_time('2016-01-01')
 class TestStartingMonthField(TestCase):
 
     def setUp(self):
@@ -72,6 +73,7 @@ class TestStartingMonthField(TestCase):
         self.assertEqual(1, start_date.day)
 
 
+@freeze_time('2016-01-01')
 class TestExpiryMonthField(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
In the process of #3401, i found that the tests for the `releases/1.6` branch currently fail for two reasons:

1. pytest-xdist has sneakily started requiring a higher pytest version in a minor version update (to 1.23.4), see https://github.com/pytest-dev/pytest/issues/3724
2. `test_forms` relied on 2014 being a valid year for a credit card date, which  it isn't anymore.

I'd like to keep the PR for the Django 2.2 compatibility as clean as possible, so i'd like to have this PR merged before submitting the PR with the actual changes.