### PR TITLE
Add support for django 3.2 and drop support for Django 3.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        django-version: [2.2, 3.0, 3.1]
+        django-version: [2.2, 3.1, 3.2]
     services:
       postgres:
         image: postgres:10

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -104,6 +104,10 @@ STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
 )
 
+# Default primary key field type
+# https://docs.djangoproject.com/en/dev/ref/settings/#default-auto-field
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = env.str('SECRET_KEY', default='UajFCuyjDKmWHe29neauXzHi9eZoRXr6RMbT5JyAdPiACBP6Cra2')
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ sys.path.append(os.path.join(PROJECT_DIR, 'src'))
 from oscar import get_version  # noqa isort:skip
 
 install_requires = [
-    'django>=2.2,<3.2',
+    'django>=2.2,<3.3',
     # PIL is required for image fields, Pillow is the "friendly" PIL fork
     'pillow>=6.0',
     # We use the ModelFormSetView from django-extra-views for the basket page
@@ -99,7 +99,8 @@ setup(
         'Environment :: Web Environment',
         'Framework :: Django',
         'Framework :: Django :: 2.2',
-        'Framework :: Django :: 3.0',
+        'Framework :: Django :: 3.1',
+        'Framework :: Django :: 3.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: Unix',

--- a/src/oscar/apps/basket/views.py
+++ b/src/oscar/apps/basket/views.py
@@ -186,7 +186,7 @@ class BasketView(ModelFormSetView):
             response = super().formset_valid(formset)
 
         # If AJAX submission, don't redirect but reload the basket content HTML
-        if self.request.is_ajax():
+        if self.request.headers.get('x-requested-with') == 'XMLHttpRequest':
             # Reload basket and apply offers again
             self.request.basket = get_model('basket', 'Basket').objects.get(
                 id=self.request.basket.id)
@@ -247,7 +247,7 @@ class BasketView(ModelFormSetView):
             "Your basket has got some issues. "
             "Please correct any validation errors below."))
 
-        if self.request.is_ajax():
+        if self.request.headers.get('x-requested-with') == 'XMLHttpRequest':
             ctx = self.get_context_data(formset=formset,
                                         basket=self.request.basket)
             return self.json_response(ctx, flash_messages)

--- a/src/oscar/apps/offer/conditions.py
+++ b/src/oscar/apps/offer/conditions.py
@@ -73,7 +73,7 @@ class CountCondition(Condition):
             return ngettext(
                 'Buy %(delta)d more product from %(range)s',
                 'Buy %(delta)d more products from %(range)s',
-                delta
+                int(delta)
             ) % {'delta': delta, 'range': self.range}
 
     def consume_items(self, offer, basket, affected_lines):
@@ -157,7 +157,7 @@ class CoverageCondition(Condition):
             return ngettext(
                 'Buy %(delta)d more product from %(range)s',
                 'Buy %(delta)d more products from %(range)s',
-                delta
+                int(delta)
             ) % {'delta': delta, 'range': self.range}
 
     def is_partially_satisfied(self, offer, basket):

--- a/tests/functional/checkout/test_guest_checkout.py
+++ b/tests/functional/checkout/test_guest_checkout.py
@@ -1,7 +1,6 @@
 import sys
 from http import client as http_client
-from imp import reload
-from importlib import import_module
+from importlib import import_module, reload
 from unittest import mock
 from urllib.parse import quote
 

--- a/tests/functional/test_basket.py
+++ b/tests/functional/test_basket.py
@@ -3,6 +3,9 @@ from decimal import Decimal as D
 from http import client as http_client
 from http.cookies import _unquote
 
+import django
+from django.contrib.messages.storage import cookie
+from django.core import signing
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils.translation import gettext
@@ -105,13 +108,20 @@ class BasketThresholdTest(WebTestCase):
                        'action': 'add',
                        'quantity': 2}
         response = self.app.post(url, params=post_params)
-
         expected = gettext(
             "Due to technical limitations we are not able to ship more "
             "than %(threshold)d items in one order. Your basket currently "
             "has %(basket)d items."
         ) % ({'threshold': 3, 'basket': 2})
-        self.assertIn(expected, response.test_app.cookies['messages'])
+        if django.VERSION < (3, 2):
+            self.assertIn(expected, response.test_app.cookies['messages'])
+        else:
+            signer = signing.get_cookie_signer(salt='django.contrib.messages')
+            message_strings = [
+                m.message for m in signer.unsign_object(response.test_app.cookies['messages'],
+                                                        serializer=cookie.MessageSerializer)
+            ]
+            self.assertIn(expected, message_strings)
 
 
 class BasketReportTests(TestCase):

--- a/tests/integration/checkout/test_session.py
+++ b/tests/integration/checkout/test_session.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 from django.contrib.sessions.middleware import SessionMiddleware
+from django.http import HttpResponse
 from django.test import TestCase
 from django.test.client import RequestFactory
 
@@ -12,9 +13,13 @@ class TestCheckoutSession(TestCase):
     oscar.apps.checkout.utils.CheckoutSessionData
     """
 
+    @staticmethod
+    def get_response_for_test(request):
+        return HttpResponse()
+
     def setUp(self):
         request = RequestFactory().get('/')
-        SessionMiddleware().process_request(request)
+        SessionMiddleware(self.get_response_for_test).process_request(request)
         self.session_data = CheckoutSessionData(request)
 
     def test_allows_data_to_be_written_and_read_out(self):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -169,7 +169,7 @@ OSCAR_INITIAL_LINE_STATUS = 'a'
 OSCAR_LINE_STATUS_PIPELINE = {'a': ('b', ), 'b': ()}
 
 SECRET_KEY = 'notverysecret'
-# Deprecated in Django 4.0, then we need to update the hashes to SHA-256 in tests/integration/order/test_models.py
+# Removed in Django 4.0, then we need to update the hashes to SHA-256 in tests/integration/order/test_models.py
 DEFAULT_HASHING_ALGORITHM = 'sha1'
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 FIXTURE_DIRS = [location('unit/fixtures')]

--- a/tests/unit/checkout/test_checkout_session_data.py
+++ b/tests/unit/checkout/test_checkout_session_data.py
@@ -2,16 +2,21 @@ from unittest.mock import Mock
 
 import pytest
 from django.contrib.sessions.middleware import SessionMiddleware
+from django.http import HttpResponse
 
 from oscar.apps.checkout.forms import ShippingAddressForm
 from oscar.apps.checkout.utils import CheckoutSessionData
+
+
+def get_response_for_test(request):
+    return HttpResponse()
 
 
 @pytest.fixture
 def csdf(rf):
     """"""
     request = rf.get('/')
-    middleware = SessionMiddleware()
+    middleware = SessionMiddleware(get_response_for_test)
     middleware.process_request(request)
     return CheckoutSessionData(request)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39}-django{22,30,31}
+    py{36,37,38,39}-django{22,31,32}
     lint
     sandbox
     docs
@@ -12,8 +12,8 @@ extras = test
 pip_pre = true
 deps =
     django22: django>=2.2,<2.3
-    django30: django>=3.0,<3.1
     django31: django>=3.1,<3.2
+    django32: django>=3.2,<3.3
 
 [testenv:lint]
 basepython = python3.7


### PR DESCRIPTION
We can't drop `DEFAULT_HASHING_ALGORITHM` from the tests until we drop support for Django 2.2. 