### PR TITLE
Removed denying of archive and cache to robots

### DIFF
--- a/src/oscar/templates/oscar/base.html
+++ b/src/oscar/templates/oscar/base.html
@@ -9,7 +9,7 @@
         <meta name="created" content="{% now "jS M Y h:i" %}" />
         <meta name="description" content="{% block description %}{% endblock %}" />
         <meta name="viewport" content="{% block viewport %}width=device-width{% endblock %}" />
-        <meta name="robots" content="NOARCHIVE,NOCACHE" />
+
         {% block favicon %}
             <link rel="shortcut icon" href="{% static "oscar/favicon.ico" %}" />
         {% endblock %}


### PR DESCRIPTION
This is extremely bad for SEO and basically makes the base template unsuable for production purposes because this statement is not in a block that can be overridden.