### PR TITLE
Render only top level categories in primary navigation menu

### DIFF
--- a/src/oscar/templates/oscar/partials/nav_primary.html
+++ b/src/oscar/templates/oscar/partials/nav_primary.html
@@ -30,16 +30,12 @@
                     {% trans "Browse store" %}
                 </a>
                 <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                    {% category_tree depth=2 as tree_categories %}
+                    {% category_tree depth=1 as tree_categories %}
                     <a class="dropdown-item" href="{% url 'catalogue:index' %}">{% trans "All products" %}</a>
                     {% if tree_categories %}
                         <div class="dropdown-divider"></div>
                         {% for tree_category in tree_categories %}
-                            {% if tree_category.has_children %}
-                                <a class="dropdown-item" href="{{ tree_category.get_absolute_url }}">{{ tree_category.name }}</a>
-                            {% else %}
-                                <a class="dropdown-item" href="{{ tree_category.get_absolute_url }}">{{ tree_category.name }}</a>
-                            {% endif %}
+                            <a class="dropdown-item" href="{{ tree_category.get_absolute_url }}">{{ tree_category.name }}</a>
                         {% endfor %}
                     {% endif %}
                     <div class="dropdown-divider"></div>


### PR DESCRIPTION
Support for multi-level dropdowns was removed from Bootstrap 4, with the justification being that these are difficult to use on mobile (and BS4 was designed with a mobile-first approach). Our primary navigation template got a bit mangled during the port to BS4 as a result - resulting in 1st and 2nd level categories all being rendered in a flat list.

This changes the primary navigation only to render the top level categories. I think this is fine given that the menu is already inside a dropdown, and that the full category tree is available on search/category pages.