### PR TITLE
Update several test/development dependencies and add support for Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         django-version: [2.2, 3.0, 3.1]
     services:
       postgres:

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,13 +20,12 @@ whitenoise==5.2.0
 # Linting
 flake8==3.8.4
 flake8-debugger==4.0.0
-flake8-blind-except==0.1.1
 isort==5.7.0
 
 # Helpers
 pyprof2calltree==1.4.5
 ipdb==0.13.4
-ipython>=7.12,<7.20
+ipython>=7.12,<7.21
 
 # Country data
 pycountry>=19.8,<20.8

--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,9 @@ install_requires = [
     'purl>=0.7',
     # For phone number field
     'phonenumbers',
-    'django-phonenumber-field>=3.0.0,<4.0.0',
-    # Used for oscar.test.newfactories
-    'factory-boy>=2.4.1,<3.0',
+    'django-phonenumber-field>=4.0.0,<6.0.0',
+    # Used for oscar.test.factories
+    'factory-boy>=3.0,<3.3',
     # Used for automatically building larger HTML tables
     'django-tables2>=2.3,<2.4',
     # Used for manipulating form field attributes in templates (eg: add
@@ -47,10 +47,10 @@ sorl_thumbnail_version = 'sorl-thumbnail>=12.6,<12.7'
 easy_thumbnails_version = 'easy-thumbnails>=2.7,<2.8'
 
 docs_requires = [
-    'Sphinx==2.2.2',
+    'Sphinx>=3.4,<3.5',
     'sphinxcontrib-napoleon==0.7',
-    'sphinxcontrib-spelling==4.3.0',
-    'sphinx_rtd_theme==0.4.3',
+    'sphinxcontrib-spelling==7.1.0',
+    'sphinx_rtd_theme==0.5.1',
     'sphinx-issues==1.2.0',
     sorl_thumbnail_version,
     easy_thumbnails_version,
@@ -58,13 +58,13 @@ docs_requires = [
 
 test_requires = [
     'WebTest>=2.0,<2.1',
-    'coverage>=5.0,<5.1',
+    'coverage>=5.4,<5.5',
     'django-webtest>=1.9,<1.10',
     'psycopg2-binary>=2.8,<2.9',
-    'pytest-django>=3.7,<3.8',
-    'pytest-xdist>=1.31,<1.32',
-    'tox>=3.14,<3.15',
-    'freezegun>=0.3,<0.4',
+    'pytest-django>=3.7,<3.9',
+    'pytest-xdist>=2.2,<3',
+    'tox>=3.21,<4',
+    'freezegun>=1.1,<2',
     sorl_thumbnail_version,
     easy_thumbnails_version,
 ]
@@ -107,6 +107,8 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Software Development :: Libraries :: Application Frameworks']
 )
 

--- a/src/oscar/test/factories/address.py
+++ b/src/oscar/test/factories/address.py
@@ -8,7 +8,7 @@ __all__ = [
 ]
 
 
-class CountryFactory(factory.DjangoModelFactory):
+class CountryFactory(factory.django.DjangoModelFactory):
     iso_3166_1_a2 = 'GB'
     printable_name = "UNITED KINGDOM"
 
@@ -17,7 +17,7 @@ class CountryFactory(factory.DjangoModelFactory):
         django_get_or_create = ('iso_3166_1_a2',)
 
 
-class UserAddressFactory(factory.DjangoModelFactory):
+class UserAddressFactory(factory.django.DjangoModelFactory):
     title = "Dr"
     first_name = "Barry"
     last_name = 'Barrington'

--- a/src/oscar/test/factories/basket.py
+++ b/src/oscar/test/factories/basket.py
@@ -10,7 +10,7 @@ __all__ = [
 ]
 
 
-class BasketFactory(factory.DjangoModelFactory):
+class BasketFactory(factory.django.DjangoModelFactory):
 
     @factory.post_generation
     def set_strategy(self, create, extracted, **kwargs):
@@ -21,7 +21,7 @@ class BasketFactory(factory.DjangoModelFactory):
         model = get_model('basket', 'Basket')
 
 
-class BasketLineAttributeFactory(factory.DjangoModelFactory):
+class BasketLineAttributeFactory(factory.django.DjangoModelFactory):
     option = factory.SubFactory('oscar.test.factories.OptionFactory')
 
     class Meta:

--- a/src/oscar/test/factories/catalogue.py
+++ b/src/oscar/test/factories/catalogue.py
@@ -13,7 +13,7 @@ __all__ = [
 ]
 
 
-class ProductClassFactory(factory.DjangoModelFactory):
+class ProductClassFactory(factory.django.DjangoModelFactory):
     name = "Books"
     requires_shipping = True
     track_stock = True
@@ -22,7 +22,7 @@ class ProductClassFactory(factory.DjangoModelFactory):
         model = get_model('catalogue', 'ProductClass')
 
 
-class ProductFactory(factory.DjangoModelFactory):
+class ProductFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = get_model('catalogue', 'Product')
 
@@ -37,7 +37,7 @@ class ProductFactory(factory.DjangoModelFactory):
         'oscar.test.factories.ProductCategoryFactory', 'product')
 
 
-class CategoryFactory(factory.DjangoModelFactory):
+class CategoryFactory(factory.django.DjangoModelFactory):
     name = factory.Sequence(lambda n: 'Category %d' % n)
 
     # Very naive handling of treebeard node fields. Works though!
@@ -48,14 +48,14 @@ class CategoryFactory(factory.DjangoModelFactory):
         model = get_model('catalogue', 'Category')
 
 
-class ProductCategoryFactory(factory.DjangoModelFactory):
+class ProductCategoryFactory(factory.django.DjangoModelFactory):
     category = factory.SubFactory(CategoryFactory)
 
     class Meta:
         model = get_model('catalogue', 'ProductCategory')
 
 
-class ProductAttributeFactory(factory.DjangoModelFactory):
+class ProductAttributeFactory(factory.django.DjangoModelFactory):
     code = name = 'weight'
     product_class = factory.SubFactory(ProductClassFactory)
     type = "float"
@@ -64,7 +64,7 @@ class ProductAttributeFactory(factory.DjangoModelFactory):
         model = get_model('catalogue', 'ProductAttribute')
 
 
-class OptionFactory(factory.DjangoModelFactory):
+class OptionFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = get_model('catalogue', 'Option')
 
@@ -74,7 +74,7 @@ class OptionFactory(factory.DjangoModelFactory):
     required = False
 
 
-class AttributeOptionFactory(factory.DjangoModelFactory):
+class AttributeOptionFactory(factory.django.DjangoModelFactory):
     # Ideally we'd get_or_create a AttributeOptionGroup here, but I'm not
     # aware of how to not create a unique option group for each call of the
     # factory
@@ -85,14 +85,14 @@ class AttributeOptionFactory(factory.DjangoModelFactory):
         model = get_model('catalogue', 'AttributeOption')
 
 
-class AttributeOptionGroupFactory(factory.DjangoModelFactory):
+class AttributeOptionGroupFactory(factory.django.DjangoModelFactory):
     name = 'Grüppchen'
 
     class Meta:
         model = get_model('catalogue', 'AttributeOptionGroup')
 
 
-class ProductAttributeValueFactory(factory.DjangoModelFactory):
+class ProductAttributeValueFactory(factory.django.DjangoModelFactory):
     attribute = factory.SubFactory(ProductAttributeFactory)
     product = factory.SubFactory(ProductFactory)
 
@@ -100,7 +100,7 @@ class ProductAttributeValueFactory(factory.DjangoModelFactory):
         model = get_model('catalogue', 'ProductAttributeValue')
 
 
-class ProductReviewFactory(factory.DjangoModelFactory):
+class ProductReviewFactory(factory.django.DjangoModelFactory):
     score = 5
     product = factory.SubFactory(ProductFactory, stockrecords=[])
 
@@ -108,7 +108,7 @@ class ProductReviewFactory(factory.DjangoModelFactory):
         model = get_model('reviews', 'ProductReview')
 
 
-class ProductImageFactory(factory.DjangoModelFactory):
+class ProductImageFactory(factory.django.DjangoModelFactory):
     product = factory.SubFactory(ProductFactory, stockrecords=[])
     original = factory.django.ImageField(width=100, height=200, filename='test_image.jpg')
 

--- a/src/oscar/test/factories/contrib.py
+++ b/src/oscar/test/factories/contrib.py
@@ -5,7 +5,7 @@ from django.contrib.sites import models as sites_models
 __all__ = ['PermissionFactory', 'SiteFactory']
 
 
-class PermissionFactory(factory.DjangoModelFactory):
+class PermissionFactory(factory.django.DjangoModelFactory):
     name = 'Dummy permission'
     codename = 'dummy'
 
@@ -14,7 +14,7 @@ class PermissionFactory(factory.DjangoModelFactory):
         django_get_or_create = ('content_type', 'codename')
 
 
-class SiteFactory(factory.DjangoModelFactory):
+class SiteFactory(factory.django.DjangoModelFactory):
     domain = factory.Sequence(lambda n: 'site-%d.oscarcommerce.com' % n)
 
     class Meta:

--- a/src/oscar/test/factories/customer.py
+++ b/src/oscar/test/factories/customer.py
@@ -6,7 +6,7 @@ from oscar.core.loading import get_model
 __all__ = ['ProductAlertFactory', 'UserFactory']
 
 
-class ProductAlertFactory(factory.DjangoModelFactory):
+class ProductAlertFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = get_model('customer', 'ProductAlert')
 
@@ -15,7 +15,7 @@ class ProductAlertFactory(factory.DjangoModelFactory):
     status = Meta.model.ACTIVE
 
 
-class UserFactory(factory.DjangoModelFactory):
+class UserFactory(factory.django.DjangoModelFactory):
     username = factory.Sequence(lambda n: 'the_j_meister nummer %d' % n)
     email = factory.Sequence(lambda n: 'example_%s@example.com' % n)
     first_name = 'joseph'

--- a/src/oscar/test/factories/offer.py
+++ b/src/oscar/test/factories/offer.py
@@ -8,7 +8,7 @@ __all__ = [
 ]
 
 
-class RangeFactory(factory.DjangoModelFactory):
+class RangeFactory(factory.django.DjangoModelFactory):
     name = factory.Sequence(lambda n: 'Range %d' % n)
     slug = factory.Sequence(lambda n: 'range-%d' % n)
 
@@ -26,7 +26,7 @@ class RangeFactory(factory.DjangoModelFactory):
             RangeProduct.objects.create(product=product, range=self)
 
 
-class BenefitFactory(factory.DjangoModelFactory):
+class BenefitFactory(factory.django.DjangoModelFactory):
     type = get_model('offer', 'Benefit').PERCENTAGE
     value = 10
     max_affected_items = None
@@ -36,7 +36,7 @@ class BenefitFactory(factory.DjangoModelFactory):
         model = get_model('offer', 'Benefit')
 
 
-class ConditionFactory(factory.DjangoModelFactory):
+class ConditionFactory(factory.django.DjangoModelFactory):
     type = get_model('offer', 'Condition').COUNT
     value = 10
     range = factory.SubFactory(RangeFactory)
@@ -45,7 +45,7 @@ class ConditionFactory(factory.DjangoModelFactory):
         model = get_model('offer', 'Condition')
 
 
-class ConditionalOfferFactory(factory.DjangoModelFactory):
+class ConditionalOfferFactory(factory.django.DjangoModelFactory):
     name = factory.Sequence(lambda n: 'Test offer %d' % n)
     benefit = factory.SubFactory(BenefitFactory)
     condition = factory.SubFactory(ConditionFactory)

--- a/src/oscar/test/factories/order.py
+++ b/src/oscar/test/factories/order.py
@@ -17,7 +17,7 @@ __all__ = [
 ]
 
 
-class BillingAddressFactory(factory.DjangoModelFactory):
+class BillingAddressFactory(factory.django.DjangoModelFactory):
     country = factory.SubFactory('oscar.test.factories.CountryFactory')
 
     first_name = 'John'
@@ -31,7 +31,7 @@ class BillingAddressFactory(factory.DjangoModelFactory):
         model = get_model('order', 'BillingAddress')
 
 
-class ShippingAddressFactory(factory.DjangoModelFactory):
+class ShippingAddressFactory(factory.django.DjangoModelFactory):
     country = factory.SubFactory('oscar.test.factories.CountryFactory')
 
     first_name = 'John'
@@ -46,13 +46,13 @@ class ShippingAddressFactory(factory.DjangoModelFactory):
         model = get_model('order', 'ShippingAddress')
 
 
-class OrderDiscountFactory(factory.DjangoModelFactory):
+class OrderDiscountFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = get_model('order', 'OrderDiscount')
 
 
-class OrderFactory(factory.DjangoModelFactory):
+class OrderFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = get_model('order', 'Order')
 
@@ -105,7 +105,7 @@ class OrderFactory(factory.DjangoModelFactory):
                 OrderCreator().create_line_models(obj, line)
 
 
-class OrderLineFactory(factory.DjangoModelFactory):
+class OrderLineFactory(factory.django.DjangoModelFactory):
     order = factory.SubFactory(OrderFactory)
     product = factory.SubFactory(
         'oscar.test.factories.ProductFactory')
@@ -129,7 +129,7 @@ class OrderLineFactory(factory.DjangoModelFactory):
         model = get_model('order', 'Line')
 
 
-class ShippingEventTypeFactory(factory.DjangoModelFactory):
+class ShippingEventTypeFactory(factory.django.DjangoModelFactory):
     name = 'Test event'
     code = factory.LazyAttribute(lambda o: slugify(o.name).replace('-', '_'))
 
@@ -138,7 +138,7 @@ class ShippingEventTypeFactory(factory.DjangoModelFactory):
         django_get_or_create = ('code', )
 
 
-class ShippingEventFactory(factory.DjangoModelFactory):
+class ShippingEventFactory(factory.django.DjangoModelFactory):
 
     order = factory.SubFactory(OrderFactory)
     event_type = factory.SubFactory(ShippingEventTypeFactory)

--- a/src/oscar/test/factories/partner.py
+++ b/src/oscar/test/factories/partner.py
@@ -9,7 +9,7 @@ __all__ = [
 ]
 
 
-class PartnerFactory(factory.DjangoModelFactory):
+class PartnerFactory(factory.django.DjangoModelFactory):
     name = "Gardners"
 
     class Meta:
@@ -25,7 +25,7 @@ class PartnerFactory(factory.DjangoModelFactory):
                 self.users.add(user)
 
 
-class StockRecordFactory(factory.DjangoModelFactory):
+class StockRecordFactory(factory.django.DjangoModelFactory):
     partner = factory.SubFactory(PartnerFactory)
     partner_sku = factory.Sequence(lambda n: 'unit%d' % n)
     price_currency = "GBP"

--- a/src/oscar/test/factories/payment.py
+++ b/src/oscar/test/factories/payment.py
@@ -7,7 +7,7 @@ __all__ = [
 ]
 
 
-class SourceTypeFactory(factory.DjangoModelFactory):
+class SourceTypeFactory(factory.django.DjangoModelFactory):
     name = 'Creditcard'
     code = 'creditcard'
 
@@ -15,7 +15,7 @@ class SourceTypeFactory(factory.DjangoModelFactory):
         model = get_model('payment', 'SourceType')
 
 
-class SourceFactory(factory.DjangoModelFactory):
+class SourceFactory(factory.django.DjangoModelFactory):
     order = factory.SubFactory(
         'oscar.test.factories.OrderFactory')
     source_type = factory.SubFactory(SourceTypeFactory)
@@ -24,7 +24,7 @@ class SourceFactory(factory.DjangoModelFactory):
         model = get_model('payment', 'Source')
 
 
-class TransactionFactory(factory.DjangoModelFactory):
+class TransactionFactory(factory.django.DjangoModelFactory):
     amount = factory.LazyAttribute(lambda obj: obj.source.order.total_incl_tax)
     reference = factory.LazyAttribute(lambda obj: obj.source.order.number)
     source = factory.SubFactory(SourceFactory)

--- a/src/oscar/test/factories/voucher.py
+++ b/src/oscar/test/factories/voucher.py
@@ -9,7 +9,7 @@ from oscar.test.factories import ConditionalOfferFactory
 __all__ = ['VoucherFactory', 'VoucherSetFactory']
 
 
-class VoucherFactory(factory.DjangoModelFactory):
+class VoucherFactory(factory.django.DjangoModelFactory):
     name = "My voucher"
     code = "MYVOUCHER"
 
@@ -20,7 +20,7 @@ class VoucherFactory(factory.DjangoModelFactory):
         model = get_model('voucher', 'Voucher')
 
 
-class VoucherSetFactory(factory.DjangoModelFactory):
+class VoucherSetFactory(factory.django.DjangoModelFactory):
     name = factory.Sequence(lambda n: 'Voucher Set %d' % n)
     count = 100
     code_length = 12

--- a/src/oscar/test/factories/wishlists.py
+++ b/src/oscar/test/factories/wishlists.py
@@ -5,7 +5,7 @@ from oscar.core.loading import get_model
 __all__ = ['WishListFactory']
 
 
-class WishListFactory(factory.DjangoModelFactory):
+class WishListFactory(factory.django.DjangoModelFactory):
     name = factory.Sequence(lambda n: 'Wishlist %d' % n)
 
     class Meta:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38}-django{22,30,31}
+    py{36,37,38,39}-django{22,30,31}
     lint
     sandbox
     docs


### PR DESCRIPTION
Also remove `flake8-blind-except` which causes lint errors for cases where we legitimately catch bare exceptions. I think those are better judged on a case-by-case basis rather than blindly.