### PR TITLE
Add 'currrency' to 'shipping_discount' method

### DIFF
--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -343,7 +343,7 @@ class AbstractConditionalOffer(models.Model):
             .aggregate(total=models.Sum('frequency'))
         return aggregates['total'] if aggregates['total'] is not None else 0
 
-    def shipping_discount(self, charge, basket):
+    def shipping_discount(self, charge, basket=None):
         return self.benefit.proxy().shipping_discount(charge, basket)
 
     def record_usage(self, discount):
@@ -680,7 +680,7 @@ class AbstractBenefit(BaseOfferMixin, models.Model):
         # We sort lines to be cheapest first to ensure consistent applications
         return sorted(line_tuples, key=operator.itemgetter(0))
 
-    def shipping_discount(self, charge, basket):
+    def shipping_discount(self, charge, basket=None):
         return D('0.00')
 
 

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -343,8 +343,8 @@ class AbstractConditionalOffer(models.Model):
             .aggregate(total=models.Sum('frequency'))
         return aggregates['total'] if aggregates['total'] is not None else 0
 
-    def shipping_discount(self, charge):
-        return self.benefit.proxy().shipping_discount(charge)
+    def shipping_discount(self, charge, basket):
+        return self.benefit.proxy().shipping_discount(charge, basket)
 
     def record_usage(self, discount):
         self.num_applications += discount['freq']
@@ -680,7 +680,7 @@ class AbstractBenefit(BaseOfferMixin, models.Model):
         # We sort lines to be cheapest first to ensure consistent applications
         return sorted(line_tuples, key=operator.itemgetter(0))
 
-    def shipping_discount(self, charge):
+    def shipping_discount(self, charge, basket):
         return D('0.00')
 
 

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -343,8 +343,8 @@ class AbstractConditionalOffer(models.Model):
             .aggregate(total=models.Sum('frequency'))
         return aggregates['total'] if aggregates['total'] is not None else 0
 
-    def shipping_discount(self, charge, basket=None):
-        return self.benefit.proxy().shipping_discount(charge, basket)
+    def shipping_discount(self, charge, currency=None):
+        return self.benefit.proxy().shipping_discount(charge, currency)
 
     def record_usage(self, discount):
         self.num_applications += discount['freq']
@@ -680,7 +680,7 @@ class AbstractBenefit(BaseOfferMixin, models.Model):
         # We sort lines to be cheapest first to ensure consistent applications
         return sorted(line_tuples, key=operator.itemgetter(0))
 
-    def shipping_discount(self, charge, basket=None):
+    def shipping_discount(self, charge, currency=None):
         return D('0.00')
 
 

--- a/src/oscar/apps/offer/benefits.py
+++ b/src/oscar/apps/offer/benefits.py
@@ -316,7 +316,7 @@ class ShippingAbsoluteDiscountBenefit(ShippingBenefit):
         verbose_name = _("Shipping absolute discount benefit")
         verbose_name_plural = _("Shipping absolute discount benefits")
 
-    def shipping_discount(self, charge, basket=None):
+    def shipping_discount(self, charge, currency=None):
         return min(charge, self.value)
 
 
@@ -334,7 +334,7 @@ class ShippingFixedPriceBenefit(ShippingBenefit):
         verbose_name = _("Fixed price shipping benefit")
         verbose_name_plural = _("Fixed price shipping benefits")
 
-    def shipping_discount(self, charge, basket=None):
+    def shipping_discount(self, charge, currency=None):
         if charge < self.value:
             return D('0.00')
         return charge - self.value
@@ -354,6 +354,6 @@ class ShippingPercentageDiscountBenefit(ShippingBenefit):
         verbose_name = _("Shipping percentage discount benefit")
         verbose_name_plural = _("Shipping percentage discount benefits")
 
-    def shipping_discount(self, charge, basket=None):
+    def shipping_discount(self, charge, currency=None):
         discount = charge * self.value / D('100.0')
         return discount.quantize(D('0.01'))

--- a/src/oscar/apps/offer/benefits.py
+++ b/src/oscar/apps/offer/benefits.py
@@ -316,7 +316,7 @@ class ShippingAbsoluteDiscountBenefit(ShippingBenefit):
         verbose_name = _("Shipping absolute discount benefit")
         verbose_name_plural = _("Shipping absolute discount benefits")
 
-    def shipping_discount(self, charge, basket):
+    def shipping_discount(self, charge, basket=None):
         return min(charge, self.value)
 
 
@@ -334,7 +334,7 @@ class ShippingFixedPriceBenefit(ShippingBenefit):
         verbose_name = _("Fixed price shipping benefit")
         verbose_name_plural = _("Fixed price shipping benefits")
 
-    def shipping_discount(self, charge, basket):
+    def shipping_discount(self, charge, basket=None):
         if charge < self.value:
             return D('0.00')
         return charge - self.value
@@ -354,6 +354,6 @@ class ShippingPercentageDiscountBenefit(ShippingBenefit):
         verbose_name = _("Shipping percentage discount benefit")
         verbose_name_plural = _("Shipping percentage discount benefits")
 
-    def shipping_discount(self, charge, basket):
+    def shipping_discount(self, charge, basket=None):
         discount = charge * self.value / D('100.0')
         return discount.quantize(D('0.01'))

--- a/src/oscar/apps/offer/benefits.py
+++ b/src/oscar/apps/offer/benefits.py
@@ -316,7 +316,7 @@ class ShippingAbsoluteDiscountBenefit(ShippingBenefit):
         verbose_name = _("Shipping absolute discount benefit")
         verbose_name_plural = _("Shipping absolute discount benefits")
 
-    def shipping_discount(self, charge):
+    def shipping_discount(self, charge, basket):
         return min(charge, self.value)
 
 
@@ -334,7 +334,7 @@ class ShippingFixedPriceBenefit(ShippingBenefit):
         verbose_name = _("Fixed price shipping benefit")
         verbose_name_plural = _("Fixed price shipping benefits")
 
-    def shipping_discount(self, charge):
+    def shipping_discount(self, charge, basket):
         if charge < self.value:
             return D('0.00')
         return charge - self.value
@@ -354,6 +354,6 @@ class ShippingPercentageDiscountBenefit(ShippingBenefit):
         verbose_name = _("Shipping percentage discount benefit")
         verbose_name_plural = _("Shipping percentage discount benefits")
 
-    def shipping_discount(self, charge):
+    def shipping_discount(self, charge, basket):
         discount = charge * self.value / D('100.0')
         return discount.quantize(D('0.01'))

--- a/src/oscar/apps/shipping/methods.py
+++ b/src/oscar/apps/shipping/methods.py
@@ -151,7 +151,7 @@ class TaxExclusiveOfferDiscount(OfferDiscount):
 
     def calculate(self, basket):
         base_charge = self.method.calculate(basket)
-        discount = self.offer.shipping_discount(base_charge.excl_tax, basket.currency)
+        discount = self.offer.shipping_discount(base_charge.excl_tax, base_charge.currency)
         excl_tax = base_charge.excl_tax - discount
         return prices.Price(
             currency=base_charge.currency,
@@ -159,7 +159,7 @@ class TaxExclusiveOfferDiscount(OfferDiscount):
 
     def discount(self, basket):
         base_charge = self.method.calculate(basket)
-        return self.offer.shipping_discount(base_charge.excl_tax, basket.currency)
+        return self.offer.shipping_discount(base_charge.excl_tax, base_charge.currency)
 
 
 class TaxInclusiveOfferDiscount(OfferDiscount):
@@ -169,7 +169,7 @@ class TaxInclusiveOfferDiscount(OfferDiscount):
 
     def calculate(self, basket):
         base_charge = self.method.calculate(basket)
-        discount = self.offer.shipping_discount(base_charge.incl_tax, basket.currency)
+        discount = self.offer.shipping_discount(base_charge.incl_tax, base_charge.currency)
         incl_tax = base_charge.incl_tax - discount
         excl_tax = self.calculate_excl_tax(base_charge, incl_tax)
         return prices.Price(
@@ -190,4 +190,4 @@ class TaxInclusiveOfferDiscount(OfferDiscount):
 
     def discount(self, basket):
         base_charge = self.method.calculate(basket)
-        return self.offer.shipping_discount(base_charge.incl_tax, basket.currency)
+        return self.offer.shipping_discount(base_charge.incl_tax, base_charge.currency)

--- a/src/oscar/apps/shipping/methods.py
+++ b/src/oscar/apps/shipping/methods.py
@@ -151,7 +151,7 @@ class TaxExclusiveOfferDiscount(OfferDiscount):
 
     def calculate(self, basket):
         base_charge = self.method.calculate(basket)
-        discount = self.offer.shipping_discount(base_charge.excl_tax, basket)
+        discount = self.offer.shipping_discount(base_charge.excl_tax, basket.currency)
         excl_tax = base_charge.excl_tax - discount
         return prices.Price(
             currency=base_charge.currency,
@@ -159,7 +159,7 @@ class TaxExclusiveOfferDiscount(OfferDiscount):
 
     def discount(self, basket):
         base_charge = self.method.calculate(basket)
-        return self.offer.shipping_discount(base_charge.excl_tax, basket)
+        return self.offer.shipping_discount(base_charge.excl_tax, basket.currency)
 
 
 class TaxInclusiveOfferDiscount(OfferDiscount):
@@ -169,7 +169,7 @@ class TaxInclusiveOfferDiscount(OfferDiscount):
 
     def calculate(self, basket):
         base_charge = self.method.calculate(basket)
-        discount = self.offer.shipping_discount(base_charge.incl_tax, basket)
+        discount = self.offer.shipping_discount(base_charge.incl_tax, basket.currency)
         incl_tax = base_charge.incl_tax - discount
         excl_tax = self.calculate_excl_tax(base_charge, incl_tax)
         return prices.Price(
@@ -190,4 +190,4 @@ class TaxInclusiveOfferDiscount(OfferDiscount):
 
     def discount(self, basket):
         base_charge = self.method.calculate(basket)
-        return self.offer.shipping_discount(base_charge.incl_tax, basket)
+        return self.offer.shipping_discount(base_charge.incl_tax, basket.currency)

--- a/src/oscar/apps/shipping/methods.py
+++ b/src/oscar/apps/shipping/methods.py
@@ -151,7 +151,7 @@ class TaxExclusiveOfferDiscount(OfferDiscount):
 
     def calculate(self, basket):
         base_charge = self.method.calculate(basket)
-        discount = self.offer.shipping_discount(base_charge.excl_tax)
+        discount = self.offer.shipping_discount(base_charge.excl_tax, basket)
         excl_tax = base_charge.excl_tax - discount
         return prices.Price(
             currency=base_charge.currency,
@@ -159,7 +159,7 @@ class TaxExclusiveOfferDiscount(OfferDiscount):
 
     def discount(self, basket):
         base_charge = self.method.calculate(basket)
-        return self.offer.shipping_discount(base_charge.excl_tax)
+        return self.offer.shipping_discount(base_charge.excl_tax, basket)
 
 
 class TaxInclusiveOfferDiscount(OfferDiscount):
@@ -169,7 +169,7 @@ class TaxInclusiveOfferDiscount(OfferDiscount):
 
     def calculate(self, basket):
         base_charge = self.method.calculate(basket)
-        discount = self.offer.shipping_discount(base_charge.incl_tax)
+        discount = self.offer.shipping_discount(base_charge.incl_tax, basket)
         incl_tax = base_charge.incl_tax - discount
         excl_tax = self.calculate_excl_tax(base_charge, incl_tax)
         return prices.Price(
@@ -190,4 +190,4 @@ class TaxInclusiveOfferDiscount(OfferDiscount):
 
     def discount(self, basket):
         base_charge = self.method.calculate(basket)
-        return self.offer.shipping_discount(base_charge.incl_tax)
+        return self.offer.shipping_discount(base_charge.incl_tax, basket)


### PR DESCRIPTION
The added `currency` parameter for `shipping_discount` can have multiple use cases such as possible **multi-currency** feature integration by dependant projects.