### PR TITLE
Make child products searchable

### DIFF
--- a/src/oscar/apps/dashboard/catalogue/views.py
+++ b/src/oscar/apps/dashboard/catalogue/views.py
@@ -159,8 +159,7 @@ class ProductListView(PartnerProductFilterMixin, SingleTableView):
                 queryset = qs_match
             else:
                 # No direct UPC match. Let's try the same with an icontains search.
-                matches_upc = Product.objects.filter(Q(upc__icontains=upc) | Q(children__upc__icontains=upc))\
-                    .distinct()
+                matches_upc = Product.objects.filter(Q(upc__icontains=upc) | Q(children__upc__icontains=upc))
                 queryset = queryset.filter(
                     Q(id__in=matches_upc.values('id')) | Q(id__in=matches_upc.values('parent_id')))
 

--- a/src/oscar/apps/dashboard/catalogue/views.py
+++ b/src/oscar/apps/dashboard/catalogue/views.py
@@ -159,8 +159,8 @@ class ProductListView(PartnerProductFilterMixin, SingleTableView):
                 queryset = qs_match
             else:
                 # No direct UPC match. Let's try the same with an icontains search.
-                matches_upc = Product.objects.filter(Q(upc__icontains=upc) |
-                                                     Q(children__upc__icontains=upc)).distinct()
+                matches_upc = Product.objects.filter(Q(upc__icontains=upc) | Q(children__upc__icontains=upc))\
+                    .distinct()
                 queryset = queryset.filter(
                     Q(id__in=matches_upc.values('id')) | Q(id__in=matches_upc.values('parent_id')))
 

--- a/src/oscar/apps/dashboard/catalogue/views.py
+++ b/src/oscar/apps/dashboard/catalogue/views.py
@@ -139,14 +139,15 @@ class ProductListView(PartnerProductFilterMixin, SingleTableView):
 
         data = self.form.cleaned_data
 
-        if data.get('upc'):
+        upc = data.get('upc')
+        if upc:
             # Filter the queryset by upc
             # For usability reasons, we first look at exact matches and only return
             # them if there are any. Otherwise we return all results
             # that contain the UPC.
 
             # Look up all matches (child products, products not allowed to access) ...
-            matches_upc = Product.objects.filter(Q(upc__iexact=data['upc']) | Q(children__upc__iexact=data['upc']))
+            matches_upc = Product.objects.filter(Q(upc__iexact=upc) | Q(children__upc__iexact=upc)).distinct()
 
             # ... and use that to pick all standalone or parent products that the user is
             # allowed to access.
@@ -158,12 +159,13 @@ class ProductListView(PartnerProductFilterMixin, SingleTableView):
                 queryset = qs_match
             else:
                 # No direct UPC match. Let's try the same with an icontains search.
-                matches_upc = Product.objects.filter(upc__icontains=data['upc'])
+                matches_upc = Product.objects.filter(Q(upc__icontains=upc) | Q(children__upc__icontains=upc)).distinct()
                 queryset = queryset.filter(
                     Q(id__in=matches_upc.values('id')) | Q(id__in=matches_upc.values('parent_id')))
 
-        if data.get('title'):
-            queryset = queryset.filter(Q(title__icontains=data['title']) | Q(children__title__icontains=data['title']))
+        title = data.get('title')
+        if title:
+            queryset = queryset.filter(Q(title__icontains=title) | Q(children__title__icontains=title))
 
         return queryset
 

--- a/src/oscar/apps/dashboard/catalogue/views.py
+++ b/src/oscar/apps/dashboard/catalogue/views.py
@@ -146,7 +146,7 @@ class ProductListView(PartnerProductFilterMixin, SingleTableView):
             # that contain the UPC.
 
             # Look up all matches (child products, products not allowed to access) ...
-            matches_upc = Product.objects.filter(upc__iexact=data['upc'])
+            matches_upc = Product.objects.filter(Q(upc__iexact=data['upc']) | Q(children__upc__iexact=data['upc']))
 
             # ... and use that to pick all standalone or parent products that the user is
             # allowed to access.
@@ -163,7 +163,7 @@ class ProductListView(PartnerProductFilterMixin, SingleTableView):
                     Q(id__in=matches_upc.values('id')) | Q(id__in=matches_upc.values('parent_id')))
 
         if data.get('title'):
-            queryset = queryset.filter(title__icontains=data['title'])
+            queryset = queryset.filter(Q(title__icontains=data['title']) | Q(children__title__icontains=data['title']))
 
         return queryset
 

--- a/src/oscar/apps/dashboard/catalogue/views.py
+++ b/src/oscar/apps/dashboard/catalogue/views.py
@@ -159,7 +159,8 @@ class ProductListView(PartnerProductFilterMixin, SingleTableView):
                 queryset = qs_match
             else:
                 # No direct UPC match. Let's try the same with an icontains search.
-                matches_upc = Product.objects.filter(Q(upc__icontains=upc) | Q(children__upc__icontains=upc)).distinct()
+                matches_upc = Product.objects.filter(Q(upc__icontains=upc) |
+                                                     Q(children__upc__icontains=upc)).distinct()
                 queryset = queryset.filter(
                     Q(id__in=matches_upc.values('id')) | Q(id__in=matches_upc.values('parent_id')))
 

--- a/src/oscar/apps/dashboard/catalogue/views.py
+++ b/src/oscar/apps/dashboard/catalogue/views.py
@@ -147,7 +147,7 @@ class ProductListView(PartnerProductFilterMixin, SingleTableView):
             # that contain the UPC.
 
             # Look up all matches (child products, products not allowed to access) ...
-            matches_upc = Product.objects.filter(Q(upc__iexact=upc) | Q(children__upc__iexact=upc)).distinct()
+            matches_upc = Product.objects.filter(Q(upc__iexact=upc) | Q(children__upc__iexact=upc))
 
             # ... and use that to pick all standalone or parent products that the user is
             # allowed to access.
@@ -168,7 +168,7 @@ class ProductListView(PartnerProductFilterMixin, SingleTableView):
         if title:
             queryset = queryset.filter(Q(title__icontains=title) | Q(children__title__icontains=title))
 
-        return queryset
+        return queryset.distinct()
 
 
 class ProductCreateRedirectView(generic.RedirectView):

--- a/tests/integration/dashboard/test_catalogue_views.py
+++ b/tests/integration/dashboard/test_catalogue_views.py
@@ -1,0 +1,24 @@
+from django.test import TestCase
+
+from oscar.apps.dashboard.catalogue.views import ProductListView
+from oscar.core.loading import get_model
+from oscar.test.factories import create_product
+from oscar.test.utils import RequestFactory
+
+Product = get_model('catalogue', 'Product')
+
+
+class ProductListViewTestCase(TestCase):
+    def test_searching_child_product_by_title_returns_parent_product(self):
+        self.parent_product = create_product(structure=Product.PARENT, title='Parent', upc='PARENT_UPC')
+        create_product(structure=Product.CHILD, title='Child', parent=self.parent_product, upc='CHILD_UPC',
+                       partner_sku='SKU123')
+        view = ProductListView(request=RequestFactory().get('/?title=Child'))
+        assert list(view.get_queryset()) == [self.parent_product]
+
+    def test_searching_child_product_by_upc_returns_parent_product(self):
+        self.parent_product = create_product(structure=Product.PARENT, title='Parent', upc='PARENT_UPC')
+        create_product(structure=Product.CHILD, title='Child', parent=self.parent_product, upc='CHILD_UPC',
+                       partner_sku='SKU123')
+        view = ProductListView(request=RequestFactory().get('/?upc=CHILD_UPC'))
+        assert list(view.get_queryset()) == [self.parent_product]

--- a/tests/integration/dashboard/test_catalogue_views.py
+++ b/tests/integration/dashboard/test_catalogue_views.py
@@ -11,14 +11,26 @@ Product = get_model('catalogue', 'Product')
 class ProductListViewTestCase(TestCase):
     def test_searching_child_product_by_title_returns_parent_product(self):
         self.parent_product = create_product(structure=Product.PARENT, title='Parent', upc='PARENT_UPC')
-        create_product(structure=Product.CHILD, title='Child', parent=self.parent_product, upc='CHILD_UPC',
-                       partner_sku='SKU123')
+        create_product(structure=Product.CHILD, title='Child', parent=self.parent_product, upc='CHILD_UPC')
         view = ProductListView(request=RequestFactory().get('/?title=Child'))
+        assert list(view.get_queryset()) == [self.parent_product]
+
+    def test_searching_child_product_by_title_returns_1_parent_product_if_title_is_partially_shared(self):
+        self.parent_product = create_product(structure=Product.PARENT, title='Shared', upc='PARENT_UPC')
+        create_product(structure=Product.CHILD, title='Shared', parent=self.parent_product, upc='CHILD_UPC')
+        create_product(structure=Product.CHILD, title='Shared1', parent=self.parent_product, upc='CHILD_UPC1')
+        view = ProductListView(request=RequestFactory().get('/?title=Shared'))
         assert list(view.get_queryset()) == [self.parent_product]
 
     def test_searching_child_product_by_upc_returns_parent_product(self):
         self.parent_product = create_product(structure=Product.PARENT, title='Parent', upc='PARENT_UPC')
-        create_product(structure=Product.CHILD, title='Child', parent=self.parent_product, upc='CHILD_UPC',
-                       partner_sku='SKU123')
+        create_product(structure=Product.CHILD, title='Child', parent=self.parent_product, upc='CHILD_UPC')
         view = ProductListView(request=RequestFactory().get('/?upc=CHILD_UPC'))
+        assert list(view.get_queryset()) == [self.parent_product]
+
+    def test_searching_child_product_by_upc_returns_1_parent_product_if_upc_is_partially_shared(self):
+        self.parent_product = create_product(structure=Product.PARENT, title='Parent', upc='PARENT_UPC')
+        create_product(structure=Product.CHILD, title='Child', parent=self.parent_product, upc='CHILD_UPC')
+        create_product(structure=Product.CHILD, title='Child1', parent=self.parent_product, upc='CHILD_UPC1')
+        view = ProductListView(request=RequestFactory().get('/?upc=CHILD'))
         assert list(view.get_queryset()) == [self.parent_product]


### PR DESCRIPTION
Searching by UPC/title in the dashboard should also search child products and show the parent product in the results.