### PR TITLE
Fix various Bootstrap 4 and other template issues

### DIFF
--- a/src/oscar/static_src/oscar/scss/dashboard/navbar.scss
+++ b/src/oscar/static_src/oscar/scss/dashboard/navbar.scss
@@ -1,6 +1,10 @@
 // Navigation bar
 
 .navbar {
+  .dropdown-menu {
+    z-index: 2000;
+  }
+
   &.navbar-accounts,
   &.navbar-primary {
     padding: 0;

--- a/src/oscar/templates/flatpages/default.html
+++ b/src/oscar/templates/flatpages/default.html
@@ -8,7 +8,7 @@
 {% block header%}
     <div class="page-header">
         {% if user.is_staff %}
-            <a class="float-right d-sm-none" href="{% url 'dashboard:page-update' pk=flatpage.id %}"><small><i class="fas fa-pencil-alt"></i> {% trans "Edit this page" %}</small></a>
+            <a class="float-right d-none d-md-block" href="{% url 'dashboard:page-update' pk=flatpage.id %}"><small><i class="fas fa-pencil-alt"></i> {% trans "Edit this page" %}</small></a>
         {% endif %}
         <h1>{{ flatpage.title }}</h1>
     </div>

--- a/src/oscar/templates/oscar/basket/partials/basket_content.html
+++ b/src/oscar/templates/oscar/basket/partials/basket_content.html
@@ -178,10 +178,10 @@
             <div class="sub-header">
                 <h2>{% trans "Items to buy later" %}</h2>
             </div>
-            <div class="row basket-title d-sm-none">
-                <p class="col-sm-8 h4">{% trans "Items" %}</p>
-                <p class="col-sm-2 h4 text-center">{% trans "Price" %}</p>
-                <div class="col-sm-2">&nbsp;</div>
+            <div class="row basket-title d-none d-md-flex">
+                <div class="col-md-8 h4">{% trans "Items" %}</div>
+                <div class="col-md-2 h4 text-center">{% trans "Price" %}</div>
+                <div class="col-md-2">&nbsp;</div>
             </div>
             <form action="{% url 'basket:saved' %}" method="post" id="saved_basket_formset">
                 {% csrf_token %}
@@ -190,7 +190,7 @@
                     {% purchase_info_for_product request form.instance.product as session %}
                     <div class="basket-items">
                         <div class="row">
-                            <div class="col-sm-2">
+                            <div class="col-md-2">
                                 {{ form.id }}
                                 {% with image=form.instance.product.primary_image %}
                                     {% oscar_thumbnail image.original "100x100" upscale=False as thumb %}
@@ -199,7 +199,7 @@
                                     </a>
                                 {% endwith %}
                             </div>
-                            <div class="col-sm-6">
+                            <div class="col-md-6">
                                 <h3><a href="{{ form.instance.product.get_absolute_url }}">{{ form.instance.description }}</a></h3>
                                 <p class="availability {{ session.availability.code }}">{{ session.availability.message }}</p>
                                 <a href="#" data-id="{{ forloop.counter0 }}" data-behaviours="remove">{% trans "Remove" %}</a>
@@ -209,7 +209,7 @@
                                 </div>
                             </div>
                             {% purchase_info_for_product request form.instance.product as saved %}
-                            <div class="col-sm-2 text-center">
+                            <div class="col-md-2 text-center">
                                 <p class="price_color">
                                     {% if saved.price.is_tax_known %}
                                         {{ saved.price.incl_tax|currency:saved.price.currency }}
@@ -218,7 +218,7 @@
                                     {% endif %}
                                 </p>
                             </div>
-                            <div class="col-sm-2">
+                            <div class="col-md-2">
                                 <a href="#" data-id="{{ forloop.counter0 }}" class="btn float-right btn-block" data-behaviours="move">{% trans "Move to basket" %}</a>
                             </div>
                         </div>

--- a/src/oscar/templates/oscar/catalogue/category.html
+++ b/src/oscar/templates/oscar/catalogue/category.html
@@ -13,7 +13,7 @@
 {% block header%}
     <div class="page-header">
         {% if user.is_staff %}
-            <a class="float-right d-sm-none" href="{% url 'dashboard:catalogue-category-update' pk=category.id %}">
+            <a class="float-right d-none d-md-block" href="{% url 'dashboard:catalogue-category-update' pk=category.id %}">
               <small><i class="fas fa-pencil-alt"></i> {% trans "Edit this category" %}</small></a>
         {% endif %}
         <h1>{% block headertext %}{{ category.name }}{% endblock %}</h1>

--- a/src/oscar/templates/oscar/catalogue/detail.html
+++ b/src/oscar/templates/oscar/catalogue/detail.html
@@ -61,7 +61,7 @@
                 pops out when clicked.  A bit like the Django-Debug-Toolbar button
             {% endcomment %}
             {% if user.is_staff %}
-                <a class="float-right d-none d-sm-block" href="{% url 'dashboard:catalogue-product' pk=product.id %}">
+                <a class="float-right d-none d-md-block" href="{% url 'dashboard:catalogue-product' pk=product.id %}">
                     <small><i class="fas fa-pencil-alt"></i> {% trans "Edit this product" %}</small>
                 </a>
             {% endif %}

--- a/src/oscar/templates/oscar/dashboard/catalogue/category_delete.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/category_delete.html
@@ -12,7 +12,7 @@
                     {% trans "Categories" %}
                 </a>
             </li>
-            <li class="breadcrumb-item active" aria-current="page">{% trans "Delete category?" %}}</li>
+            <li class="breadcrumb-item active" aria-current="page">{% trans "Delete category?" %}</li>
         </ol>
     </nav>
 {% endblock %}

--- a/src/oscar/templates/oscar/dashboard/catalogue/category_form.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/category_form.html
@@ -27,7 +27,7 @@
 {% block headertext %}{{ title }}{% endblock %}
 
 {% block dashboard_content %}
-    <form action="{% if request.GET.urlencode %}?{{ request.GET.urlencode }}{% endif %}" method="post" class="form-stacked wysiwyg fixed-actions" enctype="multipart/form-data" data-behaviour="affix-nav-errors" autocomplete="off">
+    <form action="{% if request.GET.urlencode %}?{{ request.GET.urlencode }}{% endif %}" method="post" class="form-stacked wysiwyg fixed-actions" enctype="multipart/form-data" data-behaviour="tab-nav-errors" autocomplete="off">
         {% csrf_token %}
         <div class="row">
             {% block tab_nav %}
@@ -83,10 +83,6 @@
                                 </div>
                                 <div class="card card-body">
                                     {% block seo_content %}
-                                        <span class="error-block">{{ form.non_field_errors }}</span>
-                                        {% for field in form.hidden_fields %}
-                                            {{ field }}
-                                        {% endfor %}
                                         {% for field in form.seo_form_fields %}
                                             {% if 'attr' not in field.id_for_label %}
                                                 {% include 'oscar/dashboard/partials/form_field.html' with field=field %}

--- a/src/oscar/templates/oscar/dashboard/reviews/review_list.html
+++ b/src/oscar/templates/oscar/dashboard/reviews/review_list.html
@@ -31,7 +31,7 @@
     <div class="card card-body">
         <form method="get" class="form-inline">
             {% include 'oscar/dashboard/partials/form_fields_inline.html' with form=form %}
-            <button type="submit" class="btn btn-primary top-spacer" data-loading-text="{% trans 'Searching...' %}">{% trans "Search" %}</button>
+            <button type="submit" class="btn btn-primary" data-loading-text="{% trans 'Searching...' %}">{% trans "Search" %}</button>
         </form>
     </div>
 

--- a/src/oscar/templates/oscar/partials/mini_basket.html
+++ b/src/oscar/templates/oscar/partials/mini_basket.html
@@ -1,7 +1,7 @@
 {% load currency_filters %}
 {% load i18n %}
 
-<div class="basket-mini col-sm-5 text-right d-none d-sm-block">
+<div class="basket-mini col-sm-5 text-right d-none d-md-block">
     <strong>{% trans "Basket total:" %}</strong>
     {% if request.basket.is_tax_known %}
         {{ request.basket.total_incl_tax|currency:request.basket.currency }}

--- a/src/oscar/templates/oscar/partials/nav_primary.html
+++ b/src/oscar/templates/oscar/partials/nav_primary.html
@@ -10,7 +10,7 @@
     {% endblock %}
 
     {% block navbar_basket %}
-        <a class="btn btn-secondary float-right btn-cart ml-auto d-inline d-sm-none" href="{% url 'basket:summary' %}">
+        <a class="btn btn-secondary float-right btn-cart ml-auto d-inline-block d-md-none" href="{% url 'basket:summary' %}">
             <i class="fas fa-shopping-cart"></i>
             {% trans "Basket" %}
             {% if not request.basket.is_empty %}


### PR DESCRIPTION
- Hide edit link on mobile, on flatpages
- Hide column headers on mobile, on basket page "Items to buy later"
  table
- Hide edit link on mobile, on category page
- Move dislay of various elements from "sm" to "md" grid tier
- Display error icon on navigation tab, on dashboard category-form page
- Increase "z-index" of dropdown menu on dashboard, so that it appears
  above all other elements
- Remove useless "top-spacer" class from dashboard review-list page
- Fix typo in use of template tag, on dashboard category-delete page
- Remove repeated display of non-field errors, and hidden fields, on
  dashboard category-form page