### PR TITLE
Fix logic for cleaning voucher start/end datetimes.

### DIFF
--- a/src/oscar/apps/voucher/abstract_models.py
+++ b/src/oscar/apps/voucher/abstract_models.py
@@ -170,10 +170,8 @@ class AbstractVoucher(models.Model):
         return self.name
 
     def clean(self):
-        if all([self.start_datetime, self.end_datetime,
-                self.start_datetime > self.end_datetime]):
-            raise exceptions.ValidationError(
-                _('End date should be later than start date'))
+        if self.start_datetime and self.end_datetime and self.start_datetime > self.end_datetime:
+            raise exceptions.ValidationError(_('End date should be later than start date'))
 
     def save(self, *args, **kwargs):
         self.code = self.code.upper()


### PR DESCRIPTION
Using `all()` with a list is problematic because all items in the list will be evaluated before passing to `all()`, and we can't do the `>` check unless both the datetimes are non-null.

Fixes #3619. 