### PR TITLE
Include sorl-thumbnail in installation steps for getting started docs.

### DIFF
--- a/docs/source/internals/getting_started.rst
+++ b/docs/source/internals/getting_started.rst
@@ -24,7 +24,7 @@ project:
 .. code-block:: bash
 
     $ mkvirtualenv oscar
-    $ pip install django-oscar
+    $ pip install django-oscar[sorl-thumbnail]
     $ django-admin startproject frobshop
 
 If you do not have :command:`mkvirtualenv`, then replace that line with::
@@ -35,6 +35,12 @@ If you do not have :command:`mkvirtualenv`, then replace that line with::
 
 This will create a folder ``frobshop`` for your project. It is highly
 recommended to install Oscar in a virtualenv.
+
+.. tip::
+
+    ``sorl-thumbnail`` is an optional dependency for image thumbnail, but is what Oscar expects
+    to use by default. It can be replaced with ``easy-thumbnails`` or a custom thumbnail backend. If you want to
+    use a different backend then remember to change the ``OSCAR_THUMBNAILER`` setting to point to it.
 
 .. attention::
 
@@ -119,7 +125,7 @@ depends on. Also set ``SITE_ID``:
         'widget_tweaks',
         'haystack',
         'treebeard',
-        'sorl.thumbnail',
+        'sorl.thumbnail',   # Default thumbnail backend, can be replaced
         'django_tables2',
     ]
 


### PR DESCRIPTION
The getting started documentation does not tell you to install `sorl-thumbnail` or any other thumbnail package - which means that anyone who follows these instructions exactly will get an error when they try to run the server:

```
ModuleNotFoundError: No module named 'sorl'
```

Currently the user has to figure out for themselves what the issue is, which doesn't make for a good beginner experience. This PR changes the instructions to include the `sorl-thumbnail` dependency, which is what Oscar expects by default.

My preference would still be that since sorl is the default, [it should be a required dependency](https://github.com/django-oscar/django-oscar/pull/3027), as the current approach is still confusing to someone who is new to Oscar, make makes it harder to get started. I think it's reasonable for someone to expect that running `pip install django-oscar` will install everything they need to get a working project running - and we're currently failing to meet that expectation.