### PR TITLE
Further cleanups and fixes for dashboard styles.

### DIFF
--- a/src/oscar/static_src/oscar/scss/dashboard/base.scss
+++ b/src/oscar/static_src/oscar/scss/dashboard/base.scss
@@ -14,14 +14,6 @@ h3.app-ico:before {
   display: none;
 }
 
-body {
-  font-size: $body-font-size;
-}
-
-label, input, button, select, textarea {
-  font-size: $body-font-size;
-}
-
 .breadcrumb {
   margin-top: ($spacer * 1.25);
 }
@@ -41,16 +33,11 @@ label, input, button, select, textarea {
 .tabbable.dashboard {
   margin-bottom: $paragraph-margin-bottom;
 
-  .navbar {
-    margin-bottom: 0;
-  }
-
   .tab-content {
-    display: block;
-    width: auto;
     border: 1px solid $gray-200;
     border-top-width: 0;
     padding: 30px;
+    background: $white;
   }
 }
 
@@ -66,20 +53,12 @@ label, input, button, select, textarea {
 
 // SIDE NAV CREATE PAGES
 // ---------------------
-.tab-nav {
-  width: 266px;
-}
-
 .bs-docs-sidenav {
-  padding: 0;
   background-color: $white;
   box-shadow: 0 1px 4px rgba(0, 0, 0, .065);
 }
 
-.bs-docs-sidenav > li > a,
-.bs-docs-sidenav > li > span {
-  display: block;
-  margin: 0;
+.bs-docs-sidenav .nav-link {
   padding: 8px 14px;
   border: 1px solid $gray-200;
   border-top-width: 0;
@@ -95,24 +74,12 @@ label, input, button, select, textarea {
   }
 }
 
-.bs-docs-sidenav > li > span {
-  color: $gray-800;
-}
-
-.bs-docs-sidenav > li > a.active,
-.bs-docs-sidenav > li > span.active {
+.bs-docs-sidenav .nav-link.active {
   font-weight: bold;
   position: relative;
-  color: $link-color;
   background: $gray-200;
   z-index: 2;
   padding: 9px 15px;
-  text-shadow: 0 1px 0 rgba(0, 0, 0, .15);
-
-  &:hover {
-    background: $gray-200;
-    color: $link-color;
-  }
 
   &:after {
     border-bottom: 10px solid transparent;
@@ -164,24 +131,15 @@ label, input, button, select, textarea {
 // RESPONSIVE
 // ----------
 @media (max-width: 1300px) {
-  .tab-nav {
-    width: 200px;
-  }
   .navbar-primary .nav {
     > li a:before {
       display: none;
     }
   }
-  table .btn {
-    padding: 3px 9px;
-    font-size: $font-size-base;
-    line-height: $line-height-base;
-  }
 }
 
 @media (max-width: 979px) {
   .tab-nav {
-    width: 100%;
     margin-bottom: $paragraph-margin-bottom;
   }
 }

--- a/src/oscar/static_src/oscar/scss/dashboard/buttons.scss
+++ b/src/oscar/static_src/oscar/scss/dashboard/buttons.scss
@@ -1,16 +1,5 @@
 // BUTTONS
 // -------
-.btn-group > .btn,
-.btn-group > .dropdown-menu,
-.btn {
-  font-size: $body-font-size;
-  font-family: inherit;
-}
-
-td .btn-toolbar {
-  margin: 0;
-}
-
 .float-left.btn {
   margin-left: 20px;
 }
@@ -38,11 +27,5 @@ td .btn-toolbar {
 
   .form-group {
     margin: 0;
-  }
-}
-
-@media (max-width: 1300px) {
-  table .btn {
-    font-size: $body-font-size;
   }
 }

--- a/src/oscar/static_src/oscar/scss/dashboard/forms.scss
+++ b/src/oscar/static_src/oscar/scss/dashboard/forms.scss
@@ -1,6 +1,12 @@
 // FORM CHANGES
 // ------------
 
+.col-form-label.required:after {
+  color: $red;
+  content: "*";
+  display: inline-block;
+}
+
 .form-inline {
   select {
     min-width: 200px;

--- a/src/oscar/static_src/oscar/scss/dashboard/index.scss
+++ b/src/oscar/static_src/oscar/scss/dashboard/index.scss
@@ -9,8 +9,7 @@
     text-align: center;
     top: 0;
 
-    h1 {
-      font-size: $h2-font-size;
+    h2 {
       color: $gray-900;
       font-weight: bold;
       text-transform: uppercase;
@@ -103,15 +102,12 @@
     display: block;
     margin-bottom: 15px;
     padding: 12px;
-    color: $gray-500;
-    font-size: $body-font-size;
+    color: $gray-900;
 
     span {
       display: inline-block;
       font-weight: bold;
       width: 30%;
-      font-size: $font-size-base;
-      color: $gray-900;
     }
 
     i {
@@ -121,4 +117,3 @@
     }
   }
 }
-

--- a/src/oscar/static_src/oscar/scss/dashboard/navbar.scss
+++ b/src/oscar/static_src/oscar/scss/dashboard/navbar.scss
@@ -1,13 +1,6 @@
 // Navigation bar
 
 .navbar {
-  margin-bottom: 0;
-
-  .nav > li span {
-    display: block;
-    padding: $navbar-brand-padding-y;
-  }
-
   &.navbar-accounts,
   &.navbar-primary {
     padding: 0;
@@ -53,10 +46,6 @@
       border-top: 1px solid $gray-700;
     }
 
-    .navbar-brand {
-      margin-right: 0;
-    }
-
     .navbar-nav {
       .nav-link {
         padding: 0.75rem 1rem;
@@ -73,8 +62,4 @@
       }
     }
   }
-}
-
-.dropdown-menu {
-  font-size: $body-font-size;
 }

--- a/src/oscar/static_src/oscar/scss/dashboard/tables.scss
+++ b/src/oscar/static_src/oscar/scss/dashboard/tables.scss
@@ -23,12 +23,8 @@
 
 caption,
 .table-header {
-  @include clearfix();
-
   h2, h3 {
     font-weight: bold;
-    font-size: $font-size-sm;
-    line-height: normal;
     margin: 0;
 
     > i {
@@ -37,8 +33,6 @@ caption,
   }
 
   font-weight: bold;
-  font-size: $font-size-sm;
-  margin-bottom: 0;
   border: 1px solid $gray-400;
   border-bottom: none;
   color: $gray-900;

--- a/src/oscar/static_src/oscar/scss/dashboard/variables.scss
+++ b/src/oscar/static_src/oscar/scss/dashboard/variables.scss
@@ -1,19 +1,17 @@
 // Overridden Bootstrap4 variables
 // -------------------------------
 
-$font-size-base:              1rem; // The value copied from Bootstrap (assumes the browser default, typically `16px`)
+$font-size-base:              0.8rem;
 
-$h1-font-size:                $font-size-base * 1.875;  // 30px
-$h2-font-size:                $font-size-base * 1.125;  // 18px
-$h3-font-size:                $font-size-base * 1.25;   // 20px
+$h1-font-size:                $font-size-base * 1.875;
+$h2-font-size:                $font-size-base * 1.25;
+$h3-font-size:                $font-size-base * 1.125;
 
 
 // Custom variables
 // ----------------
 
 $font-family-icons:           "Font Awesome 5 Free";
-
-$body-font-size:              $font-size-base * 0.75;   // 12px
 
 $navbar-padding-vertical:     14px;
 

--- a/src/oscar/templates/oscar/dashboard/catalogue/attribute_option_group_form.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/attribute_option_group_form.html
@@ -49,12 +49,10 @@
                         <div class="table-header">
                             <h3>{% trans "Sections" %}</h3>
                         </div>
-                        <ul class="nav nav-list bs-docs-sidenav" id="attribute_option_group_update_tabs">
-
+                        <ul class="nav flex-column bs-docs-sidenav" id="attribute_option_group_update_tabs">
                             {% block tabs %}
-                                <li class="active"><a href="#attribute_option_group_details" data-toggle="tab">{% trans 'Attribute Option Group details' %}</a></li>
-                                <li><a href="#attribute_options" data-toggle="tab">{% trans 'Attribute Options' %}</a></li>
-
+                                <li class="nav-item"><a class="nav-link active" href="#attribute_option_group_details" data-toggle="tab">{% trans 'Attribute Option Group details' %}</a></li>
+                                <li class="nav-item"><a class="nav-link" href="#attribute_options" data-toggle="tab">{% trans 'Attribute Options' %}</a></li>
                             {% endblock tabs %}
                         </ul>
                     </div>
@@ -140,7 +138,7 @@
                             {% trans "Cancel" %}
                         </a>
                         {% trans "or" %}
-                        <button class="btn btn-lg btn-primary" type="submit">
+                        <button class="btn btn-primary" type="submit">
                             {% trans "Save" %}
                         </button>
                     </div>

--- a/src/oscar/templates/oscar/dashboard/catalogue/attribute_option_group_list.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/attribute_option_group_list.html
@@ -17,7 +17,7 @@
 
 {% block header %}
     <div class="page-header">
-        <a href="{% url 'dashboard:catalogue-attribute-option-group-create' %}?{{ querystring }}" class="btn btn-primary btn-lg float-right">
+        <a href="{% url 'dashboard:catalogue-attribute-option-group-create' %}?{{ querystring }}" class="btn btn-primary float-right">
             <i class="fas fa-plus-circle"></i> {% trans "Create new Attribute Option Group" %}
         </a>
         <h1>{% trans "Attribute Option Group" %}</h1>

--- a/src/oscar/templates/oscar/dashboard/catalogue/category_form.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/category_form.html
@@ -108,15 +108,15 @@
                             {% trans "Cancel" %}
                         </a>
                         {% trans "or" %}
-                        <button class="btn btn-secondary btn-lg" name="action" type="submit" value="continue" data-loading-text="{% trans 'Saving...' %}">
+                        <button class="btn btn-secondary" name="action" type="submit" value="continue" data-loading-text="{% trans 'Saving...' %}">
                             {% trans "Save and continue editing" %}
                         </button>
-                        <button class="btn btn-primary btn-lg" name="action" type="submit" value="save" data-loading-text="{% trans 'Saving...' %}">
+                        <button class="btn btn-primary" name="action" type="submit" value="save" data-loading-text="{% trans 'Saving...' %}">
                             {% trans "Save" %}
                         </button>
                     </div>
                     {% if category %}
-                        <a class="btn btn-success btn-lg" href="{{ category.get_absolute_url }}">{% trans "View on site" %}</a>
+                        <a class="btn btn-success" href="{{ category.get_absolute_url }}">{% trans "View on site" %}</a>
                     {% endif %}
                 </div>
             </div>

--- a/src/oscar/templates/oscar/dashboard/catalogue/category_list.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/category_list.html
@@ -24,7 +24,7 @@
 
 {% block header %}
     <div class="page-header">
-        <a href="{% url 'dashboard:catalogue-category-create' %}" class="btn btn-primary btn-lg float-right"><i class="fas fa-plus-circle"></i> {% trans "Create new category" %}</a>
+        <a href="{% url 'dashboard:catalogue-category-create' %}" class="btn btn-primary float-right"><i class="fas fa-plus-circle"></i> {% trans "Create new category" %}</a>
         <h1>{% trans "Categories" %}</h1>
     </div>
 {% endblock header %}

--- a/src/oscar/templates/oscar/dashboard/catalogue/option_form.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/option_form.html
@@ -86,7 +86,7 @@
                             {% trans "Cancel" %}
                         </a>
                         {% trans "or" %}
-                        <button class="btn btn-lg btn-primary" type="submit">
+                        <button class="btn btn-primary" type="submit">
                             {% trans "Save" %}
                         </button>
                     </div>

--- a/src/oscar/templates/oscar/dashboard/catalogue/option_list.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/option_list.html
@@ -17,7 +17,7 @@
 
 {% block header %}
     <div class="page-header">
-        <a href="{% url 'dashboard:catalogue-option-create' %}" class="btn btn-primary btn-lg float-right"><i class="fas fa-plus-circle"></i> {% trans "Create new Option" %}</a>
+        <a href="{% url 'dashboard:catalogue-option-create' %}" class="btn btn-primary float-right"><i class="fas fa-plus-circle"></i> {% trans "Create new Option" %}</a>
         <h1>{% trans "Option" %}</h1>
     </div>
 {% endblock header %}

--- a/src/oscar/templates/oscar/dashboard/catalogue/product_class_form.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/product_class_form.html
@@ -139,7 +139,7 @@
                             {% trans "Cancel" %}
                         </a>
                         {% trans "or" %}
-                        <button class="btn btn-lg btn-primary" type="submit">
+                        <button class="btn btn-primary" type="submit">
                             {% trans "Save" %}
                         </button>
                     </div>

--- a/src/oscar/templates/oscar/dashboard/catalogue/product_class_list.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/product_class_list.html
@@ -12,7 +12,7 @@
 
 {% block header %}
     <div class="page-header">
-        <a href="{% url 'dashboard:catalogue-class-create' %}" class="btn btn-primary btn-lg float-right">
+        <a href="{% url 'dashboard:catalogue-class-create' %}" class="btn btn-primary float-right">
             <i class="fas fa-plus-circle"></i> {% trans "Create new product type" %}</a>
         <h1>{% trans "Product types" %}</h1>
     </div>

--- a/src/oscar/templates/oscar/dashboard/catalogue/product_update.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/product_update.html
@@ -18,7 +18,7 @@
                 <a href="{% url 'dashboard:catalogue-product-list' %}">{% trans "Products" %}</a>
             </li>
             {% if parent %}
-                <li>
+                <li class="breadcrumb-item">
                     <a href="{% url 'dashboard:catalogue-product' parent.id %}">{{ parent.title }}</a>
                 </li>
             {% endif %}
@@ -111,7 +111,11 @@
                                         </a>
                                     </li>
                                 {% endif %}
-                                <li><a href="#seo" data-toggle="tab">{% trans 'Search engine optimisation' %}</a></li>
+                                <li class="nav-item">
+                                    <a class="nav-link" href="#seo" data-toggle="tab">
+                                        {% trans 'Search engine optimisation' %}
+                                    </a>
+                                </li>
                             {% endblock tabs %}
                         </ul>
                     </div>
@@ -369,19 +373,19 @@
                         </a>
                         {% trans "or" %}
                         {% if parent %}
-                            <button class="btn btn-secondary btn-lg" name="action" type="submit" value="create-another-child" data-loading-text="{% trans 'Saving...' %}">
+                            <button class="btn btn-secondary" name="action" type="submit" value="create-another-child" data-loading-text="{% trans 'Saving...' %}">
                                 {% trans "Save and add another variant" %}
                             </button>
                         {% endif %}
-                        <button class="btn btn-secondary btn-lg" name="action" type="submit" value="continue" data-loading-text="{% trans 'Saving...' %}">
+                        <button class="btn btn-secondary" name="action" type="submit" value="continue" data-loading-text="{% trans 'Saving...' %}">
                             {% trans "Save and continue editing" %}
                         </button>
-                        <button class="btn btn-primary btn-lg" name="action" type="submit" value="save" data-loading-text="{% trans 'Saving...' %}">
+                        <button class="btn btn-primary" name="action" type="submit" value="save" data-loading-text="{% trans 'Saving...' %}">
                             {% trans "Save" %}
                         </button>
                     </div>
                     {% if product %}
-                        <a class="btn btn-success btn-lg" href="{{ product.get_absolute_url }}">{% trans "View on site" %}</a>
+                        <a class="btn btn-success" href="{{ product.get_absolute_url }}">{% trans "View on site" %}</a>
                     {% endif %}
                 </div>
             </div>

--- a/src/oscar/templates/oscar/dashboard/catalogue/product_update.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/product_update.html
@@ -349,7 +349,6 @@
                                 </div>
                                 <div class="card card-body">
                                     {% block seo_content %}
-                                        <span class="error-block">{{ form.non_field_errors }}</span>
                                         {% for field in form.seo_form_fields %}
                                             {% if 'attr' not in field.id_for_label %}
                                                 {% include 'oscar/dashboard/partials/form_field.html' with field=field %}

--- a/src/oscar/templates/oscar/dashboard/comms/detail.html
+++ b/src/oscar/templates/oscar/dashboard/comms/detail.html
@@ -26,8 +26,6 @@
 
 
 {% block dashboard_content %}
-
-
     <form method="post" class="form-stacked">
         <div class="tabbable dashboard">
             {% if preview %}
@@ -75,7 +73,7 @@
                         <p>{% trans "View a preview of this email using order:" %}</p>
                         {% include 'oscar/dashboard/partials/form_field.html' with field=form.preview_order_number %}
                     {% endif %}
-                    <button type="submit" class="btn btn-primary btn-lg" name="show_preview" data-loading-text="{% trans 'Submitting...' %}">{% trans "View preview" %}</button>
+                    <button type="submit" class="btn btn-primary" name="show_preview" data-loading-text="{% trans 'Submitting...' %}">{% trans "View preview" %}</button>
                     <p>{% trans "or send a preview to:" %}</p>
                     {% include 'oscar/dashboard/partials/form_field.html' with field=form.preview_email %}
                     <button type="submit" class="btn btn-secondary" name="send_preview" data-loading-text="{% trans 'Sending...' %}">{% trans "Send preview email" %}</button>
@@ -100,7 +98,7 @@
                     </table>
                 </div>
                 <div class="form-actions">
-                    <button type="submit" class="btn btn-primary btn-lg" data-loading-text="{% trans 'Saving...' %}">{% trans "Save" %}</button>
+                    <button type="submit" class="btn btn-primary" data-loading-text="{% trans 'Saving...' %}">{% trans "Save" %}</button>
                     {% trans "or" %} <a href="{% url 'dashboard:comms-list' %}">{% trans "cancel" %}</a>.
                 </div>
             </div>

--- a/src/oscar/templates/oscar/dashboard/index.html
+++ b/src/oscar/templates/oscar/dashboard/index.html
@@ -32,7 +32,7 @@
         </aside>
         <div class="col-md-9">
             <div id="order_graph">
-                <div class="bar-caption"><h1>{% trans "Latest Orders (last 24 hours)" %}</h1></div>
+                <div class="bar-caption"><h2>{% trans "Latest Orders (last 24 hours)" %}</h2></div>
                 <div class="bar-y-axis">
                     <ul>
                     {% for y_value in hourly_report_dict.y_range %}

--- a/src/oscar/templates/oscar/dashboard/layout.html
+++ b/src/oscar/templates/oscar/dashboard/layout.html
@@ -53,7 +53,6 @@
     {% block dashboard_nav %}
         {% dashboard_navigation user as nav_items %}
         <nav class="navbar navbar-expand-lg navbar-dark bg-dark navbar-primary">
-            <a class="navbar-brand" href="#"></a>
             <button class="navbar-toggler float-right" type="button" data-toggle="collapse" data-target="#bottom_nav_bar" aria-controls="bottom_nav_bar" aria-expanded="false" aria-label="Toggle navigation">
                 <i class="fas fa-bars"></i>
             </button>

--- a/src/oscar/templates/oscar/dashboard/offers/offer_delete.html
+++ b/src/oscar/templates/oscar/dashboard/offers/offer_delete.html
@@ -27,7 +27,7 @@
         {% csrf_token %}
         <p>{% trans "Are you sure you want to delete this offer?" %}</p>
         <div class="form-actions">
-            <button class="btn btn-lg btn-danger" type="submit" data-loading-text="{% trans 'Deleting...' %}">{% trans "Delete" %}</button> {% trans "or" %}
+            <button class="btn btn-danger" type="submit" data-loading-text="{% trans 'Deleting...' %}">{% trans "Delete" %}</button> {% trans "or" %}
             <a href="{% url 'dashboard:offer-list' %}">{% trans "cancel" %}</a>
         </div>
     </form>

--- a/src/oscar/templates/oscar/dashboard/offers/offer_list.html
+++ b/src/oscar/templates/oscar/dashboard/offers/offer_list.html
@@ -19,7 +19,7 @@
 
 {% block header %}
     <div class="page-header">
-        <a href="{% url 'dashboard:offer-metadata' %}" class="btn btn-primary btn-lg float-right"><i class="fas fa-plus-circle"></i> {% trans "Create new offer" %}</a>
+        <a href="{% url 'dashboard:offer-metadata' %}" class="btn btn-primary float-right"><i class="fas fa-plus-circle"></i> {% trans "Create new offer" %}</a>
         <h1>{% trans "Offers" %}</h1>
     </div>
 {% endblock header %}

--- a/src/oscar/templates/oscar/dashboard/offers/progress.html
+++ b/src/oscar/templates/oscar/dashboard/offers/progress.html
@@ -11,9 +11,9 @@
                 {% trans "1. Name and description" %}
             </a>
             {% else %}
-            <span class="{% if step == 1 %}active{% else %}disabled{% endif %}">
+            <a class="nav-link {% if step == 1 %}active{% else %}disabled text-reset{% endif %}">
                 {% trans "1. Name and description" %}
-            </span>
+            </a>
             {% endif %}
         </li>
         <li class="nav-item step2">
@@ -22,9 +22,9 @@
                 {% trans "2. Incentive" %}
             </a>
             {% else %}
-            <span class="{% if step == 2 %}active{% else %}disabled{% endif %}">
+            <a class="nav-link {% if step == 2 %}active{% else %}disabled text-reset{% endif %}">
                 {% trans "2. Incentive" %}
-            </span>
+            </a>
             {% endif %}
         </li>
         <li class="nav-item step3">
@@ -33,15 +33,15 @@
                 {% trans "3. Condition" %}
             </a>
             {% else %}
-            <span class="{% if step == 3 %}active{% else %}disabled{% endif %}">
+            <a class="nav-link {% if step == 3 %}active{% else %}disabled text-reset{% endif %}">
                 {% trans "3. Condition" %}
-            </span>
+            </a>
             {% endif %}
         </li>
         <li class="nav-item step4">
-            <span class="{% if step == 4 %}active{% else %}disabled{% endif %}">
+            <a class="nav-link {% if step == 4 %}active{% else %}disabled text-reset{% endif %}">
                 {% trans "4. Restrictions" %}
-            </span>
+            </a>
         </li>
     </ul>
 </div>

--- a/src/oscar/templates/oscar/dashboard/offers/step_form.html
+++ b/src/oscar/templates/oscar/dashboard/offers/step_form.html
@@ -54,7 +54,6 @@
                 </div>
                 <div class="card card-body">
                     {% csrf_token %}
-                    <p>{% trans "Fields marked with * are mandatory." %}</p>
                     {% block form_fields %}
                         {% include "oscar/dashboard/partials/form_fields.html" with form=form %}
                     {% endblock %}

--- a/src/oscar/templates/oscar/dashboard/pages/index.html
+++ b/src/oscar/templates/oscar/dashboard/pages/index.html
@@ -19,7 +19,7 @@
 
 {% block header %}
     <div class="page-header">
-        <a href="{% url 'dashboard:page-create' %}" class="btn btn-primary btn-lg float-right">
+        <a href="{% url 'dashboard:page-create' %}" class="btn btn-primary float-right">
             <i class="fas fa-plus-circle"></i> {% trans "Create new page" %}
         </a>
         <h1>{% trans "Pages" %}</h1>

--- a/src/oscar/templates/oscar/dashboard/pages/update.html
+++ b/src/oscar/templates/oscar/dashboard/pages/update.html
@@ -30,7 +30,7 @@
     {% csrf_token %}
     {% include 'oscar/dashboard/partials/form_fields.html' with form=form %}
     <div class="form-actions">
-        <button class="btn btn-lg btn-primary" type="submit" data-loading-text="{% trans 'Saving...' %}">{% trans "Save" %}</button>
+        <button class="btn btn-primary" type="submit" data-loading-text="{% trans 'Saving...' %}">{% trans "Save" %}</button>
         {% trans "or" %} <a href="{% url 'dashboard:page-list' %}">{% trans "cancel" %}</a>.
     </div>
 </form>

--- a/src/oscar/templates/oscar/dashboard/partials/form.html
+++ b/src/oscar/templates/oscar/dashboard/partials/form.html
@@ -7,8 +7,7 @@
     {% if not method == "get" %}{% csrf_token %}{% endif %}
     {% include 'oscar/dashboard/partials/form_fields.html' %}
     <div class="form-group form-actions">
-        <button class="btn btn-lg btn-primary" type="submit" data-loading-text="{% trans 'Saving...' %}">{% trans "Save" %}</button>
+        <button class="btn btn-primary" type="submit" data-loading-text="{% trans 'Saving...' %}">{% trans "Save" %}</button>
         {% trans "or" %} <a href="#" onclick="window.history.go(-1);return false" >{% trans "cancel" %}</a>.
     </div>
 </form>
-

--- a/src/oscar/templates/oscar/dashboard/partners/partner_delete.html
+++ b/src/oscar/templates/oscar/dashboard/partners/partner_delete.html
@@ -27,7 +27,7 @@
         {% csrf_token %}
         <p>{% trans "Are you sure you want to delete this partner?" %}</p>
         <div class="form-actions">
-            <button class="btn btn-lg btn-danger" type="submit" data-loading-text="{% trans 'Deleting...' %}">{% trans "Delete" %}</button> {% trans "or" %}
+            <button class="btn btn-danger" type="submit" data-loading-text="{% trans 'Deleting...' %}">{% trans "Delete" %}</button> {% trans "or" %}
             <a href="{% url 'dashboard:partner-list' %}">{% trans "cancel" %}</a>
         </div>
     </form>

--- a/src/oscar/templates/oscar/dashboard/partners/partner_list.html
+++ b/src/oscar/templates/oscar/dashboard/partners/partner_list.html
@@ -17,7 +17,7 @@
 
 {% block header %}
     <div class="page-header">
-        <a href="{% url 'dashboard:partner-create' %}" class="btn btn-lg btn-primary float-right"><i class="fas fa-plus-circle"></i> {% trans "Create new partner" %}</a>
+        <a href="{% url 'dashboard:partner-create' %}" class="btn btn-primary float-right"><i class="fas fa-plus-circle"></i> {% trans "Create new partner" %}</a>
         <h1>{% trans "Partners" %}</h1>
     </div>
 {% endblock header %}

--- a/src/oscar/templates/oscar/dashboard/partners/partner_user_form.html
+++ b/src/oscar/templates/oscar/dashboard/partners/partner_user_form.html
@@ -30,7 +30,7 @@
         {% csrf_token %}
         {% include 'oscar/dashboard/partials/form_fields.html' with form=form %}
         <div class="form-actions">
-            <button class="btn btn-lg btn-primary" type="submit" data-loading-text="{% trans 'Saving...' %}">{% trans "Save" %}</button>
+            <button class="btn btn-primary" type="submit" data-loading-text="{% trans 'Saving...' %}">{% trans "Save" %}</button>
             {% trans "or" %} <a href="{% url 'dashboard:partner-manage' pk=partner.pk %}">{% trans "cancel" %}</a>.
         </div>
     </form>

--- a/src/oscar/templates/oscar/dashboard/partners/partner_user_list.html
+++ b/src/oscar/templates/oscar/dashboard/partners/partner_user_list.html
@@ -18,7 +18,7 @@
 {% block header %}
     <div class="page-header">
         <div class="btn-group float-right">
-            <a class="btn btn-lg btn-primary dropdown-toggle" data-toggle="dropdown" href="#">
+            <a class="btn btn-primary dropdown-toggle" data-toggle="dropdown" href="#">
                 <i class="fas fa-plus-circle"></i>
                 {% trans 'Link a user' %}
             </a>

--- a/src/oscar/templates/oscar/dashboard/ranges/range_form.html
+++ b/src/oscar/templates/oscar/dashboard/ranges/range_form.html
@@ -33,9 +33,9 @@
         {% include "oscar/dashboard/partials/form_fields.html" with form=form %}
         {% block form_actions %}
             <div class="form-actions">
-                <button class="btn btn-primary btn-lg" type="submit" data-loading-text="{% trans 'Saving...' %}">{% trans "Save" %}</button> {% trans "or" %}
+                <button class="btn btn-primary" type="submit" data-loading-text="{% trans 'Saving...' %}">{% trans "Save" %}</button> {% trans "or" %}
                 {# This is an input so we distinguish between which button was pressed #}
-                <input class="btn btn-primary btn-lg" type="submit" name="action" value="{% trans "Save and edit products" %}"/>
+                <input class="btn btn-primary" type="submit" name="action" value="{% trans "Save and edit products" %}"/>
                 {% trans "or" %}
                 <a href="{% url 'dashboard:range-list' %}">{% trans "cancel" %}</a>
             </div>

--- a/src/oscar/templates/oscar/dashboard/ranges/range_list.html
+++ b/src/oscar/templates/oscar/dashboard/ranges/range_list.html
@@ -16,7 +16,7 @@
 
 {% block header %}
     <div class="page-header">
-        <a href="{% url 'dashboard:range-create' %}" class="btn btn-primary btn-lg float-right"><i class="fas fa-plus-circle"></i> {% trans "Create new range" %}</a>
+        <a href="{% url 'dashboard:range-create' %}" class="btn btn-primary float-right"><i class="fas fa-plus-circle"></i> {% trans "Create new range" %}</a>
         <h1>{% trans "Ranges" %}</h1>
     </div>
 {% endblock header %}

--- a/src/oscar/templates/oscar/dashboard/ranges/range_product_list.html
+++ b/src/oscar/templates/oscar/dashboard/ranges/range_product_list.html
@@ -134,7 +134,7 @@
     </div>
         {% endif %}
         <div class="form-actions">
-            <a href="{% url 'dashboard:range-update' pk=range.id %}" class="btn btn-lg btn-primary">{% trans "Edit range" %}</a> {% trans "or" %}
+            <a href="{% url 'dashboard:range-update' pk=range.id %}" class="btn btn-primary">{% trans "Edit range" %}</a> {% trans "or" %}
             <a href="{% url 'dashboard:range-list' %}" class="">{% trans "return to range list" %}</a>
         </div>
 

--- a/src/oscar/templates/oscar/dashboard/reviews/review_update.html
+++ b/src/oscar/templates/oscar/dashboard/reviews/review_update.html
@@ -74,7 +74,7 @@
                 {% endfor %}
             </div>
             <div class="form-actions">
-                <button class="btn btn-primary btn-lg" type="submit" data-loading-text="{% trans 'Saving...' %}">{% trans "Save" %}</button> {% trans "or" %}
+                <button class="btn btn-primary" type="submit" data-loading-text="{% trans 'Saving...' %}">{% trans "Save" %}</button> {% trans "or" %}
                 <a href="{% url 'dashboard:reviews-list' %}">{% trans "cancel" %}</a>
             </div>
         </div>

--- a/src/oscar/templates/oscar/dashboard/shipping/weight_band_form.html
+++ b/src/oscar/templates/oscar/dashboard/shipping/weight_band_form.html
@@ -30,7 +30,7 @@
             {% include "oscar/dashboard/partials/form_fields.html" with form=form %}
             {% block form_actions %}
                 <div class="form-actions">
-                    <button class="btn btn-primary btn-lg" type="submit" data-loading-text="{% trans 'Saving...' %}">{% trans "Save" %}</button> {% trans "or" %}
+                    <button class="btn btn-primary" type="submit" data-loading-text="{% trans 'Saving...' %}">{% trans "Save" %}</button> {% trans "or" %}
                     <a href="{% url 'dashboard:shipping-method-list' %}">{% trans "cancel" %}</a>
                 </div>
             {% endblock form_actions %}

--- a/src/oscar/templates/oscar/dashboard/shipping/weight_based_form.html
+++ b/src/oscar/templates/oscar/dashboard/shipping/weight_based_form.html
@@ -40,7 +40,7 @@
         {% include "oscar/dashboard/partials/form_fields.html" with form=form %}
         {% block form_actions %}
             <div class="form-actions">
-                <button class="btn btn-primary btn-lg" type="submit" data-loading-text="{% trans 'Saving...' %}">{% trans "Save" %}</button> {% trans "or" %}
+                <button class="btn btn-primary" type="submit" data-loading-text="{% trans 'Saving...' %}">{% trans "Save" %}</button> {% trans "or" %}
                 <a href="{% url 'dashboard:shipping-method-list' %}">{% trans "cancel" %}</a>
             </div>
         {% endblock form_actions %}

--- a/src/oscar/templates/oscar/dashboard/shipping/weight_based_list.html
+++ b/src/oscar/templates/oscar/dashboard/shipping/weight_based_list.html
@@ -17,7 +17,7 @@
 
 {% block header %}
     <div class="page-header">
-        <a id="create_new_shipping_method" href="{% url 'dashboard:shipping-method-create' %}" class="btn btn-primary btn-lg float-right"><i class="fas fa-plus-circle"></i> {% trans "Create new shipping charge" %}</a>
+        <a id="create_new_shipping_method" href="{% url 'dashboard:shipping-method-create' %}" class="btn btn-primary float-right"><i class="fas fa-plus-circle"></i> {% trans "Create new shipping charge" %}</a>
         <h1>{% trans "Shipping methods" %}</h1>
     </div>
 {% endblock header %}

--- a/src/oscar/templates/oscar/dashboard/users/alerts/delete.html
+++ b/src/oscar/templates/oscar/dashboard/users/alerts/delete.html
@@ -32,7 +32,7 @@
             {% csrf_token %}
             <div class="form-actions">
                 <p>{% trans "Are you sure that you want to delete this alert?" %}</p>
-                <button type='submit' class="btn btn-lg btn-danger" data-loading-text="{% trans 'Deleting...' %}">{% trans "Delete" %}</button> {% trans "or" %}
+                <button type='submit' class="btn btn-danger" data-loading-text="{% trans 'Deleting...' %}">{% trans "Delete" %}</button> {% trans "or" %}
                 <a href="{% url 'dashboard:user-alert-list' %}">{% trans "cancel" %}</a>
             </div>
         </form>

--- a/src/oscar/templates/oscar/dashboard/users/detail.html
+++ b/src/oscar/templates/oscar/dashboard/users/detail.html
@@ -86,7 +86,7 @@
                             <td>
                                 <form id="password_reset_form" action="{% url 'dashboard:user-password-reset' pk=customer.id %}" method="post">
                                     {% csrf_token %}
-                                    <button type="submit" class="btn btn-primary btn-lg" data-loading-text="{% trans 'Sending...' %}">{% trans 'Send password reset email' %}</button>
+                                    <button type="submit" class="btn btn-primary" data-loading-text="{% trans 'Sending...' %}">{% trans 'Send password reset email' %}</button>
                                 </form>
                             </td>
                         </tr>

--- a/src/oscar/templates/oscar/dashboard/vouchers/voucher_delete.html
+++ b/src/oscar/templates/oscar/dashboard/vouchers/voucher_delete.html
@@ -41,7 +41,7 @@
         <form method="post">
             {% csrf_token %}
             <div class="form-actions">
-                <button class="btn btn-danger btn-lg" type="submit" data-loading-text="{% trans 'Deleting...' %}">{% trans "Delete" %}</button> {% trans "or" %}
+                <button class="btn btn-danger" type="submit" data-loading-text="{% trans 'Deleting...' %}">{% trans "Delete" %}</button> {% trans "or" %}
                 <a href="{% url 'dashboard:voucher-list' %}">{% trans "cancel" %}</a>
             </div>
         </form>

--- a/src/oscar/templates/oscar/dashboard/vouchers/voucher_form.html
+++ b/src/oscar/templates/oscar/dashboard/vouchers/voucher_form.html
@@ -38,7 +38,7 @@
         {% include "oscar/dashboard/partials/form_fields.html" with form=form %}
         {% block form_actions %}
             <div class="form-actions">
-                <button class="btn btn-primary btn-lg" type="submit" data-loading-text="{% trans 'Saving...' %}">{% trans "Save" %}</button> {% trans "or" %}
+                <button class="btn btn-primary" type="submit" data-loading-text="{% trans 'Saving...' %}">{% trans "Save" %}</button> {% trans "or" %}
                 <a href="{% url 'dashboard:voucher-list' %}">{% trans "cancel" %}</a>
             </div>
         {% endblock form_actions %}

--- a/src/oscar/templates/oscar/dashboard/vouchers/voucher_list.html
+++ b/src/oscar/templates/oscar/dashboard/vouchers/voucher_list.html
@@ -21,7 +21,7 @@
 
 {% block header %}
     <div class="page-header">
-        <a href="{% url 'dashboard:voucher-create' %}" class="btn btn-primary btn-lg float-right"><i class="fas fa-plus-circle"></i> {% trans "Create new voucher" %}</a>
+        <a href="{% url 'dashboard:voucher-create' %}" class="btn btn-primary float-right"><i class="fas fa-plus-circle"></i> {% trans "Create new voucher" %}</a>
         <h1>{% trans "Vouchers" %}</h1>
     </div>
 {% endblock header %}

--- a/src/oscar/templates/oscar/dashboard/vouchers/voucher_set_detail.html
+++ b/src/oscar/templates/oscar/dashboard/vouchers/voucher_set_detail.html
@@ -20,10 +20,10 @@
 {% block header %}
 <div class="page-header">
     <div class="float-right">
-        <a href="{% url 'dashboard:voucher-set-update' pk=voucher_set.pk %}" class="btn btn-primary btn-lg ">
+        <a href="{% url 'dashboard:voucher-set-update' pk=voucher_set.pk %}" class="btn btn-primary">
             <i class="fas fa-plus-circle"></i> {% trans "Update voucher set" %}
         </a>
-        <a href="{% url 'dashboard:voucher-set-download' pk=voucher_set.pk %}" class="btn btn-primary btn-lg ">
+        <a href="{% url 'dashboard:voucher-set-download' pk=voucher_set.pk %}" class="btn btn-primary">
             <i class="fas fa-plus-circle"></i> {% trans "Download CSV" %}
         </a>
     </div>

--- a/src/oscar/templates/oscar/dashboard/vouchers/voucher_set_form.html
+++ b/src/oscar/templates/oscar/dashboard/vouchers/voucher_set_form.html
@@ -38,7 +38,7 @@
         {% include "oscar/dashboard/partials/form_fields.html" with form=form %}
         {% block form_actions %}
             <div class="form-actions">
-                <button class="btn btn-primary btn-lg" type="submit">{% trans "Save" %}</button> {% trans "or" %}
+                <button class="btn btn-primary" type="submit">{% trans "Save" %}</button> {% trans "or" %}
                 <a href="{% url 'dashboard:voucher-set-list' %}">{% trans "cancel" %}</a>
             </div>
         {% endblock form_actions %}

--- a/src/oscar/templates/oscar/dashboard/vouchers/voucher_set_list.html
+++ b/src/oscar/templates/oscar/dashboard/vouchers/voucher_set_list.html
@@ -18,7 +18,7 @@
 
 {% block header %}
 <div class="page-header">
-    <a href="{% url 'dashboard:voucher-set-create' %}" class="btn btn-primary btn-lg float-right"><i class="fas fa-plus-circle"></i> {% trans "Create new voucher set" %}</a>
+    <a href="{% url 'dashboard:voucher-set-create' %}" class="btn btn-primary float-right"><i class="fas fa-plus-circle"></i> {% trans "Create new voucher set" %}</a>
     <h1>{% trans "Voucher sets" %}</h1>
 </div>
 {% endblock header %}


### PR DESCRIPTION
- Remove unnecessary CSS in favour of Bootstrap defaults (also remove some completely unused CSS).
- Remove use of `btn-lg` in the dashboard, whose presentation was being overridden in CSS to make it look like a normal button anyway.
- Fix a few classes on HTML elements.