### PR TITLE
Fix table column misalignment in dashboard order detail page

### DIFF
--- a/src/oscar/templates/oscar/dashboard/orders/order_detail.html
+++ b/src/oscar/templates/oscar/dashboard/orders/order_detail.html
@@ -153,7 +153,7 @@
                                 {% endfor %}
 
                                 <tr>
-                                    <td colspan="9"></td>
+                                    <td colspan="8"></td>
                                     <th>{% trans "Discount" %}</th>
                                     <td class="text-right">{{ order.total_discount_excl_tax|currency:order.currency }}</td>
                                     <td class="text-right">{{ order.total_discount_incl_tax|currency:order.currency }}</td>
@@ -162,7 +162,7 @@
                                 {% with discounts=order.basket_discounts %}
                                     {% if discounts %}
                                         <tr>
-                                            <td colspan="9"></td>
+                                            <td colspan="8"></td>
                                             <th>{% trans "Basket total (excl. discounts)" %}</th>
                                             <td class="text-right">{{ order.basket_total_before_discounts_excl_tax|currency:order.currency }}</td>
                                             <td class="text-right">{{ order.basket_total_before_discounts_incl_tax|currency:order.currency }}</td>
@@ -170,7 +170,7 @@
                                         </tr>
                                         {% for discount in discounts %}
                                             <tr>
-                                                <td colspan="9"></td>
+                                                <td colspan="8"></td>
                                                 <td>
                                                     <span class="label label-success">{% trans "Discount" %}</span>
                                                     {{ discount.offer_name }}
@@ -181,7 +181,7 @@
                                             </tr>
                                         {% endfor %}
                                         <tr>
-                                            <td colspan="9"></td>
+                                            <td colspan="8"></td>
                                             <th>{% trans "Basket total (inc. discounts)" %}</th>
                                             <th class="text-right">{{ order.basket_total_excl_tax|currency:order.currency }}</th>
                                             <th class="text-right">{{ order.basket_total_incl_tax|currency:order.currency }}</th>
@@ -189,7 +189,7 @@
                                         </tr>
                                     {% else %}
                                         <tr>
-                                            <td colspan="9"></td>
+                                            <td colspan="8"></td>
                                             <th>{% trans "Basket total" %}</th>
                                             <th class="text-right">{{ order.basket_total_excl_tax|currency:order.currency }}</th>
                                             <th class="text-right">{{ order.basket_total_incl_tax|currency:order.currency }}</th>
@@ -200,7 +200,7 @@
 
                                 {% if order.has_shipping_discounts %}
                                     <tr>
-                                        <td colspan="9"></td>
+                                        <td colspan="8"></td>
                                         <td>{% trans "Shipping total (excl. discounts)" %}</td>
                                         <td class="text-right">{{ order.shipping_before_discounts_excl_tax|currency:order.currency }}</td>
                                         <td class="text-right">{{ order.shipping_before_discounts_incl_tax|currency:order.currency }}</td>
@@ -208,7 +208,7 @@
                                     </tr>
                                     {% for discount in order.shipping_discounts %}
                                         <tr>
-                                            <td colspan="9"></td>
+                                            <td colspan="8"></td>
                                             <td>
                                                 <span class="label label-success">{% trans "Discount" %}</span>
                                                 {{ discount.offer_name }}
@@ -219,7 +219,7 @@
                                         </tr>
                                     {% endfor %}
                                     <tr>
-                                        <td colspan="9"></td>
+                                        <td colspan="8"></td>
                                         <th>{% trans "Shipping total (inc. discounts)" %}</th>
                                         <th class="text-right">{{ order.shipping_excl_tax|currency:order.currency }}</th>
                                         <th class="text-right">{{ order.shipping_incl_tax|currency:order.currency }}</th>
@@ -227,7 +227,7 @@
                                     </tr>
                                 {% else %}
                                     <tr>
-                                        <td colspan="9"></td>
+                                        <td colspan="8"></td>
                                         <th>{% trans "Shipping total" %}</th>
                                         <th class="text-right">{{ order.shipping_excl_tax|currency:order.currency }}</th>
                                         <th class="text-right">{{ order.shipping_incl_tax|currency:order.currency }}</th>
@@ -239,7 +239,7 @@
                                 {% if surcharges %}
                                     {% for charge in surcharges %}
                                         <tr>
-                                            <td colspan="9"></td>
+                                            <td colspan="8"></td>
                                             <th>{% blocktrans with name=charge.name %}Surcharge (name){% endblocktrans %}</th>
                                             <th class="text-right">{{ charge.excl_tax|currency:order.currency }}</th>
                                             <th class="text-right">{{ charge.incl_tax|currency:order.currency }}</th>
@@ -250,7 +250,7 @@
                                 {% endwith %}
 
                                 <tr>
-                                    <td colspan="9"></td>
+                                    <td colspan="8"></td>
                                     <th>{% trans "Order total" %}</th>
                                     <th class="text-right">{{ order.total_excl_tax|currency:order.currency }}</th>
                                     <th class="text-right">{{ order.total_incl_tax|currency:order.currency }}</th>


### PR DESCRIPTION
PR #3019 removed some fields, but one of the tables in the dashboard order detail page was not adjusted accordingly when the "Estimated dispatch date" column was removed. This issue can be replicated using the latest sandbox docker image.

![image](https://user-images.githubusercontent.com/7114869/90594732-b1044f00-e21d-11ea-91b0-834591b359be.png)

The `colspan` attribute must be changed so that the column headers and the right edge will be aligned like so:

![image](https://user-images.githubusercontent.com/7114869/90594965-57e8eb00-e21e-11ea-89fa-14d7b5ca2e07.png)
