### PR TITLE
Remove unused "footer", "inline" and "footer_links" classes from templates

### DIFF
--- a/src/oscar/templates/oscar/basket/partials/basket_content.html
+++ b/src/oscar/templates/oscar/basket/partials/basket_content.html
@@ -67,9 +67,9 @@
                                     </div>
                                 </div>
                                     <div class="basket-line-actions">
-                                        <a href="#" data-id="{{ forloop.counter0 }}" data-behaviours="remove" class="inline">{% trans "Remove" %}</a>
+                                        <a href="#" data-id="{{ forloop.counter0 }}" data-behaviours="remove">{% trans "Remove" %}</a>
                                         {% if user.is_authenticated %}
-                                            | <a href="#" data-id="{{ forloop.counter0 }}" data-behaviours="save" class="inline">{% trans "Save for later" %}</a>
+                                            | <a href="#" data-id="{{ forloop.counter0 }}" data-behaviours="save">{% trans "Save for later" %}</a>
                                         {% endif %}
                                         <div style="display:none">
                                             {{ form.save_for_later }}

--- a/src/oscar/templates/oscar/partials/footer.html
+++ b/src/oscar/templates/oscar/partials/footer.html
@@ -1,12 +1,7 @@
-{% load i18n %}
-<footer class="footer container">
+<footer class="container">
     {% block footer %}
         {% comment %}
             Could be used for displaying links to privacy policy, terms of service, etc.
-            We have a CSS class defined:
-                <ul class="footer_links inline">
-                    ...
-                </ul>
          {% endcomment %}
     {% endblock %}
 </footer>

--- a/src/oscar/templates/oscar/partials/footer_checkout.html
+++ b/src/oscar/templates/oscar/partials/footer_checkout.html
@@ -1,4 +1,4 @@
-<footer class="footer container">
+<footer class="container">
     {% block footer %}
     {% endblock %}
 </footer>


### PR DESCRIPTION
Fixes #3689. 