### PR TITLE
Remove deprecated providing_args argument from signals.

### DIFF
--- a/src/oscar/apps/basket/signals.py
+++ b/src/oscar/apps/basket/signals.py
@@ -1,8 +1,5 @@
 import django.dispatch
 
-basket_addition = django.dispatch.Signal(
-    providing_args=["product", "user", "request"])
-voucher_addition = django.dispatch.Signal(
-    providing_args=["basket", "voucher"])
-voucher_removal = django.dispatch.Signal(
-    providing_args=["basket", "voucher"])
+basket_addition = django.dispatch.Signal()
+voucher_addition = django.dispatch.Signal()
+voucher_removal = django.dispatch.Signal()

--- a/src/oscar/apps/catalogue/reviews/signals.py
+++ b/src/oscar/apps/catalogue/reviews/signals.py
@@ -1,4 +1,3 @@
 import django.dispatch
 
-review_added = django.dispatch.Signal(
-    providing_args=["review", "user", "request", "response"])
+review_added = django.dispatch.Signal()

--- a/src/oscar/apps/catalogue/signals.py
+++ b/src/oscar/apps/catalogue/signals.py
@@ -1,4 +1,3 @@
 import django.dispatch
 
-product_viewed = django.dispatch.Signal(
-    providing_args=["product", "user", "request", "response"])
+product_viewed = django.dispatch.Signal()

--- a/src/oscar/apps/checkout/signals.py
+++ b/src/oscar/apps/checkout/signals.py
@@ -1,6 +1,6 @@
 from django.dispatch import Signal
 
-start_checkout = Signal(providing_args=["request"])
-pre_payment = Signal(providing_args=["view"])
-post_payment = Signal(providing_args=["view"])
-post_checkout = Signal(providing_args=["order", "user", "request", "response"])
+start_checkout = Signal()
+pre_payment = Signal()
+post_payment = Signal()
+post_checkout = Signal()

--- a/src/oscar/apps/customer/signals.py
+++ b/src/oscar/apps/customer/signals.py
@@ -1,4 +1,4 @@
 from django.dispatch import Signal
 
-user_registered = Signal(providing_args=["request", "user"])
-user_logged_in = Signal(providing_args=["request", "user"])
+user_registered = Signal()
+user_logged_in = Signal()

--- a/src/oscar/apps/order/signals.py
+++ b/src/oscar/apps/order/signals.py
@@ -1,9 +1,7 @@
 import django.dispatch
 
-order_placed = django.dispatch.Signal(providing_args=["order", "user"])
+order_placed = django.dispatch.Signal()
 
-order_status_changed = django.dispatch.Signal(
-    providing_args=["order", "old_status", "new_status"])
+order_status_changed = django.dispatch.Signal()
 
-order_line_status_changed = django.dispatch.Signal(
-    providing_args=["line", "old_status", "new_status"])
+order_line_status_changed = django.dispatch.Signal()

--- a/src/oscar/apps/search/signals.py
+++ b/src/oscar/apps/search/signals.py
@@ -1,3 +1,3 @@
 from django.dispatch import Signal
 
-user_search = Signal(providing_args=["session_id", "user", "query"])
+user_search = Signal()


### PR DESCRIPTION
The `providing_args` argument was [deprecated in Django 3.1](https://docs.djangoproject.com/en/3.1/releases/3.1/), with no replacement. It was purely informational. The `providing_args` were actually wrong in quite a few cases (probably because the signal call site has changed, without updating the signal definition). 

The Django documentation recommends using comments to replace this - I've not done that here because I'm not sure that adding comments to where the signal is defined is very useful - it seems better just to inspect the code that is firing the signal?