### PR TITLE
Simplify code for several old template tags.

### DIFF
--- a/src/oscar/templates/oscar/dashboard/catalogue/product_list.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/product_list.html
@@ -1,7 +1,6 @@
 {% extends 'oscar/dashboard/layout.html' %}
 {% load i18n %}
 {% load render_table from django_tables2 %}
-{% load sorting_tags %}
 
 {% block body_class %}{{ block.super }} catalogue{% endblock %}
 

--- a/src/oscar/templates/oscar/dashboard/partners/partner_manage.html
+++ b/src/oscar/templates/oscar/dashboard/partners/partner_manage.html
@@ -1,5 +1,4 @@
 {% extends 'oscar/dashboard/layout.html' %}
-{% load sorting_tags %}
 {% load i18n %}
 
 {% block body_class %}{{ block.super }} create-page partners{% endblock %}

--- a/src/oscar/templates/oscar/dashboard/partners/partner_user_list.html
+++ b/src/oscar/templates/oscar/dashboard/partners/partner_user_list.html
@@ -1,5 +1,4 @@
 {% extends 'oscar/dashboard/layout.html' %}
-{% load sorting_tags %}
 {% load i18n %}
 
 {% block title %}

--- a/src/oscar/templates/oscar/dashboard/partners/partner_user_select.html
+++ b/src/oscar/templates/oscar/dashboard/partners/partner_user_select.html
@@ -1,5 +1,4 @@
 {% extends 'oscar/dashboard/layout.html' %}
-{% load sorting_tags %}
 {% load i18n %}
 
 {% block title %}

--- a/src/oscar/templatetags/display_tags.py
+++ b/src/oscar/templatetags/display_tags.py
@@ -5,41 +5,17 @@ from oscar.core.loading import feature_hidden
 register = template.Library()
 
 
-def get_parameters(parser, token):
-    """
-    {% get_parameters except_field %}
-    """
-
-    args = token.split_contents()
-    if len(args) < 2:
-        raise template.TemplateSyntaxError(
-            "get_parameters tag takes at least 1 argument")
-    return GetParametersNode(args[1].strip())
-
-
-class GetParametersNode(template.Node):
+@register.simple_tag(takes_context=True)
+def get_parameters(context, except_field):
     """
     Renders current get parameters except for the specified parameter
     """
-    def __init__(self, field):
-        self.field = field
+    getvars = context['request'].GET.copy()
+    getvars.pop(except_field, None)
+    if len(getvars.keys()) > 0:
+        return "%s&" % getvars.urlencode()
 
-    def render(self, context):
-        request = context['request']
-        getvars = request.GET.copy()
-
-        if self.field in getvars:
-            del getvars[self.field]
-
-        if len(getvars.keys()) > 0:
-            get_params = "%s&" % getvars.urlencode()
-        else:
-            get_params = ''
-
-        return get_params
-
-
-get_parameters = register.tag(get_parameters)
+    return ''
 
 
 @register.tag()

--- a/src/oscar/templatetags/wishlist_tags.py
+++ b/src/oscar/templatetags/wishlist_tags.py
@@ -3,36 +3,6 @@ from django import template
 register = template.Library()
 
 
-@register.tag(name="wishlists_containing_product")
-def do_basket_form(parse, token):
-    """
-    Template tag for adding the user's wishlists form to the
-    template context so it can be rendered.
-    """
-    tokens = token.split_contents()
-    if len(tokens) != 5:
-        raise template.TemplateSyntaxError(
-            "%r tag uses the following syntax: "
-            "{%% wishlists_containing_product wishlists product as "
-            "ctx_var %%}" % tokens[0])
-
-    wishlists_var, product_var, name_var = tokens[1], tokens[2], tokens[4]
-    return ProductWishlistsNode(
-        wishlists_var, product_var, name_var)
-
-
-class ProductWishlistsNode(template.Node):
-    def __init__(self, wishlists_var, product_var, name_var):
-        self.wishlists_var = template.Variable(wishlists_var)
-        self.product_var = template.Variable(product_var)
-        self.name_var = name_var
-
-    def render(self, context):
-        try:
-            wishlists = self.wishlists_var.resolve(context)
-            product = self.product_var.resolve(context)
-        except template.VariableDoesNotExist:
-            return ''
-        context[self.name_var] = wishlists.filter(
-            lines__product=product)
-        return ''
+@register.simple_tag
+def wishlists_containing_product(wishlists, product):
+    return wishlists.filter(lines__product=product)

--- a/tests/unit/templatetags/test_display_tags.py
+++ b/tests/unit/templatetags/test_display_tags.py
@@ -1,0 +1,16 @@
+from django.test import RequestFactory, TestCase
+
+from oscar.templatetags.display_tags import get_parameters
+
+
+class DisplayTagsTestCase(TestCase):
+
+    def test_get_parameters_strips_except_field(self):
+        ctx = {'request': RequestFactory().get('/?foo=bar&bar=baz')}
+        self.assertEqual(get_parameters(ctx, 'foo'), 'bar=baz&')
+        self.assertEqual(get_parameters(ctx, 'bar'), 'foo=bar&')
+        self.assertEqual(get_parameters(ctx, 'invalid'), 'foo=bar&bar=baz&')
+
+    def test_get_parameters_returns_empty_string_if_no_params_left(self):
+        ctx = {'request': RequestFactory().get('/?foo=bar')}
+        self.assertEqual(get_parameters(ctx, 'foo'), '')

--- a/tests/unit/templatetags/test_sorting_tags.py
+++ b/tests/unit/templatetags/test_sorting_tags.py
@@ -1,0 +1,18 @@
+from django.test import RequestFactory, TestCase
+
+from oscar.templatetags.sorting_tags import anchor
+
+
+class SortingTagsTestCase(TestCase):
+
+    def test_anchor_tag_output(self):
+        ctx = {'request': RequestFactory().get('/')}
+        # No title supplied
+        self.assertEqual(anchor(ctx, 'foo'), '<a href="/?sort=foo">Foo</a>')
+        # Title supplied
+        self.assertEqual(anchor(ctx, 'foo', 'Title'), '<a href="/?sort=foo">Title</a>')
+        # Title supplied with unsafe chars
+        self.assertEqual(anchor(ctx, 'foo', 'Ti&tle'), '<a href="/?sort=foo">Ti&amp;tle</a>')
+        # Reverse sort order
+        ctx = {'request': RequestFactory().get('/?sort=foo&dir=asc')}
+        self.assertEqual(anchor(ctx, 'foo'), '<a href="/?sort=foo&dir=desc">Foo <i class="fas fa-chevron-up"></i></a>')

--- a/tests/unit/templatetags/test_wishlist_tags.py
+++ b/tests/unit/templatetags/test_wishlist_tags.py
@@ -1,0 +1,24 @@
+from django.test import TestCase
+
+from oscar.core.loading import get_model
+from oscar.templatetags.wishlist_tags import wishlists_containing_product
+from oscar.test.factories import ProductFactory, UserFactory, WishListFactory
+
+Wishlist = get_model('wishlists', 'Wishlist')
+
+
+class WishlistTagsTestCase(TestCase):
+
+    def test_wishlists_containing_product(self):
+        p1 = ProductFactory()
+        p2 = ProductFactory()
+        user = UserFactory()
+        wishlist1 = WishListFactory(owner=user)
+        WishListFactory(owner=user)
+        wishlist1.add(p1)
+
+        containing_one = wishlists_containing_product(Wishlist.objects.all(), p1)
+        self.assertEqual(len(containing_one), 1)
+        self.assertEqual(containing_one[0], wishlist1)
+        containing_none = wishlists_containing_product(Wishlist.objects.all(), p2)
+        self.assertEqual(len(containing_none), 0)


### PR DESCRIPTION
Cleans up several old template tags to considerably simplify the code (at the time they were written Django's template tag framework was not as easy to use). None of these tags had any tests, so I've added tests for each as well.