### PR TITLE
Added refresh method to refetch the product attribute values from the db

### DIFF
--- a/src/oscar/apps/catalogue/product_attributes.py
+++ b/src/oscar/apps/catalogue/product_attributes.py
@@ -9,6 +9,10 @@ class ProductAttributesContainer:
     To set attributes on a product, use the `attr` attribute:
 
         product.attr.weight = 125
+
+    To refetch the attribute values from the database:
+
+        product.attr.refresh()
     """
 
     def __setstate__(self, state):
@@ -16,6 +20,9 @@ class ProductAttributesContainer:
 
     def __init__(self, product):
         self.product = product
+        self.refresh()
+
+    def refresh(self):
         values = self.get_values().select_related('attribute')
         for v in values:
             setattr(self, v.attribute.code, v.value)

--- a/tests/integration/catalogue/test_attributes.py
+++ b/tests/integration/catalogue/test_attributes.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 
-from oscar.apps.catalogue.models import Product
+from oscar.apps.catalogue.models import Product, ProductAttribute
 from oscar.test import factories
 
 
@@ -29,6 +29,20 @@ class TestContainer(TestCase):
         product = Product.objects.get(pk=product.pk)
         assert product.attr.a1 == "v2"
         assert product.attr.a3 == "v6"
+
+    def test_attributes_refresh(self):
+        product_class = factories.ProductClassFactory()
+        product_class.attributes.create(name='a1', code='a1', required=True)
+        product = factories.ProductFactory(product_class=product_class)
+        product.attr.a1 = "v1"
+        product.attr.save()
+
+        product_attr = ProductAttribute.objects.get(code="a1", product=product)
+        product_attr.save_value(product, "v2")
+        assert product.attr.a1 == "v1"
+
+        product.attr.refresh()
+        assert product.attr.a1 == "v2"
 
 
 class TestBooleanAttributes(TestCase):


### PR DESCRIPTION
In https://github.com/django-oscar/django-oscar/pull/3497 the `initiate_attributes` method was removed in order to simplify the `ProductAttributeContainer` and to introduce lazy loading. Which is 👍 of course!

In some usecases however, it would be convenient to refresh the attribute values without completely reloading the product instance from the database. For example, in OscarAPI we need [to refresh the atttributes when the Admin API is used](https://github.com/django-oscar/django-oscar-api/blob/e9924f5980ed5a0af7e0df197800987317063e30/oscarapi/serializers/admin/product.py#L164).

A `refresh` method would be much cleaner and more convenient.