### PR TITLE
Fix display of product class for child products in dashboard order detail template

### DIFF
--- a/src/oscar/templates/oscar/dashboard/orders/line_detail.html
+++ b/src/oscar/templates/oscar/dashboard/orders/line_detail.html
@@ -44,7 +44,7 @@
                     </td>
                 </tr>
                 <tr>
-                    <th>{% trans "Product Type" %}</th><td>{{ line.product.product_class }}</td>
+                    <th>{% trans "Product Type" %}</th><td>{{ line.product.get_product_class }}</td>
                 </tr>
                 <tr>
                     <th>{% trans "UPC" %}</th><td>{{ line.upc|default:"-" }}</td>


### PR DESCRIPTION
`product.product_class` is `None` for child products - we shouldn't be accessing it directly.