### PR TITLE
Deprecate and remove Python 3.5 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ addons:
 matrix:
   fast_finish: true
   include:
-    - python: 3.5
-      env: TOXENV=py35-django22
     - python: 3.6
       env: TOXENV=py36-django22
     - python: 3.7

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,6 @@ setup(
         'Operating System :: Unix',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Libraries :: Application Frameworks']

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{35,36,37,38}-django{22,30}
+    py{36,37,38}-django{22,30}
     lint
     sandbox
     docs


### PR DESCRIPTION
> Python 3.5 will reach its "end of life" at the end of September 2020. If there are no security patches filed for Python 3.5 after the release of Python 3.5.10, then Python 3.5.10 will be the final release of the 3.5 series.

Python 3.5 removal would allow to start using f-strings and other useful features of Python 3.6+.