### PR TITLE
Pin treebeard dependency to <4.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ install_requires = [
     # Search support
     'django-haystack>=3.0b1',
     # Treebeard is used for categories
-    'django-treebeard>=4.3.0',
+    'django-treebeard>=4.3,<4.5',
     # Babel is used for currency formatting
     'Babel>=1.0,<3.0',
     # For manipulating search URLs


### PR DESCRIPTION
See https://github.com/django-treebeard/django-treebeard/issues/210 - Treebeard version 4.5 breaks Oscar (can be verified by attempting to run our test suite against it). For now, let's pin this dependency and issue a patch release of Oscar. We will in any case have to declare version 4.5.0 as incompatible, assuming that the migration issue is fixed in a subsequent version.

For any project that depends on Oscar, running into issues, I think the simplest fix for now is to pin treebeard in your own dependencies.