### PR TITLE
Add support for django 3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        django-version: [2.2, 3.0, 3.1]
+        django-version: [2.2, 3.0, 3.1, 3.2]
     services:
       postgres:
         image: postgres:10

--- a/docs/source/releases/v3.0.rst
+++ b/docs/source/releases/v3.0.rst
@@ -19,7 +19,7 @@ also need to upgrade their frontend and dashboard templates to use Bootstrap 4.
 Compatibility
 ~~~~~~~~~~~~~
 
-Oscar 3.0 is compatible with Django 2.2, Django 3.0 and Django 3.1 as well as Python 3.6, 3.7 and 3.8.
+Oscar 3.0 is compatible with Django 2.2, Django 3.0, 3.1 and 3.2 as well as Python 3.6, 3.7 and 3.8.
 
 Support for Django 1.11 and Django 2.1 has been dropped. Support for Python 3.5 has been dropped.
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ sys.path.append(os.path.join(PROJECT_DIR, 'src'))
 from oscar import get_version  # noqa isort:skip
 
 install_requires = [
-    'django>=2.2,<3.2',
+    'django>=2.2,<3.3',
     # PIL is required for image fields, Pillow is the "friendly" PIL fork
     'pillow>=6.0',
     # We use the ModelFormSetView from django-extra-views for the basket page

--- a/tests/functional/test_basket.py
+++ b/tests/functional/test_basket.py
@@ -3,6 +3,8 @@ from decimal import Decimal as D
 from http import client as http_client
 from http.cookies import _unquote
 
+from django.core import signing
+from django.contrib.messages.storage.cookie import MessageSerializer
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils.translation import gettext
@@ -105,13 +107,17 @@ class BasketThresholdTest(WebTestCase):
                        'action': 'add',
                        'quantity': 2}
         response = self.app.post(url, params=post_params)
-
+        signer = signing.get_cookie_signer(salt='django.contrib.messages')
+        message_strings = [
+            m.message for m in signer.unsign_object(response.test_app.cookies['messages'],
+                                                    serializer=MessageSerializer)
+        ]
         expected = gettext(
             "Due to technical limitations we are not able to ship more "
             "than %(threshold)d items in one order. Your basket currently "
             "has %(basket)d items."
         ) % ({'threshold': 3, 'basket': 2})
-        self.assertIn(expected, response.test_app.cookies['messages'])
+        self.assertIn(expected, message_strings)
 
 
 class BasketReportTests(TestCase):

--- a/tests/functional/test_basket.py
+++ b/tests/functional/test_basket.py
@@ -3,8 +3,9 @@ from decimal import Decimal as D
 from http import client as http_client
 from http.cookies import _unquote
 
+import django
+from django.contrib.messages.storage import cookie
 from django.core import signing
-from django.contrib.messages.storage.cookie import MessageSerializer
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils.translation import gettext
@@ -107,17 +108,20 @@ class BasketThresholdTest(WebTestCase):
                        'action': 'add',
                        'quantity': 2}
         response = self.app.post(url, params=post_params)
-        signer = signing.get_cookie_signer(salt='django.contrib.messages')
-        message_strings = [
-            m.message for m in signer.unsign_object(response.test_app.cookies['messages'],
-                                                    serializer=MessageSerializer)
-        ]
         expected = gettext(
             "Due to technical limitations we are not able to ship more "
             "than %(threshold)d items in one order. Your basket currently "
             "has %(basket)d items."
         ) % ({'threshold': 3, 'basket': 2})
-        self.assertIn(expected, message_strings)
+        if django.VERSION < (3, 2):
+            self.assertIn(expected, response.test_app.cookies['messages'])
+        else:
+            signer = signing.get_cookie_signer(salt='django.contrib.messages')
+            message_strings = [
+                m.message for m in signer.unsign_object(response.test_app.cookies['messages'],
+                                                        serializer=cookie.MessageSerializer)
+            ]
+            self.assertIn(expected, message_strings)
 
 
 class BasketReportTests(TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39}-django{22,30,31}
+    py{36,37,38,39}-django{22,30,31,32}
     lint
     sandbox
     docs
@@ -14,6 +14,7 @@ deps =
     django22: django>=2.2,<2.3
     django30: django>=3.0,<3.1
     django31: django>=3.1,<3.2
+    django32: django>=3.2,<3.3
 
 [testenv:lint]
 basepython = python3.7


### PR DESCRIPTION
This updates Oscar's requirements to support Django 3.2 and fixes a test failure that appears related to [this change](https://docs.djangoproject.com/en/3.2/ref/contrib/messages/#django.contrib.messages.storage.cookie.CookieStorage) to the Cookie storage hash format by using the new in 3.2 [`Signer.unsign_object()`](https://docs.djangoproject.com/en/3.2/topics/signing/#signing-complex-data) method to retrieve the human-readable message for the test assertion.