### PR TITLE
Add shipping charge to the percentage surcharge

### DIFF
--- a/src/oscar/apps/basket/views.py
+++ b/src/oscar/apps/basket/views.py
@@ -137,7 +137,9 @@ class BasketView(ModelFormSetView):
                                                prefix='saved')
                     context['saved_formset'] = formset
 
-        surcharges = SurchargeApplicator(self.request, context).get_applicable_surcharges(self.request.basket)
+        surcharges = SurchargeApplicator(self.request, context).get_applicable_surcharges(
+            self.request.basket, shipping_charge=shipping_charge
+        )
         context['surcharges'] = surcharges
         context['order_total'] = OrderTotalCalculator().calculate(
             self.request.basket, shipping_charge, surcharges=surcharges)

--- a/src/oscar/apps/checkout/session.py
+++ b/src/oscar/apps/checkout/session.py
@@ -229,7 +229,6 @@ class CheckoutSessionMixin(object):
         shipping_address = self.get_shipping_address(request.basket)
         shipping_method = self.get_shipping_method(
             request.basket, shipping_address)
-        surcharges = SurchargeApplicator(request).get_applicable_surcharges(basket=request.basket)
         if shipping_method:
             shipping_charge = shipping_method.calculate(request.basket)
         else:
@@ -240,6 +239,10 @@ class CheckoutSessionMixin(object):
                 currency=request.basket.currency, excl_tax=D('0.00'),
                 tax=D('0.00')
             )
+
+        surcharges = SurchargeApplicator(request).get_applicable_surcharges(
+            basket=request.basket, shipping_charge=shipping_charge
+        )
         total = self.get_order_totals(request.basket, shipping_charge, surcharges)
         if total.excl_tax == D('0.00'):
             raise exceptions.PassedSkipCondition(
@@ -282,11 +285,13 @@ class CheckoutSessionMixin(object):
             'payment_kwargs': {}
         }
 
-        surcharges = SurchargeApplicator(self.request, submission).get_applicable_surcharges(self.request.basket)
         if not shipping_method:
-            total = shipping_charge = None
+            total = shipping_charge = surcharges = None
         else:
             shipping_charge = shipping_method.calculate(basket)
+            surcharges = SurchargeApplicator(self.request, submission).get_applicable_surcharges(
+                self.request.basket, shipping_charge=shipping_charge
+            )
             total = self.get_order_totals(
                 basket, shipping_charge=shipping_charge, surcharges=surcharges, **kwargs)
 

--- a/src/oscar/apps/checkout/surcharges.py
+++ b/src/oscar/apps/checkout/surcharges.py
@@ -27,11 +27,20 @@ class PercentageCharge(BaseSurcharge):
         self.percentage = percentage
 
     def calculate(self, basket, **kwargs):
-        if basket.total_excl_tax:
+        if not basket.is_empty:
+            shipping_charge = kwargs.get("shipping_charge")
+
+            if shipping_charge is not None:
+                total_excl_tax = basket.total_excl_tax + shipping_charge.excl_tax
+                total_incl_tax = basket.total_incl_tax + shipping_charge.incl_tax
+            else:
+                total_excl_tax = basket.total_excl_tax
+                total_incl_tax = basket.total_incl_tax
+
             return prices.Price(
                 currency=basket.currency,
-                excl_tax=basket.total_excl_tax * self.percentage / 100,
-                incl_tax=basket.total_incl_tax * self.percentage / 100
+                excl_tax=total_excl_tax * self.percentage / 100,
+                incl_tax=total_incl_tax * self.percentage / 100
             )
         else:
             return prices.Price(

--- a/tests/integration/checkout/test_surcharges.py
+++ b/tests/integration/checkout/test_surcharges.py
@@ -2,6 +2,7 @@ from decimal import Decimal as D
 
 from django.test import TestCase
 
+from oscar.core import prices
 from oscar.core.loading import get_class
 from oscar.test import factories
 from oscar.test.basket import add_product
@@ -46,3 +47,15 @@ class TestSurcharges(TestCase):
         self.assertEqual(self.basket.total_incl_tax, D(12))
         self.assertEqual(price.incl_tax, D("1.21"))
         self.assertEqual(price.excl_tax, D(1))
+
+    def test_percentage_with_shipping_charge(self):
+        percentage_surcharge = PercentageCharge(percentage=D(4))
+        add_product(self.basket, D(10))
+        shipping_charge = prices.Price(
+            currency=self.basket.currency,
+            excl_tax=D('3.95'), tax=D('1.05'))
+        price = percentage_surcharge.calculate(self.basket, shipping_charge=shipping_charge)
+
+        self.assertEqual(self.basket.total_incl_tax, D(10))
+        self.assertEqual(shipping_charge.incl_tax, D(5))
+        self.assertEqual(price.incl_tax, D("0.6"))


### PR DESCRIPTION
Give the shipping charges as kwarg to the applicator and use it to calculate the total surcharge.

This is necessary because before the surcharges were only calculated over the basket items.
For example when using this as a payment surcharge you actually pay the shipping charge but don't pay surcharges over them. This way it will cost the webshop owner some money in transaction cost. 