### PR TITLE
Remove old JS/CSS used for IE compatibility.

### DIFF
--- a/src/oscar/static_src/oscar/js/oscar/ui.js
+++ b/src/oscar/static_src/oscar/js/oscar/ui.js
@@ -150,26 +150,6 @@ var oscar = (function(o, $) {
         }
     };
 
-    // IE compabibility hacks
-    o.compatibility = {
-        init: function() {
-            if (!o.compatibility.isIE()) return;
-            // Set the width of a select in an overflow hidden container.
-            // This is for add-to-basket forms within browing pages
-            $('.product_pod select').on({
-                mousedown: function(){
-                    $(this).addClass("select-open");
-                },
-                change: function(){
-                    $(this).removeClass("select-open");
-                }
-            });
-        },
-        isIE: function() {
-            return navigator.userAgent.toLowerCase().indexOf("msie") > -1;
-        }
-    };
-
     o.basket = {
         is_form_being_submitted: false,
         init: function(options) {
@@ -350,7 +330,6 @@ var oscar = (function(o, $) {
         o.page.init();
         o.responsive.init();
         o.responsive.initSlider();
-        o.compatibility.init();
     };
 
     return o;

--- a/src/oscar/static_src/oscar/scss/page/forms.scss
+++ b/src/oscar/static_src/oscar/scss/page/forms.scss
@@ -5,11 +5,6 @@ form {
   @include clearfix;
 }
 
-// For IE: adds width for selects inside overflow hidden containers
-.select-open {
-  width: 300px !important;
-}
-
 // Additional errors
 .errorlist {
   margin: 0;


### PR DESCRIPTION
These hacks appear to be [at least 9 years](https://github.com/django-oscar/django-oscar/commit/da2889be9d777b9b4917f82f47dee566f438e964) old... fond memories of IE6.