### PR TITLE
ProductCreateUpdateView: Avoid AttributeError

### DIFF
--- a/src/oscar/apps/dashboard/catalogue/views.py
+++ b/src/oscar/apps/dashboard/catalogue/views.py
@@ -220,6 +220,9 @@ class ProductCreateUpdateView(generic.UpdateView):
     recommendations_formset = ProductRecommendationFormSet
     stockrecord_formset = StockRecordFormSet
 
+    creating = False
+    parent = None
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.formsets = {'category_formset': self.category_formset,


### PR DESCRIPTION
DELETE requests were failing with an exception instead
of the appropriate HTTP 405 response.

Fixes https://github.com/django-oscar/django-oscar/issues/3429