### PR TITLE
Make ProductAttributesContainer a lazy object so that initialisation is simpler.

### DIFF
--- a/docs/source/releases/v3.0.rst
+++ b/docs/source/releases/v3.0.rst
@@ -47,6 +47,10 @@ Backwards incompatible changes
 Bug fixes
 ~~~~~~~~~
 
+- ``catalogue.product_attributes.ProductAttributesContainer`` was refactored to ensure that attributes
+  inside the container are always properly loaded at initialisation. The container is now wrapped in a
+  ``SimpleLazyObject`` when assigned to ``Product.attr``. ``ProductAttributesContainer.initiate_attributes()``
+  was removed as the database query now happens on instantiation.
 
 Removal of deprecated features
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -15,7 +15,7 @@ from django.db.models import Count, Exists, OuterRef, Sum
 from django.db.models.fields import Field
 from django.db.models.lookups import StartsWith
 from django.urls import reverse
-from django.utils.functional import cached_property
+from django.utils.functional import SimpleLazyObject, cached_property
 from django.utils.html import strip_tags
 from django.utils.safestring import mark_safe
 from django.utils.translation import get_language
@@ -435,7 +435,7 @@ class AbstractProduct(models.Model):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.attr = ProductAttributesContainer(product=self)
+        self.attr = SimpleLazyObject(lambda: ProductAttributesContainer(product=self))
 
     def __str__(self):
         if self.title:

--- a/src/oscar/apps/catalogue/product_attributes.py
+++ b/src/oscar/apps/catalogue/product_attributes.py
@@ -2,7 +2,7 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 
 
-class ProductAttributesContainer(object):
+class ProductAttributesContainer:
     """
     Stolen liberally from django-eav, but simplified to be product-specific
 
@@ -13,25 +13,16 @@ class ProductAttributesContainer(object):
 
     def __setstate__(self, state):
         self.__dict__ = state
-        self.initialised = False
 
     def __init__(self, product):
         self.product = product
-        self.initialised = False
-
-    def initiate_attributes(self):
         values = self.get_values().select_related('attribute')
         for v in values:
             setattr(self, v.attribute.code, v.value)
-        self.initialised = True
 
     def __getattr__(self, name):
-        if not name.startswith('_') and not self.initialised:
-            self.initiate_attributes()
-            return getattr(self, name)
         raise AttributeError(
-            _("%(obj)s has no attribute named '%(attr)s'") % {
-                'obj': self.product.get_product_class(), 'attr': name})
+            _("%(obj)s has no attribute named '%(attr)s'") % {'obj': self.product.get_product_class(), 'attr': name})
 
     def validate_attributes(self):
         for attribute in self.get_all_attributes():

--- a/src/oscar/apps/dashboard/catalogue/forms.py
+++ b/src/oscar/apps/dashboard/catalogue/forms.py
@@ -286,7 +286,6 @@ class ProductForm(forms.ModelForm):
         Set attributes before ModelForm calls the product's clean method
         (which it does in _post_clean), which in turn validates attributes.
         """
-        self.instance.attr.initiate_attributes()
         for attribute in self.instance.attr.get_all_attributes():
             field_name = 'attr_%s' % attribute.code
             # An empty text field won't show up in cleaned_data.


### PR DESCRIPTION
Fixes #3258.