### PR TITLE
dynamic parent class for SimpleAddToBasketForm

### DIFF
--- a/src/oscar/apps/basket/forms.py
+++ b/src/oscar/apps/basket/forms.py
@@ -4,7 +4,7 @@ from django.db.models import Sum
 from django.forms.utils import ErrorDict
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.loading import get_model, get_class
+from oscar.core.loading import get_class, get_model
 from oscar.forms import widgets
 
 Line = get_model('basket', 'line')

--- a/src/oscar/apps/basket/forms.py
+++ b/src/oscar/apps/basket/forms.py
@@ -4,7 +4,7 @@ from django.db.models import Sum
 from django.forms.utils import ErrorDict
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.loading import get_model
+from oscar.core.loading import get_model, get_class
 from oscar.forms import widgets
 
 Line = get_model('basket', 'line')
@@ -268,7 +268,7 @@ class AddToBasketForm(forms.Form):
         return options
 
 
-class SimpleAddToBasketForm(AddToBasketForm):
+class SimpleAddToBasketForm(get_class('basket.forms', 'AddToBasketForm')):
     """
     Simplified version of the add to basket form where the quantity is
     defaulted to 1 and rendered in a hidden widget


### PR DESCRIPTION
Fixing https://github.com/django-oscar/django-oscar/issues/3435

I don't know `get_class()` internals well, but this small change is working to simplify overriding `AddToBasketForm` as described in the issue.

Is this a good idea?