### PR TITLE
Prevent notifications DELETE

### DIFF
--- a/src/oscar/apps/communication/notifications/views.py
+++ b/src/oscar/apps/communication/notifications/views.py
@@ -69,11 +69,10 @@ class DetailView(PageTitleMixin, generic.DetailView):
             recipient=self.request.user)
 
 
-class UpdateView(BulkEditMixin, generic.RedirectView):
+class UpdateView(BulkEditMixin, generic.View):
     model = Notification
     actions = ('archive', 'delete')
     checkbox_object_name = 'notification'
-    permanent = False
 
     def get_object_dict(self, ids):
         return self.model.objects.filter(

--- a/src/oscar/apps/communication/notifications/views.py
+++ b/src/oscar/apps/communication/notifications/views.py
@@ -71,6 +71,7 @@ class DetailView(PageTitleMixin, generic.DetailView):
 
 class UpdateView(BulkEditMixin, generic.View):
     model = Notification
+    http_method_names = ['post']
     actions = ('archive', 'delete')
     checkbox_object_name = 'notification'
 


### PR DESCRIPTION
HTTP method DELETE causes a TypeError, as the delete operation
must be done via POST.

Fixes https://github.com/django-oscar/django-oscar/issues/3431