### PR TITLE
Fix inflexible product url

### DIFF
--- a/src/oscar/templates/oscar/dashboard/reviews/review_list.html
+++ b/src/oscar/templates/oscar/dashboard/reviews/review_list.html
@@ -70,7 +70,7 @@
                         </td>
                         <td>
                             {% if review.product %}
-                                <a href='{% url 'catalogue:detail' product_slug=review.product.slug pk=review.product.id %}'>{{ review.product.title }}</a> </td>
+                                <a href='{{ review.product.get_absolute_url }}'>{{ review.product.title }}</a> </td>
                         {% else %}
                             {% trans "[Product deleted]" %}
                         {% endif %}


### PR DESCRIPTION
This ensures updating the get_absolute_url in Product model won’t cause issues in dashboard reviews list section.