### PR TITLE
Update Travis config to use bionic build and PostgreSQL version 10.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
-dist: xenial
+dist: bionic
 sudo: false
 language: python
 
 addons:
-  postgresql: "9.6"
+  postgresql: "10"
   apt_packages:
     - enchant
 


### PR DESCRIPTION
The bionic build is a bit [faster](https://docs.travis-ci.com/user/reference/bionic/) than xenial, and defaults to nodejs v10 instead of v8, which we need in order to run [eslint v7](https://github.com/django-oscar/django-oscar/pull/3440).