### PR TITLE
Fix surcharge name in blocktrans

### DIFF
--- a/src/oscar/templates/oscar/dashboard/orders/order_detail.html
+++ b/src/oscar/templates/oscar/dashboard/orders/order_detail.html
@@ -258,7 +258,7 @@
                                     {% for charge in surcharges %}
                                         <tr>
                                             <td colspan="8"></td>
-                                            <th>{% blocktrans with name=charge.name %}Surcharge (name){% endblocktrans %}</th>
+                                            <th>{% blocktrans with name=charge.name %}Surcharge {{ name }}{% endblocktrans %}</th>
                                             <th class="text-right">{{ charge.excl_tax|currency:order.currency }}</th>
                                             <th class="text-right">{{ charge.incl_tax|currency:order.currency }}</th>
                                             <td></td>


### PR DESCRIPTION
Just a little thing I found in the order_detail template not using the surcharge `name` in `blocktrans` block.