### PR TITLE
WIP: Add support for Django 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,12 @@ matrix:
       env: TOXENV=py37-django30
     - python: 3.8
       env: TOXENV=py38-django30
+    - python: 3.6
+      env: TOXENV=py36-django31
+    - python: 3.7
+      env: TOXENV=py37-django31
+    - python: 3.8
+      env: TOXENV=py38-django31
 
     - python: 3.7
       env: TOXENV=lint

--- a/docs/source/releases/v3.0.rst
+++ b/docs/source/releases/v3.0.rst
@@ -47,6 +47,11 @@ Backwards incompatible changes
   Projects that have forked the ``partner`` app will need to generate their own migration
   to rename this field.
 
+- The ``annotate_form_field`` template tag will now set the ``widget_type`` in `the format of Django 3.1`_: so no longer
+  ``CheckboxField``, but just ``checkbox``.
+
+.. _`the format of Django 3.1`: https://docs.djangoproject.com/en/3.1/ref/forms/api/#django.forms.BoundField.widget_type
+
 Bug fixes
 ~~~~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ sys.path.append(os.path.join(PROJECT_DIR, 'src'))
 from oscar import get_version  # noqa isort:skip
 
 install_requires = [
-    'django>=2.2,<3.1',
+    'django>=2.2,<3.2',
     # PIL is required for image fields, Pillow is the "friendly" PIL fork
     'pillow>=6.0',
     # We use the ModelFormSetView from django-extra-views for the basket page
@@ -37,7 +37,7 @@ install_requires = [
     # Used for oscar.test.newfactories
     'factory-boy>=2.4.1,<3.0',
     # Used for automatically building larger HTML tables
-    'django-tables2>=2.2,<2.3',
+    'django-tables2>=2.3,<2.4',
     # Used for manipulating form field attributes in templates (eg: add
     # a css class)
     'django-widget-tweaks>=1.4.1',

--- a/src/oscar/apps/payment/forms.py
+++ b/src/oscar/apps/payment/forms.py
@@ -3,6 +3,7 @@ from calendar import monthrange
 from datetime import date
 
 from django import forms
+from django.core import validators
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import gettext_lazy as _
 
@@ -140,10 +141,10 @@ class BankcardExpiryMonthField(BankcardMonthField):
 
     def compress(self, data_list):
         if data_list:
-            if data_list[1] in forms.fields.EMPTY_VALUES:
+            if data_list[1] in validators.EMPTY_VALUES:
                 error = self.error_messages['invalid_year']
                 raise forms.ValidationError(error)
-            if data_list[0] in forms.fields.EMPTY_VALUES:
+            if data_list[0] in validators.EMPTY_VALUES:
                 error = self.error_messages['invalid_month']
                 raise forms.ValidationError(error)
             year = int(data_list[1])
@@ -186,10 +187,10 @@ class BankcardStartingMonthField(BankcardMonthField):
 
     def compress(self, data_list):
         if data_list:
-            if data_list[1] in forms.fields.EMPTY_VALUES:
+            if data_list[1] in validators.EMPTY_VALUES:
                 error = self.error_messages['invalid_year']
                 raise forms.ValidationError(error)
-            if data_list[0] in forms.fields.EMPTY_VALUES:
+            if data_list[0] in validators.EMPTY_VALUES:
                 error = self.error_messages['invalid_month']
                 raise forms.ValidationError(error)
             year = int(data_list[1])

--- a/src/oscar/core/compat.py
+++ b/src/oscar/core/compat.py
@@ -1,5 +1,7 @@
 import csv
+import re
 
+from django import template
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ImproperlyConfigured
@@ -127,3 +129,19 @@ class UnicodeCSVWriter:
     def writerows(self, rows):
         for row in rows:
             self.writerow(row)
+
+
+class FormFieldNode(template.Node):
+    """"
+    Add the widget type to a BoundField. Until 3.1, Django did not make this available by default.
+
+    Used by `oscar.templatetags.form_tags.annotate_form_field`
+    """
+    def __init__(self, field_str):
+        self.field = template.Variable(field_str)
+
+    def render(self, context):
+        field = self.field.resolve(context)
+        if not hasattr(field, 'widget_type') and hasattr(field, 'field'):
+            field.widget_type = re.sub(r'widget$|input$', '', field.field.widget.__class__.__name__.lower())
+        return ''

--- a/src/oscar/templates/oscar/dashboard/partials/form_field.html
+++ b/src/oscar/templates/oscar/dashboard/partials/form_field.html
@@ -14,7 +14,7 @@
         <div class="form-group {% if field.errors %}error{% endif %}">
 
             {% block label %}
-                {% if not nolabel and field.widget_type != 'CheckboxInput' %}
+                {% if not nolabel and field.widget_type != 'checkbox' %}
                     <label for="{{ field.auto_id }}" class="{% if style|default:"stacked" != 'stacked' %}col-sm-4{% endif%} control-label{% if field.field.required %} required{% endif %}">
                         {{ field.label|safe }}
                         {% if field.field.required %} <span>*</span>{% endif %}
@@ -23,14 +23,14 @@
             {% endblock %}
 
             {% block controls %}
-                <div class="{% if style|default:"stacked" != 'stacked' %}col-sm-8{% endif %}{% if field.widget_type == 'CheckboxInput' %} checkbox{% endif %}">
+                <div class="{% if style|default:"stacked" != 'stacked' %}col-sm-8{% endif %}{% if field.widget_type == 'checkbox' %} checkbox{% endif %}">
                     {% block widget %}
-                        {% if field.widget_type == 'CheckboxInput' %}
+                        {% if field.widget_type == 'checkbox' %}
                             <label for="{{ field.auto_id }}" class="checkbox {% if field.field.required %}required{% endif %}">
                                 {% render_field field %}
                                 {{ field.label|safe }}{% if field.field.required %} <span>*</span>{% endif %}
                             </label>
-                        {% elif field.widget_type == 'RadioSelect' %}
+                        {% elif field.widget_type == 'radioselect' %}
                             <label for="{{ field.auto_id }}" class="controls {% if field.field.required %}required{% endif %}">
                             {% render_field field %}
                             </label>

--- a/src/oscar/templates/oscar/partials/form_field.html
+++ b/src/oscar/templates/oscar/partials/form_field.html
@@ -14,7 +14,7 @@
         <div class="form-group {% if field.errors %}has-error{% endif %}">
 
             {% block label %}
-                {% if not nolabel and field.widget_type != 'CheckboxInput' %}
+                {% if not nolabel and field.widget_type != 'checkbox' %}
                     <label for="{{ field.auto_id }}" class="{% if style|default:"stacked" != 'stacked' %}col-sm-4{% endif%} control-label{% if field.field.required %} required{% endif %}">
                         {{ field.label|safe }}
                     </label>
@@ -22,9 +22,9 @@
             {% endblock %}
 
             {% block controls %}
-                <div class="{% if style|default:"stacked" != 'stacked' %}col-sm-7{% endif %}{% if field.widget_type == 'CheckboxInput' %} checkbox{% endif %}">
+                <div class="{% if style|default:"stacked" != 'stacked' %}col-sm-7{% endif %}{% if field.widget_type == 'checkbox' %} checkbox{% endif %}">
                     {% block widget %}
-                        {% if field.widget_type == 'CheckboxInput' %}
+                        {% if field.widget_type == 'checkbox' %}
                             <label for="{{ field.auto_id }}" {% if field.field.required %}class="required"{% endif %}>
                                 {% render_field field %}
                                 {{ field.label|safe }}{% if field.field.required %} <span>*</span>{% endif %}

--- a/src/oscar/templatetags/form_tags.py
+++ b/src/oscar/templatetags/form_tags.py
@@ -1,4 +1,8 @@
+import django
 from django import template
+from django.template.base import TextNode
+
+from oscar.core.compat import FormFieldNode
 
 register = template.Library()
 
@@ -9,21 +13,12 @@ def annotate_form_field(parser, token):
     Set an attribute on a form field with the widget type
 
     This means templates can use the widget type to render things differently
-    if they want to.  Django doesn't make this available by default.
+    if they want to. Until 3.1, Django did not make this available by default.
     """
     args = token.split_contents()
     if len(args) < 2:
         raise template.TemplateSyntaxError(
             "annotate_form_field tag requires a form field to be passed")
-    return FormFieldNode(args[1])
-
-
-class FormFieldNode(template.Node):
-    def __init__(self, field_str):
-        self.field = template.Variable(field_str)
-
-    def render(self, context):
-        field = self.field.resolve(context)
-        if hasattr(field, 'field'):
-            field.widget_type = field.field.widget.__class__.__name__
-        return ''
+    if django.VERSION < (3, 1):
+        return FormFieldNode(args[1])
+    return TextNode('')

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -168,5 +168,7 @@ OSCAR_INITIAL_LINE_STATUS = 'a'
 OSCAR_LINE_STATUS_PIPELINE = {'a': ('b', ), 'b': ()}
 
 SECRET_KEY = 'notverysecret'
+# Deprecated in Django 4.0, then we need to update the hashes to SHA-256 in tests/integration/order/test_models.py
+DEFAULT_HASHING_ALGORITHM = 'sha1'
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 FIXTURE_DIRS = [location('unit/fixtures')]

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ deps =
 basepython = python3.7
 deps =
     -r{toxinidir}/requirements.txt
+allowlist_externals = npm
 commands =
     npm ci
     flake8 src tests setup.py
@@ -32,13 +33,13 @@ basepython = python3.7
 deps =
     -r{toxinidir}/requirements.txt
     django>=2.2,<2.3
-whitelist_externals = make
+allowlist_externals = make
 commands =
     make build_sandbox
 
 [testenv:docs]
 basepython = python3.7
-whitelist_externals = make
+allowlist_externals = make
 changedir = {toxinidir}/docs
 pip_pre = false
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38}-django{22,30}
+    py{36,37,38}-django{22,30,31}
     lint
     sandbox
     docs
@@ -13,7 +13,7 @@ pip_pre = true
 deps =
     django22: django>=2.2,<2.3
     django30: django>=3.0,<3.1
-
+    django31: django>=3.1,<3.2
 
 [testenv:lint]
 basepython = python3.7


### PR DESCRIPTION
`widget_type` was introduced in Django 3.1, with a slightly different syntax. We switch to this new syntax, with a comment in the release notes.

The rest was fixed by updating imports, one dependency, and an extra setting in the tests.

This passes the tests, but it does not fix the new warnings (`RemovedInDjango40Warning`).

TODO: actual testing of the sandbox