### PR TITLE
Improve `test_post_process_urls_adds_decorator`

### DIFF
--- a/tests/unit/core/test_application.py
+++ b/tests/unit/core/test_application.py
@@ -30,8 +30,11 @@ class OscarConfigTestCase(TestCase):
         mock_permissions_required.assert_called_once_with('is_staff', login_url=None)
 
     def test_post_process_urls_adds_decorator(self):
+        def fake_callback():
+            pass
+
         fake_decorator = mock.Mock()
-        fake_decorator.return_value = 'fake_callback'
+        fake_decorator.return_value = fake_callback
 
         self.myapp.get_url_decorator = mock.Mock()
         self.myapp.get_url_decorator.return_value = fake_decorator
@@ -40,4 +43,4 @@ class OscarConfigTestCase(TestCase):
         processed_patterns = self.myapp.post_process_urls([pattern])
 
         self.myapp.get_url_decorator.assert_called_once_with(pattern)
-        self.assertEqual(processed_patterns[0].callback, 'fake_callback')
+        self.assertEqual(processed_patterns[0].callback, fake_callback)


### PR DESCRIPTION
Use function as the return value of `get_url_decorator`. This change needed because `get_url_decorator` method of `OscarConfigMixin` class returns function or `None` and not string.

Refs: https://github.com/django-oscar/django-oscar/pull/3518/commits/5a10e17b8c3b38f10fe6f4241f1f38f249f2726a#r515003098