### PR TITLE
Remove setting of default value via Javascript in time picker inputs.

### DIFF
--- a/docs/source/releases/v3.0.rst
+++ b/docs/source/releases/v3.0.rst
@@ -154,6 +154,11 @@ Minor changes
 - The behaviour of ``checkout.views.ThankYouView`` when no order is found in the session has changed,
   to redirect the user to the URL defined by ``settings.OSCAR_HOMEPAGE`` instead of returning a page not found error.
 
+- The Javascript that initialises the widget for ``oscar.forms.widgets.DateTimePickerInput`` in dashboard forms
+  no longer sets a default value on the field if no initial value has been supplied for the form field. The
+  ``oscar.dashboard.options.initialDate`` Javascript utility function which was previously used to set this has been
+  removed. This change only affects date-time inputs in the dashboard.
+
 Dependency changes
 ~~~~~~~~~~~~~~~~~~
 

--- a/src/oscar/static_src/oscar/js/oscar/dashboard.js
+++ b/src/oscar/static_src/oscar/js/oscar/dashboard.js
@@ -91,7 +91,6 @@ var oscar = (function(o, $) {
                         close: 'fas fa-times'
                     }
                 },
-                'initialDate': new Date(new Date().setSeconds(0)),
                 'tinyConfig': {
                     entity_encoding: 'raw',
                     statusbar: false,
@@ -237,8 +236,7 @@ var oscar = (function(o, $) {
 
                 var defaultDatetimepickerConfig = {
                     'format': o.dashboard.options.datetimeFormat,
-                    'stepping': o.dashboard.options.stepMinute,
-                    'defaultDate': o.dashboard.options.initialDate
+                    'stepping': o.dashboard.options.stepMinute
                 };
                 var $datetimes = $(el).find('[data-oscarWidget="datetime"]').not('.no-widget-init').not('.no-widget-init *');
                 $datetimes.each(function(ind, ele) {
@@ -252,8 +250,7 @@ var oscar = (function(o, $) {
 
                 var defaultTimepickerConfig = {
                     'format': o.dashboard.options.timeFormat,
-                    'stepping': o.dashboard.options.stepMinute,
-                    'defaultDate': o.dashboard.options.initialDate
+                    'stepping': o.dashboard.options.stepMinute
                 };
                 var $times = $(el).find('[data-oscarWidget="time"]').not('.no-widget-init').not('.no-widget-init *');
                 $times.each(function(ind, ele) {


### PR DESCRIPTION
Where an initial value is required, this should be set on the form field itself.

Fixes #3590.