### PR TITLE
Use QuerySet.first() where appropriate instead of fetching by index.

### DIFF
--- a/src/oscar/apps/address/abstract_models.py
+++ b/src/oscar/apps/address/abstract_models.py
@@ -490,10 +490,7 @@ class AbstractShippingAddress(AbstractAddress):
         """
         Return the order linked to this shipping address
         """
-        try:
-            return self.order_set.all()[0]
-        except IndexError:
-            return None
+        return self.order_set.first()
 
 
 class AbstractUserAddress(AbstractShippingAddress):
@@ -594,10 +591,7 @@ class AbstractBillingAddress(AbstractAddress):
         """
         Return the order linked to this shipping address
         """
-        try:
-            return self.order_set.all()[0]
-        except IndexError:
-            return None
+        return self.order_set.first()
 
 
 class AbstractPartnerAddress(AbstractAddress):

--- a/src/oscar/apps/dashboard/vouchers/views.py
+++ b/src/oscar/apps/dashboard/vouchers/views.py
@@ -171,7 +171,7 @@ class VoucherUpdateView(generic.FormView):
 
     def get_initial(self):
         voucher = self.get_voucher()
-        offer = voucher.offers.all()[0]
+        offer = voucher.offers.first()
         benefit = offer.benefit
         return {
             'name': voucher.name,
@@ -195,7 +195,7 @@ class VoucherUpdateView(generic.FormView):
         voucher.end_datetime = form.cleaned_data['end_datetime']
         voucher.save()
 
-        offer = voucher.offers.all()[0]
+        offer = voucher.offers.first()
         offer.condition.range = form.cleaned_data['benefit_range']
         offer.condition.save()
 

--- a/src/oscar/apps/partner/strategy.py
+++ b/src/oscar/apps/partner/strategy.py
@@ -195,10 +195,7 @@ class UseFirstStockRecord(object):
     """
 
     def select_stockrecord(self, product):
-        try:
-            return product.stockrecords.all()[0]
-        except IndexError:
-            return None
+        return product.stockrecords.first()
 
 
 class StockRequired(object):

--- a/src/oscar/apps/shipping/abstract_models.py
+++ b/src/oscar/apps/shipping/abstract_models.py
@@ -166,11 +166,7 @@ class AbstractWeightBased(AbstractBase):
         """
         Return the closest matching weight band for a given weight.
         """
-        try:
-            return self.bands.filter(
-                upper_limit__gte=weight).order_by('upper_limit')[0]
-        except IndexError:
-            return None
+        return self.bands.filter(upper_limit__gte=weight).order_by('upper_limit').first()
 
     @property
     def num_bands(self):
@@ -178,10 +174,7 @@ class AbstractWeightBased(AbstractBase):
 
     @property
     def top_band(self):
-        try:
-            return self.bands.order_by('-upper_limit')[0]
-        except IndexError:
-            return None
+        return self.bands.order_by('-upper_limit').first()
 
 
 class AbstractWeightBand(models.Model):

--- a/src/oscar/apps/voucher/abstract_models.py
+++ b/src/oscar/apps/voucher/abstract_models.py
@@ -267,7 +267,7 @@ class AbstractVoucher(models.Model):
         A voucher is commonly only linked to one offer. In that case,
         this helper can be used for convenience.
         """
-        return self.offers.all()[0].benefit
+        return self.offers.first().benefit
 
 
 class AbstractVoucherApplication(models.Model):

--- a/src/oscar/test/basket.py
+++ b/src/oscar/test/basket.py
@@ -20,7 +20,7 @@ def add_product(basket, price=None, quantity=1, product=None):
     if price is None:
         price = D('1')
     if product and product.has_stockrecords:
-        record = product.stockrecords.all()[0]
+        record = product.stockrecords.first()
     else:
         record = factories.create_stockrecord(
             product=product, price=price,


### PR DESCRIPTION
Cleanup of some old code that was written before `first()` was introduced to Django's queryset methods. I haven't bothered changing some tests that also do this - just want to reduce clutter in the functional code.