### PR TITLE
Add get_attribute_values on product model

### DIFF
--- a/docs/source/releases/v3.0.rst
+++ b/docs/source/releases/v3.0.rst
@@ -77,6 +77,8 @@ Minor changes
 
 - Category slugs can now be edited via the dashboard.
 
+- A new method get_attribute_values() was added to the Product model which returns a merged set of attribute values for child and parent products.
+
 Dependency changes
 ~~~~~~~~~~~~~~~~~~
 

--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -599,7 +599,7 @@ class AbstractProduct(models.Model):
         """
         Return a string of all of a product's attributes
         """
-        attributes = self.attribute_values.all()
+        attributes = self.get_attribute_values()
         pairs = [attribute.summary() for attribute in attributes]
         return ", ".join(pairs)
 
@@ -642,6 +642,16 @@ class AbstractProduct(models.Model):
         else:
             return self.categories
     get_categories.short_description = _("Categories")
+
+    def get_attribute_values(self):
+        attribute_values = self.attribute_values.all()
+        if self.is_child:
+            parent_attribute_values = self.parent.attribute_values.exclude(
+                attribute__code__in=attribute_values.values("attribute__code")
+            )
+            return attribute_values | parent_attribute_values
+
+        return attribute_values
 
     # Images
 

--- a/src/oscar/apps/catalogue/product_attributes.py
+++ b/src/oscar/apps/catalogue/product_attributes.py
@@ -41,7 +41,7 @@ class ProductAttributesContainer:
                         {'attr': attribute.code, 'err': e})
 
     def get_values(self):
-        return self.product.attribute_values.all()
+        return self.product.get_attribute_values()
 
     def get_value_by_attribute(self, attribute):
         return self.get_values().get(attribute=attribute)

--- a/src/oscar/apps/shipping/scales.py
+++ b/src/oscar/apps/shipping/scales.py
@@ -14,15 +14,10 @@ class Scale(object):
     def weigh_product(self, product):
         weight = None
         try:
-            weight = product.attribute_values.get(
+            weight = product.get_attribute_values().get(
                 attribute__code=self.attribute).value
         except ObjectDoesNotExist:
-            if product.parent:
-                try:
-                    weight = product.parent.attribute_values.get(
-                        attribute__code=self.attribute).value
-                except ObjectDoesNotExist:
-                    pass
+            pass
 
         if weight is None:
             if self.default_weight is None:

--- a/src/oscar/templates/oscar/catalogue/detail.html
+++ b/src/oscar/templates/oscar/catalogue/detail.html
@@ -138,7 +138,7 @@
                 <td>{{ session.availability.message }}</td>
             </tr>
         {% endif %}
-        {% for av in product.attribute_values.all %}
+        {% for av in product.get_attribute_values %}
             <tr>
                 <th>{{ av.attribute.name }}</th>
                 <td>{{ av.value_as_html }}</td>


### PR DESCRIPTION
This way we also get the parent attribute values (which are not filled out on the child) which solves some weird code in the Scale and also shows it on the frontend.