### PR TITLE
Remove redundant date filtering of queryset in report-generator classes

### DIFF
--- a/src/oscar/apps/offer/reports.py
+++ b/src/oscar/apps/offer/reports.py
@@ -1,4 +1,3 @@
-import datetime
 from decimal import Decimal as D
 
 from django.utils.translation import gettext_lazy as _
@@ -36,19 +35,12 @@ class OfferReportHTMLFormatter(ReportHTMLFormatter):
 class OfferReportGenerator(ReportGenerator):
     code = 'conditional-offers'
     description = _('Offer performance')
+    model_class = OrderDiscount
 
     formatters = {
         'CSV_formatter': OfferReportCSVFormatter,
         'HTML_formatter': OfferReportHTMLFormatter,
     }
-
-    def get_queryset(self):
-        qs = OrderDiscount._default_manager.all()
-        if self.start_date:
-            qs = qs.filter(order__date_placed__gte=self.start_date)
-        if self.end_date:
-            qs = qs.filter(order__date_placed__lt=self.end_date + datetime.timedelta(days=1))
-        return qs
 
     def generate(self):
         offer_discounts = {}

--- a/src/oscar/apps/order/reports.py
+++ b/src/oscar/apps/order/reports.py
@@ -1,5 +1,3 @@
-import datetime
-
 from django.utils.translation import gettext_lazy as _
 
 from oscar.core.loading import get_class, get_model
@@ -45,20 +43,12 @@ class OrderReportGenerator(ReportGenerator):
     code = 'order_report'
     description = _("Orders placed")
     date_range_field_name = 'date_placed'
+    model_class = Order
 
     formatters = {
         'CSV_formatter': OrderReportCSVFormatter,
         'HTML_formatter': OrderReportHTMLFormatter,
     }
-
-    def get_queryset(self):
-        qs = Order._default_manager.all()
-        if self.start_date:
-            qs = qs.filter(date_placed__gte=self.start_date)
-        if self.end_date:
-            qs = qs.filter(
-                date_placed__lt=self.end_date + datetime.timedelta(days=1))
-        return qs
 
     def generate(self):
         additional_data = {


### PR DESCRIPTION
It is done by default, from the "__init__" method of the parent class,
since commit 18eca6f76c184171b978e31a0d542f845007990f.