### PR TITLE
Carousel's navigation vertical placement

### DIFF
--- a/src/oscar/templates/oscar/catalogue/partials/gallery.html
+++ b/src/oscar/templates/oscar/catalogue/partials/gallery.html
@@ -6,7 +6,7 @@
 
     {% if all_images|length > 1 %}
 
-        <div id="product_gallery" class="carousel slide">
+        <div id="product_gallery" class="carousel slide" data-ride="carousel">
 
             <div class="img-thumbnail mb-3">
                 <div class="carousel-inner">
@@ -16,15 +16,15 @@
                         <img src="{{ thumb.url }}" alt="{{ product.get_title }}" />
                     </div>
                 {% endfor %}
+                    <a class="carousel-control-prev" href="#product_gallery" role="button" data-slide="prev">
+                        <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                        <span class="sr-only">{% trans "Previous" %}</span>
+                    </a>
+                    <a class="carousel-control-next" href="#product_gallery" role="button" data-slide="next">
+                        <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                        <span class="sr-only">{% trans "Next" %}</span>
+                    </a>
                 </div>
-                <a class="carousel-control-prev" href="#product_gallery" role="button" data-slide="prev">
-                    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-                    <span class="sr-only">{% trans "Previous" %}</span>
-                </a>
-                <a class="carousel-control-next" href="#product_gallery" role="button" data-slide="next">
-                    <span class="carousel-control-next-icon" aria-hidden="true"></span>
-                    <span class="sr-only">{% trans "Next" %}</span>
-                </a>
             </div>
 
             <ol class="carousel-indicators img-thumbnail">

--- a/src/oscar/templates/oscar/communication/emails/commtype_password_changed_body.html
+++ b/src/oscar/templates/oscar/communication/emails/commtype_password_changed_body.html
@@ -17,7 +17,7 @@
 
     <tr>
         <td class="content-block">
-            <a href="{% absolute_url site.domain reset_url %}" class="btn-primary">Reset password</a>
+            <a href="{% absolute_url site.domain reset_url %}" class="btn-primary">{% trans "Reset password" %}</a>
         </td>
     </tr>
 

--- a/src/oscar/templates/oscar/communication/emails/commtype_password_reset_body.html
+++ b/src/oscar/templates/oscar/communication/emails/commtype_password_reset_body.html
@@ -17,7 +17,7 @@
 
 <tr>
     <td class="content-block">
-        <a href="{% absolute_url site.domain reset_url %}" class="btn-primary">Reset password</a>
+        <a href="{% absolute_url site.domain reset_url %}" class="btn-primary">{% trans "Reset password" %}</a>
     </td>
 </tr>
 

--- a/src/oscar/templates/oscar/customer/history/recently_viewed_products.html
+++ b/src/oscar/templates/oscar/customer/history/recently_viewed_products.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load product_tags %}
 
-{% with products_sliced=products|slice:":6" %}
+{% with products_sliced=products %}
     {% if products_sliced %}
         <div class="sub-header">
             <h2>{% trans 'Products you recently viewed' %}</h2>


### PR DESCRIPTION
Carousel's navigation more optimal placement should be inside of the `div.carousel-inner` to correct its position to the vertical middle of the main image, not of the whole gallery (constructed with the main image and thumbnails).