### PR TITLE
Replace Bootstrap 3 stateful button handling with custom JS for loading state.

### DIFF
--- a/src/oscar/static_src/oscar/js/oscar/dashboard.js
+++ b/src/oscar/static_src/oscar/js/oscar/dashboard.js
@@ -275,14 +275,22 @@ var oscar = (function(o, $) {
         },
         initForms: function() {
             // Disable buttons when they are clicked and show a "loading" message taken from the
-            // data-loading-text attribute (http://getbootstrap.com/2.3.2/javascript.html#buttons).
+            // data-loading-text attribute.
             // Do not disable if button is inside a form with invalid fields.
             // This uses a delegated event so that it keeps working for forms that are reloaded
             // via AJAX: https://api.jquery.com/on/#direct-and-delegated-events
             $(document.body).on('click', '[data-loading-text]', function(){
-                var form = $(this).parents("form");
-                if (!form || $(":invalid", form).length == 0)
-                    $(this).button('loading');
+                var $btn_or_input = $(this),
+                    form = $btn_or_input.parents("form");
+                if (!form || $(":invalid", form).length == 0) {
+                    var d = 'disabled',
+                        val = $btn_or_input.is('input') ? 'val' : 'html';
+                    // push to event loop so as not to delay form submission
+                    setTimeout(function() {
+                        $btn_or_input[val]($btn_or_input.data('loading-text'));
+                        $btn_or_input.addClass(d).attr(d, d).prop(d, true);
+                    });
+                }
             });
 
             // Display tabs that have invalid input fields

--- a/src/oscar/static_src/oscar/js/oscar/ui.js
+++ b/src/oscar/static_src/oscar/js/oscar/ui.js
@@ -66,14 +66,22 @@ var oscar = (function(o, $) {
             $('form[data-behaviours~="lock"]').submit(o.forms.submitIfNotLocked);
 
             // Disable buttons when they are clicked and show a "loading" message taken from the
-            // data-loading-text attribute (http://getbootstrap.com/2.3.2/javascript.html#buttons).
+            // data-loading-text attribute.
             // Do not disable if button is inside a form with invalid fields.
             // This uses a delegated event so that it keeps working for forms that are reloaded
             // via AJAX: https://api.jquery.com/on/#direct-and-delegated-events
-            $(document.body).on('submit', 'form', function(){
-                var form = $(this);
-                if ($(":invalid", form).length == 0)
-                    $(this).find('button[data-loading-text]').button('loading');
+            $(document.body).on('click', '[data-loading-text]', function(){
+                var $btn_or_input = $(this),
+                    form = $btn_or_input.parents("form");
+                if (!form || $(":invalid", form).length == 0) {
+                    var d = 'disabled',
+                        val = $btn_or_input.is('input') ? 'val' : 'html';
+                    // push to event loop so as not to delay form submission
+                    setTimeout(function() {
+                        $btn_or_input[val]($btn_or_input.data('loading-text'));
+                        $btn_or_input.addClass(d).attr(d, d).prop(d, true);
+                    });
+                }
             });
             // stuff for star rating on review page
             // show clickable stars instead of a select dropdown for product rating


### PR DESCRIPTION
The stateful button feature in Bootstrap was [removed in version 4](https://getbootstrap.com/docs/4.1/migration/#buttons). This replaces the reliance on that with some custom JS that does the same thing.