### PR TITLE
Relax pinning of several development dependencies.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,15 +7,14 @@ django-extensions>=2.2,<3.2
 psycopg2-binary>=2.8,<2.9
 
 # Sandbox
-Pillow==8.1.0
-Whoosh==2.7.4
-django-environ==0.4.5
-django-redis==4.12.1
-pysolr==3.9.0
-redis==3.5.3
-requests==2.25.1
-uWSGI==2.0.19.1
-whitenoise==5.2.0
+Whoosh>=2.7,<2.8
+django-environ>=0.4,<0.5
+django-redis>=4.12,<4.13
+pysolr>=3.9,<3.10
+redis>=3.5,<3.6
+requests>=2.25,<3
+uWSGI>=2.0.19,<2.1
+whitenoise>=5.2,<5.3
 
 # Linting
 flake8==3.8.4
@@ -23,9 +22,9 @@ flake8-debugger==4.0.0
 isort==5.7.0
 
 # Helpers
-pyprof2calltree==1.4.5
-ipdb==0.13.4
-ipython>=7.12,<7.21
+pyprof2calltree>=1.4,<1.5
+ipdb>=0.13,<0.14
+ipython>=7.12,<8
 
 # Country data
-pycountry>=19.8,<20.8
+pycountry


### PR DESCRIPTION
There have been a few security vulnerabilities fixed in [pillow](https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst). Instead of pinning specific versions I think it's preferable to pin only to minor/major versions as much as possible, as we do in `setup.py`.