### PR TITLE
Add a table of supported Oscar versions to the readme.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,6 +98,22 @@ Core team:
 .. _`Alexander Gaevsky`: https://github.com/sasha0
 .. _`Samir Shah`: https://github.com/solarissmoke
 
+
+Supported versions
+------------------
+
+The currently supported versions of Oscar are:
+
++---------+----------------+
+| Version | End of support |
++=========+================+
+| 2.1 LTS | August 2023    |
++---------+----------------+
+
+Supported verions are eligible for fixes for data loss bugs and security issues. Releases designated as
+Long-term support (LTS) releases will receive support for an extended period of 3 years from their release date.
+
+
 Screenshots
 -----------
 


### PR DESCRIPTION
Closes #2675 .

Currently Oscar does not have any policy on which versions are actively supported. I think it is important to provide some clarity and reassurance this, and to introduce the concept of long-term support releases which projects can rely on to be maintained for a sufficiently long period of time.

We don't at present have the resources to commit to a Django-style approach of cutting a new release every six months, and an LTS release every two years, but that is not an unreasonable target to aim for in the long run. 

For now, I propose to declare v2.1 an LTS release, and commit to supporting it for 3 years. It will be the last version of Oscar based on Bootstrap 3. The plan would be to issue the next LTS release at the beginning of 2023.