### PR TITLE
Make basket line form's 'quantity' field required

### DIFF
--- a/src/oscar/apps/basket/forms.py
+++ b/src/oscar/apps/basket/forms.py
@@ -40,9 +40,9 @@ class BasketLineForm(forms.ModelForm):
 
     def __init__(self, strategy, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        if self.data.get('quantity') == "":
+            self.data['quantity'] = 0
         self.instance.strategy = strategy
-
-        self.fields['quantity'].widget.attrs['required'] = True
 
         # Evaluate max allowed quantity check only if line still exists, in
         # order to avoid check run against missing instance -

--- a/src/oscar/apps/basket/forms.py
+++ b/src/oscar/apps/basket/forms.py
@@ -34,14 +34,12 @@ def _option_date_field(option):
 
 
 class BasketLineForm(forms.ModelForm):
-
+    quantity = forms.IntegerField(label=_('Quantity'), min_value=0, required=False, initial=1)
     save_for_later = forms.BooleanField(
         initial=False, required=False, label=_('Save for Later'))
 
     def __init__(self, strategy, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if self.data.get('quantity') == "":
-            self.data['quantity'] = 0
         self.instance.strategy = strategy
 
         # Evaluate max allowed quantity check only if line still exists, in
@@ -71,7 +69,7 @@ class BasketLineForm(forms.ModelForm):
         return super().has_changed()
 
     def clean_quantity(self):
-        qty = self.cleaned_data['quantity']
+        qty = self.cleaned_data['quantity'] or 0
         if qty > 0:
             self.check_max_allowed_quantity(qty)
             self.check_permission(qty)

--- a/src/oscar/apps/basket/forms.py
+++ b/src/oscar/apps/basket/forms.py
@@ -42,6 +42,8 @@ class BasketLineForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         self.instance.strategy = strategy
 
+        self.fields['quantity'].widget.attrs['required'] = True
+
         # Evaluate max allowed quantity check only if line still exists, in
         # order to avoid check run against missing instance -
         # https://github.com/django-oscar/django-oscar/issues/2873.

--- a/tests/integration/basket/test_forms.py
+++ b/tests/integration/basket/test_forms.py
@@ -44,6 +44,12 @@ class TestBasketLineForm(TestCase):
             data={'quantity': quantity},
             instance=self.line)
 
+    def test_empty_quantity_field_raises_validation_error(self):
+        form = self.build_form(quantity="")
+
+        self.assertFalse(form.is_valid())
+        self.assertIn('required', form.errors['quantity'][0])
+
     def test_enforces_availability_policy_for_valid_quantities(self):
         self.mock_availability_return_value(True)
         form = self.build_form()

--- a/tests/integration/basket/test_forms.py
+++ b/tests/integration/basket/test_forms.py
@@ -44,11 +44,11 @@ class TestBasketLineForm(TestCase):
             data={'quantity': quantity},
             instance=self.line)
 
-    def test_empty_quantity_field_raises_validation_error(self):
+    def test_interpret_empty_quantity_field_as_zero(self):
         form = self.build_form(quantity="")
 
-        self.assertFalse(form.is_valid())
-        self.assertIn('required', form.errors['quantity'][0])
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data['quantity'], 0)
 
     def test_enforces_availability_policy_for_valid_quantities(self):
         self.mock_availability_return_value(True)


### PR DESCRIPTION
If you empty the value in the `quantity` field and attempt to update a basket line, you'll get an error saying that "this field is required", which is not ideal. This PR seeks to address that by making the field required at the form level.