### PR TITLE
Add Django 2.2 compatibility to 1.6 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,20 +16,28 @@ matrix:
       env: TOXENV=py35-django111
     - python: 3.6
       env: TOXENV=py36-django111
+    - python: 3.7
+      env: TOXENV=py37-django111
     - python: 3.4
       env: TOXENV=py34-django20
     - python: 3.5
       env: TOXENV=py35-django20
     - python: 3.6
       env: TOXENV=py36-django20
+    - python: 3.7
+      env: TOXENV=py37-django20
     - python: 3.5
       env: TOXENV=py35-django21
     - python: 3.6
       env: TOXENV=py36-django21
+    - python: 3.7
+      env: TOXENV=py37-django21
     - python: 3.5
       env: TOXENV=py35-django22
     - python: 3.6
       env: TOXENV=py36-django22
+    - python: 3.7
+      env: TOXENV=py37-django22
 
     - python: 3.6
       env: TOXENV=lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 sudo: false
 language: python
 
@@ -25,15 +26,15 @@ matrix:
       env: TOXENV=py35-django21
     - python: 3.6
       env: TOXENV=py36-django21
+    - python: 3.5
+      env: TOXENV=py35-django22
     - python: 3.6
-      env: TOXENV=py36-djangomaster
+      env: TOXENV=py36-django22
 
     - python: 3.6
       env: TOXENV=lint
     - python: 3.5
       env: TOXENV=sandbox
-  allow_failures:
-    - env: TOXENV=py36-djangomaster
 
 
 env:

--- a/docs/source/releases/v1.6.8.rst
+++ b/docs/source/releases/v1.6.8.rst
@@ -2,7 +2,9 @@
 Oscar 1.6.8 release notes
 =========================
 
-:release: 2018-02-28
+:release: ????-??-??
 
-This is Oscar 1.6.8, a security release that updates to Bootstrap to 3.4.1
-and extend 3.0.2 to fix CVE-2019-8331 and CVE-2018-16492 vulnerabilities.
+This is Oscar 1.6.8, a Django 2.2 compatibility release.
+
+It also updates Bootstrap to 3.4.1 and explicitly specifies extend in the
+npm dependencies to fix CVE-2019-8331 and CVE-2018-16492 vulnerabilities.

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ sys.path.append(os.path.join(PROJECT_DIR, 'src'))
 from oscar import get_version  # noqa isort:skip
 
 install_requires = [
-    'django>=1.11,<2.2',
+    'django>=1.11,<2.3',
     # PIL is required for image fields, Pillow is the "friendly" PIL fork
     'pillow>=4.0',
     # We use the ModelFormSetView from django-extra-views for the basket page

--- a/src/oscar/apps/customer/utils.py
+++ b/src/oscar/apps/customer/utils.py
@@ -5,10 +5,9 @@ from django.contrib.auth.tokens import default_token_generator
 from django.core.mail import EmailMessage, EmailMultiAlternatives
 from django.urls import reverse
 from django.utils.encoding import force_bytes
-from django.utils.http import urlsafe_base64_encode
 
+from oscar.core.compat import urlsafe_base64_encode
 from oscar.core.loading import get_model
-
 
 CommunicationEvent = get_model('order', 'CommunicationEvent')
 Email = get_model('customer', 'Email')
@@ -134,7 +133,7 @@ def get_password_reset_url(user, token_generator=default_token_generator):
     """
     kwargs = {
         'token': token_generator.make_token(user),
-        'uidb64': urlsafe_base64_encode(force_bytes(user.id)).decode(),
+        'uidb64': urlsafe_base64_encode(force_bytes(user.id)),
     }
     return reverse('password-reset-confirm', kwargs=kwargs)
 

--- a/src/oscar/core/compat.py
+++ b/src/oscar/core/compat.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ImproperlyConfigured
 from django.utils import six
+from django.utils.http import urlsafe_base64_encode as django_urlsafe_base64_encode
 
 from oscar.core.loading import get_model
 
@@ -196,3 +197,12 @@ class UnicodeCSVWriter:
     def writerows(self, rows):
         for row in rows:
             self.writerow(row)
+
+
+def urlsafe_base64_encode(value):
+    # In Django 2.2 function returns string, but not bytestring, so it is necessary
+    # to decode value only for the previous Django versions.
+    encoded_value = django_urlsafe_base64_encode(value)
+    if isinstance(encoded_value, bytes):
+        encoded_value = encoded_value.decode()
+    return encoded_value

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{27,34,35,36}-django{111,20,21}
-    py36-djangomaster
+    py{35,36}-django22
     lint
     sandbox
 
@@ -14,13 +14,7 @@ deps =
     django111: django>=1.11,<2
     django20: django>=2.0,<2.1
     django21: django>=2.1,<2.2
-
-
-[testenv:py36-djangomaster]
-commands =
-    # Can't specify this in deps - see https://github.com/tox-dev/tox/issues/513
-    pip install https://github.com/django/django/archive/master.tar.gz#egg=django
-    pytest {posargs}
+    django22: django>=2.2,<2.3
 
 
 [testenv:coverage-report]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{27,34,35,36}-django{111,20,21}
-    py{35,36}-django22
+    py{27,34,35,36,37}-django{111,20,21}
+    py{35,36,37}-django22
     lint
     sandbox
 


### PR DESCRIPTION
As discussed in #3401, this makes the 1.6 branch compatible with Django 2.2.

- The only actual code change is backported from https://github.com/django-oscar/django-oscar/commit/4a479e74ab6cf359329f2a539f67e931410347eb
- Test matrices have been augumented with django22 on python3.5 and python3.6 
- Testing with django master branch has been dropped
- Release notes have been updated but will need a release date

Closes #3401.