### PR TITLE
Fix non-exclusive offers with count condition (3162)

### DIFF
--- a/src/oscar/apps/basket/utils.py
+++ b/src/oscar/apps/basket/utils.py
@@ -143,7 +143,7 @@ class LineOfferConsumer(object):
     def consumers(self):
         return [x for x in self._offers.values() if self.consumed(x)]
 
-    def available(self, offer=None) -> int: # noqa (too complex (11))
+    def available(self, offer=None) -> int:
         """
         check how many items are available for offer
 
@@ -185,9 +185,5 @@ class LineOfferConsumer(object):
                 check = offer.combinations.count() or x.combinations.count()
                 if check and offer not in x.combined_offers:
                     return 0
-
-            # respect max_affected_items
-            if offer.benefit.max_affected_items:
-                max_affected_items = min(offer.benefit.max_affected_items, max_affected_items)
 
         return max_affected_items - self.consumed(offer)

--- a/src/oscar/apps/offer/benefits.py
+++ b/src/oscar/apps/offer/benefits.py
@@ -67,6 +67,7 @@ class PercentageDiscountBenefit(Benefit):
         max_affected_items = self._effective_max_affected_items()
         affected_lines = []
         for price, line in line_tuples:
+            affected_items += line.quantity_with_offer_discount(offer)
             if affected_items >= max_affected_items:
                 break
             if discount_amount_available == 0:

--- a/src/oscar/apps/offer/conditions.py
+++ b/src/oscar/apps/offer/conditions.py
@@ -47,7 +47,7 @@ class CountCondition(Condition):
         num_matches = 0
         for line in basket.all_lines():
             if self.can_apply_condition(line):
-                num_matches += line.quantity_without_offer_discount(None)
+                num_matches += line.quantity_without_offer_discount(offer)
             if num_matches >= self.value:
                 return True
         return False

--- a/tests/integration/basket/test_utils.py
+++ b/tests/integration/basket/test_utils.py
@@ -76,7 +76,7 @@ class TestLineOfferConsumer:
         offer1 = ConditionalOfferFactory(name='offer1', benefit=benefit)
         lines = basket.all_lines()
         assert lines[0].consumer.available(offer1) == 1
-        assert lines[1].consumer.available(offer1) == 5
+        assert lines[1].consumer.available(offer1) == 10
 
     def test_consumed_with_offer(self, filled_basket):
         offer1 = ConditionalOfferFactory(name='offer1')


### PR DESCRIPTION
Fixes #3162

* Checking of `offer.benefit.max_affected_items` removed from the `available` method of `LineOfferConsumer` class - available items should not be limited by related benefit (it should be considered when applying the offer).
* Improved `apply` method of `PercentageDiscountBenefit` - affected items must include "quantities with discount applied".
* `is_satisfied` method of `CountCondition` updated to pass `offer` instead of `None` to `line.quantity_without_offer_discount` - this change is required to fix the initial issue.
* Updated `test_available_with_offer` test - initially this test was added to check the lines that we removed from the `available` method of `LineOfferConsumer` class (See fda27a1).
* Added tests to confirm that the initial issue is fixed.