### PR TITLE
 Allow migrations to be ran backwards

### DIFF
--- a/src/oscar/apps/address/migrations/0005_regenerate_user_address_hashes.py
+++ b/src/oscar/apps/address/migrations/0005_regenerate_user_address_hashes.py
@@ -25,5 +25,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(regenerate_user_address_hashes)
+        migrations.RunPython(regenerate_user_address_hashes, migrations.RunPython.noop)
     ]


### PR DESCRIPTION
currently django would raise exception if we tried to reverse the migrations because the data migration has no backwards. This avoids that problem [read more](https://django.doctor/advice/C8001)

I found this problem during auditing your codebase. [Read the full report](https://django.doctor/django-cms/django-cms)