### PR TITLE
Remove redundant JS from ui.js

### DIFF
--- a/src/oscar/static_src/oscar/js/oscar/ui.js
+++ b/src/oscar/static_src/oscar/js/oscar/ui.js
@@ -104,52 +104,6 @@ var oscar = (function(o, $) {
         }
     };
 
-
-    o.page = {
-        init: function() {
-            // Scroll to sections
-            $('.top_page a').click(function(e) {
-                var href = $(this).attr('href');
-                $('html, body').animate({
-                    scrollTop: $(href).offset().top
-                }, 500);
-                e.preventDefault();
-            });
-            // Tooltips
-            $('[rel="tooltip"]').tooltip();
-        }
-    };
-
-    o.responsive = {
-        init: function() {
-            if (o.responsive.isDesktop()) {
-                o.responsive.initNav();
-            }
-        },
-        isDesktop: function() {
-            return document.body.clientWidth > 767;
-        },
-        initNav: function() {
-            // Initial navigation for desktop
-            var $sidebar = $('aside.col-sm-3'),
-                $browse = $('[data-navigation="dropdown-menu"]'),
-                $browseOpen = $browse.parent().find('> a[data-toggle]');
-            // Set width of nav dropdown to be same as sidebar
-            $browse.css('width', $sidebar.outerWidth());
-            // Remove click on browse button if menu is currently open
-            if (!$browseOpen.length) {
-                $browse.parent().find('> a').off('click');
-                // Set margin top of aside allow space for open navigation
-                $sidebar.css({ marginTop: $browse.outerHeight() });
-            }
-        },
-        initSlider: function() {
-            $('.carousel').carousel({
-                interval: 20000
-            });
-        }
-    };
-
     o.basket = {
         is_form_being_submitted: false,
         init: function(options) {
@@ -327,9 +281,6 @@ var oscar = (function(o, $) {
     o.init = function() {
         o.forms.init();
         o.datetimepickers.init();
-        o.page.init();
-        o.responsive.init();
-        o.responsive.initSlider();
     };
 
     return o;

--- a/src/oscar/templates/oscar/catalogue/partials/gallery.html
+++ b/src/oscar/templates/oscar/catalogue/partials/gallery.html
@@ -6,7 +6,7 @@
 
     {% if all_images|length > 1 %}
 
-        <div id="product_gallery" class="carousel slide" data-ride="carousel">
+        <div id="product_gallery" class="carousel slide">
 
             <div class="img-thumbnail mb-3">
                 <div class="carousel-inner">


### PR DESCRIPTION
Removes a whole load of old JS:

1. `o.page.init` provided in-page scroll effects for links in the top navigation, from a time when those links linked to other sections on the page. It doesn't do anything now.
2. `o.page.init` also added some tooltip handling JS - I can't find any HTML that uses `rel="tooltip"` anywhere in our code.
3. `o.responsive.initNav` was doing nothing at all - the elements it is looking for no longer exist. We should be relying on BS4 for this sort of thing anyway.
4. `o.responsive.initSlider` was initialising the product detail gallery with an interval of 20 seconds (overriding the default of 5 seconds) - which is so long that you'd probably not notice it anyway. I've removed the auto-sliding altogether. 