### PR TITLE
Use minified Bootstrap JS by default.

### DIFF
--- a/gulpfile.js/subtasks/copy.js
+++ b/gulpfile.js/subtasks/copy.js
@@ -9,8 +9,10 @@ module.exports = function(done) {
     gulp.src("node_modules/jquery/dist/jquery.min.js")
         .pipe(gulp.dest("src/oscar/static/oscar/js/jquery"));
 
-    gulp.src("node_modules/bootstrap/dist/js/bootstrap.bundle.js")
-        .pipe(gulp.dest("src/oscar/static/oscar/js/bootstrap4"));
+    gulp.src([
+        "node_modules/bootstrap/dist/js/bootstrap.bundle.js",
+        "node_modules/bootstrap/dist/js/bootstrap.bundle.min.js"
+    ]).pipe(gulp.dest("src/oscar/static/oscar/js/bootstrap4"));
 
     gulp.src("node_modules/bootstrap/fonts/*")
         .pipe(gulp.dest("src/oscar/static/oscar/fonts/"));

--- a/src/oscar/templates/oscar/dashboard/layout.html
+++ b/src/oscar/templates/oscar/dashboard/layout.html
@@ -117,7 +117,7 @@
 {# Local scripts #}
 {% block scripts %}
     <!-- Twitter Bootstrap -->
-    <script src="{% static "oscar/js/bootstrap4/bootstrap.bundle.js" %}"></script>
+    <script src="{% static "oscar/js/bootstrap4/bootstrap.bundle.min.js" %}"></script>
     <!-- Oscar -->
     <script src="{% static "oscar/js/oscar/ui.js" %}"></script>
 {% endblock %}

--- a/src/oscar/templates/oscar/layout.html
+++ b/src/oscar/templates/oscar/layout.html
@@ -52,7 +52,7 @@
 {% block scripts %}
     {{ block.super }}
     <!-- Twitter Bootstrap -->
-    <script src="{% static "oscar/js/bootstrap4/bootstrap.bundle.js" %}"></script>
+    <script src="{% static "oscar/js/bootstrap4/bootstrap.bundle.min.js" %}"></script>
     <!-- Oscar -->
     <script src="{% static "oscar/js/oscar/ui.js" %}"></script>
 {% endblock %}


### PR DESCRIPTION
Fixes #3676 . The unminified version is still collected into our static directory in case projects were depending on it (and also in case they want to use it for development).