### PR TITLE
Use requirements.txt for lint dependencies so that they are pinned.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,8 +18,7 @@ deps =
 [testenv:lint]
 basepython = python3.7
 deps =
-    flake8
-    isort
+    -r{toxinidir}/requirements.txt
 commands =
     npm ci
     flake8 src tests setup.py


### PR DESCRIPTION
(isort 5.0.0 has breaking changes).