### PR TITLE
Order reviews by date created by default in the dashboard.

### DIFF
--- a/src/oscar/apps/dashboard/reviews/views.py
+++ b/src/oscar/apps/dashboard/reviews/views.py
@@ -68,7 +68,7 @@ class ReviewListView(BulkEditMixin, generic.ListView):
     def get_queryset(self):
         queryset = self.model.objects.select_related('product', 'user').all()
         queryset = sort_queryset(
-            queryset, self.request, ['score', 'total_votes', 'date_created'])
+            queryset, self.request, ['date_created', 'score', 'total_votes'], default='-date_created')
         self.desc_ctx = {
             'main_filter': _('All reviews'),
             'date_filter': '',

--- a/tests/functional/dashboard/test_review.py
+++ b/tests/functional/dashboard/test_review.py
@@ -76,15 +76,7 @@ class ReviewsDashboardTests(WebTestCase):
         self.assertEqual(response.context['review_list'][0], review2)
 
         response = self.get(url, params={'keyword': 'review'})
-        self.assertQuerysetContains(response.context['review_list'],
-                                    [review1, review2])
-
-    def assertQuerysetContains(self, qs, items):
-        qs_ids = [obj.id for obj in qs]
-        item_ids = [item.id for item in items]
-        self.assertEqual(len(qs_ids), len(item_ids))
-        for i, j in zip(qs_ids, item_ids):
-            self.assertEqual(i, j)
+        assert list(response.context['review_list']) == [review2, review1]
 
     def test_filter_reviews_by_date(self):
         def n_days_ago(days):
@@ -106,19 +98,16 @@ class ReviewsDashboardTests(WebTestCase):
 
         url = reverse('dashboard:reviews-list')
         response = self.get(url, params={'date_from': n_days_ago(5)})
-        self.assertQuerysetContains(response.context['review_list'],
-                                    [review1, review2])
+        assert list(response.context['review_list']) == [review1, review2]
 
         response = self.get(url, params={'date_to': n_days_ago(5)})
-        self.assertQuerysetContains(response.context['review_list'],
-                                    [review3])
+        assert list(response.context['review_list']) == [review3]
 
         response = self.get(url, params={
             'date_from': n_days_ago(12),
             'date_to': n_days_ago(9),
         })
-        self.assertQuerysetContains(response.context['review_list'],
-                                    [review3])
+        assert list(response.context['review_list']) == [review3]
 
     def test_filter_reviews_by_status(self):
         url = reverse('dashboard:reviews-list')


### PR DESCRIPTION
The default ordering for reviews is by score, which is fine when listing reviews for a specific product, but not very useful in the dashboard. This changes so that default dashboard ordering is by date created, most recent first.