### PR TITLE
Create a mixin for filtering partner's products so it's extendable

### DIFF
--- a/src/oscar/apps/dashboard/catalogue/mixins.py
+++ b/src/oscar/apps/dashboard/catalogue/mixins.py
@@ -1,0 +1,13 @@
+class PartnerProductFilterMixin:
+    def filter_queryset(self, queryset):
+        """
+        Restrict the queryset to products the given user has access to.
+        A staff user is allowed to access all Products.
+        A non-staff user is only allowed access to a product if they are in at
+        least one stock record's partner user list.
+        """
+        user = self.request.user
+        if user.is_staff:
+            return queryset
+
+        return queryset.filter(stockrecords__partner__users__pk=user.pk).distinct()

--- a/src/oscar/apps/dashboard/catalogue/views.py
+++ b/src/oscar/apps/dashboard/catalogue/views.py
@@ -9,7 +9,7 @@ from django.utils.translation import gettext_lazy as _
 from django.views import generic
 from django_tables2 import SingleTableMixin, SingleTableView
 
-from oscar.core.loading import get_classes, get_model
+from oscar.core.decorators import deprecated
 from oscar.views.generic import ObjectLookupView
 
 (ProductForm,
@@ -65,6 +65,7 @@ AttributeOptionGroup = get_model('catalogue', 'AttributeOptionGroup')
 Option = get_model('catalogue', 'Option')
 
 
+@deprecated
 def filter_products(queryset, user):
     """
     Restrict the queryset to products the given user has access to.

--- a/src/oscar/apps/dashboard/catalogue/views.py
+++ b/src/oscar/apps/dashboard/catalogue/views.py
@@ -10,6 +10,7 @@ from django.views import generic
 from django_tables2 import SingleTableMixin, SingleTableView
 
 from oscar.core.decorators import deprecated
+from oscar.core.loading import get_class, get_classes, get_model
 from oscar.views.generic import ObjectLookupView
 
 (ProductForm,
@@ -53,6 +54,7 @@ ProductTable, CategoryTable, AttributeOptionGroupTable, OptionTable \
                   ('PopUpWindowCreateMixin',
                    'PopUpWindowUpdateMixin',
                    'PopUpWindowDeleteMixin'))
+PartnerProductFilterMixin = get_class('dashboard.catalogue.mixins', 'PartnerProductFilterMixin')
 Product = get_model('catalogue', 'Product')
 Category = get_model('catalogue', 'Category')
 ProductImage = get_model('catalogue', 'ProductImage')
@@ -79,7 +81,7 @@ def filter_products(queryset, user):
     return queryset.filter(stockrecords__partner__users__pk=user.pk).distinct()
 
 
-class ProductListView(SingleTableView):
+class ProductListView(PartnerProductFilterMixin, SingleTableView):
 
     """
     Dashboard view of the product list.
@@ -113,12 +115,6 @@ class ProductListView(SingleTableView):
 
     def get_table_pagination(self, table):
         return dict(per_page=settings.OSCAR_DASHBOARD_ITEMS_PER_PAGE)
-
-    def filter_queryset(self, queryset):
-        """
-        Apply any filters to restrict the products that appear on the list
-        """
-        return filter_products(queryset, self.request.user)
 
     def get_queryset(self):
         """
@@ -195,7 +191,7 @@ class ProductCreateRedirectView(generic.RedirectView):
             return self.get_invalid_product_class_url()
 
 
-class ProductCreateUpdateView(generic.UpdateView):
+class ProductCreateUpdateView(PartnerProductFilterMixin, generic.UpdateView):
     """
     Dashboard view that is can both create and update products of all kinds.
     It can be used in three different ways, each of them with a unique URL
@@ -253,7 +249,7 @@ class ProductCreateUpdateView(generic.UpdateView):
         """
         Filter products that the user doesn't have permission to update
         """
-        return filter_products(Product.objects.all(), self.request.user)
+        return self.filter_queryset(Product.objects.all())
 
     def get_object(self, queryset=None):
         """
@@ -452,7 +448,7 @@ class ProductCreateUpdateView(generic.UpdateView):
         return self.get_url_with_querystring(url)
 
 
-class ProductDeleteView(generic.DeleteView):
+class ProductDeleteView(PartnerProductFilterMixin, generic.DeleteView):
     """
     Dashboard view to delete a product. Has special logic for deleting the
     last child product.
@@ -466,7 +462,7 @@ class ProductDeleteView(generic.DeleteView):
         """
         Filter products that the user doesn't have permission to update
         """
-        return filter_products(Product.objects.all(), self.request.user)
+        return self.filter_queryset(Product.objects.all())
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)


### PR DESCRIPTION
I wanted to customize the queryset for partners and after checking the code, I realized I had to extend three classes to do that: `ProductListView`, `ProductCreateUpdateView` and `ProductDeleteView`. It's because the `filter_products` function is not extendable.

This pull request fixes that by creating a mixin that you can easily extend.