### PR TITLE
Fix reference to static file path in exception message for symlink_missing_image.

### DIFF
--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -1292,13 +1292,11 @@ class MissingProductImage(object):
                     "Please copy/symlink the "
                     "'missing image' image at %s into your MEDIA_ROOT at %s. "
                     "This exception was raised because Oscar was unable to "
-                    "symlink it for you.") % (media_file_path,
-                                              settings.MEDIA_ROOT))
+                    "symlink it for you.") % (static_file_path, settings.MEDIA_ROOT))
             else:
                 logging.info((
                     "Symlinked the 'missing image' image at %s into your "
-                    "MEDIA_ROOT at %s") % (media_file_path,
-                                           settings.MEDIA_ROOT))
+                    "MEDIA_ROOT at %s") % (static_file_path, settings.MEDIA_ROOT))
 
 
 class AbstractProductImage(models.Model):


### PR DESCRIPTION
Fixes #3618 - the "copy from" path being supplied to this exception message was wrong - instead of reporting the location of the static asset that should be copied manually (`static_file_path`), we were reporting the path it should be copied into (`media_file_path`).