### PR TITLE
Ease overriding AlertsDispatcher class

### DIFF
--- a/src/oscar/apps/customer/alerts/receivers.py
+++ b/src/oscar/apps/customer/alerts/receivers.py
@@ -1,13 +1,14 @@
 from django.conf import settings
 from django.db.models.signals import post_save
 
-from oscar.core.loading import get_model
+from oscar.core.loading import get_class, get_model
+
+AlertsDispatcher = get_class('customer.alerts.utils', 'AlertsDispatcher')
 
 
 def send_product_alerts(sender, instance, created, **kwargs):
     if kwargs.get('raw', False):
         return
-    from oscar.apps.customer.alerts.utils import AlertsDispatcher
     AlertsDispatcher().send_product_alert_email_for_user(instance.product)
 
 

--- a/src/oscar/apps/customer/alerts/utils.py
+++ b/src/oscar/apps/customer/alerts/utils.py
@@ -29,13 +29,16 @@ class AlertsDispatcher:
             mail_connection=mail_connection,
         )
 
+    def get_queryset(self):
+        return Product.objects.browsable().filter(productalert__status=ProductAlert.ACTIVE).distinct()
+
     def send_alerts(self):
         """
         Check all products with active product alerts for
         availability and send out email alerts when a product is
         available to buy.
         """
-        products = Product.objects.browsable().filter(productalert__status=ProductAlert.ACTIVE).distinct()
+        products = self.get_queryset()
         self.dispatcher.logger.info("Found %d products with active alerts", products.count())
         for product in products:
             self.send_product_alert_email_for_user(product)

--- a/src/oscar/apps/customer/alerts/views.py
+++ b/src/oscar/apps/customer/alerts/views.py
@@ -5,13 +5,13 @@ from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext_lazy as _
 from django.views import generic
 
-from oscar.apps.customer.alerts.utils import AlertsDispatcher
 from oscar.core.loading import get_class, get_model
 
 Product = get_model('catalogue', 'Product')
 ProductAlert = get_model('customer', 'ProductAlert')
 PageTitleMixin = get_class('customer.mixins', 'PageTitleMixin')
 ProductAlertForm = get_class('customer.forms', 'ProductAlertForm')
+AlertsDispatcher = get_class('customer.alerts.utils', 'AlertsDispatcher')
 
 
 class ProductAlertListView(PageTitleMixin, generic.ListView):

--- a/src/oscar/management/commands/oscar_send_alerts.py
+++ b/src/oscar/management/commands/oscar_send_alerts.py
@@ -3,9 +3,11 @@ import logging
 from django.core.management.base import BaseCommand
 from django.utils.translation import gettext_lazy as _
 
-from oscar.apps.customer.alerts.utils import AlertsDispatcher
+from oscar.core.loading import get_class
 
 logger = logging.getLogger(__name__)
+
+AlertsDispatcher = get_class('customer.alerts.utils', 'AlertsDispatcher')
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
Extract `queryset` that returns `products` worthy of sending alerts to a `get_queryset()` method and dynamically import `AlertsDispatcher` class to make it easy to override.