### PR TITLE
Make category slugs dashboard-editable.

### DIFF
--- a/docs/source/releases/v3.0.rst
+++ b/docs/source/releases/v3.0.rst
@@ -67,6 +67,8 @@ Minor changes
 - Several models were updated to define a default ordering, to avoid issues with inconsistent ordering of
   items in the dashboard and elsewhere. Database migrations are required for these changes.
 
+- Category slugs can now be edited via the dashboard.
+
 Dependency changes
 ~~~~~~~~~~~~~~~~~~
 

--- a/src/oscar/apps/dashboard/catalogue/forms.py
+++ b/src/oscar/apps/dashboard/catalogue/forms.py
@@ -24,10 +24,20 @@ ProductSelect = get_class('dashboard.catalogue.widgets', 'ProductSelect')
                                                   ('RelatedFieldWidgetWrapper',
                                                    'RelatedMultipleFieldWidgetWrapper'))
 
-CategoryForm = movenodeform_factory(
+
+BaseCategoryForm = movenodeform_factory(
     Category,
-    fields=['name', 'description', 'image', 'is_public'],
+    fields=['name', 'slug', 'description', 'image', 'is_public'],
     exclude=['ancestors_are_public'])
+
+
+class CategoryForm(BaseCategoryForm):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if 'slug' in self.fields:
+            self.fields['slug'].required = False
+            self.fields['slug'].help_text = _('Leave blank to generate from category name')
 
 
 class ProductClassSelectForm(forms.Form):


### PR DESCRIPTION
Make category slugs editable from the dashboard, so that admins can modify them if they change a category name etc.

Fixes #561, fixes #3472.