### PR TITLE
[#3740] Add is_ajax helper to utils.py

### DIFF
--- a/docs/source/releases/v3.2.rst
+++ b/docs/source/releases/v3.2.rst
@@ -34,7 +34,8 @@ Removal of deprecated features
 Minor changes
 ~~~~~~~~~~~~~
 
-
+- Added a new helper ``core.utils.is_ajax`` which replicates the logic of Django's ``HttpRequest.is_ajax``
+  method that was deprecated in Django 3.1.
 
 .. _dependency_changes_in_3.2:
 

--- a/src/oscar/apps/basket/views.py
+++ b/src/oscar/apps/basket/views.py
@@ -14,7 +14,7 @@ from oscar.apps.basket.signals import (
 from oscar.core import ajax
 from oscar.core.compat import url_has_allowed_host_and_scheme
 from oscar.core.loading import get_class, get_classes, get_model
-from oscar.core.utils import redirect_to_referrer, safe_referrer, is_ajax
+from oscar.core.utils import is_ajax, redirect_to_referrer, safe_referrer
 
 Applicator = get_class('offer.applicator', 'Applicator')
 (BasketLineForm, AddToBasketForm, BasketVoucherForm, SavedLineForm) = get_classes(

--- a/src/oscar/apps/basket/views.py
+++ b/src/oscar/apps/basket/views.py
@@ -14,7 +14,7 @@ from oscar.apps.basket.signals import (
 from oscar.core import ajax
 from oscar.core.compat import url_has_allowed_host_and_scheme
 from oscar.core.loading import get_class, get_classes, get_model
-from oscar.core.utils import redirect_to_referrer, safe_referrer
+from oscar.core.utils import redirect_to_referrer, safe_referrer, is_ajax
 
 Applicator = get_class('offer.applicator', 'Applicator')
 (BasketLineForm, AddToBasketForm, BasketVoucherForm, SavedLineForm) = get_classes(
@@ -186,7 +186,7 @@ class BasketView(ModelFormSetView):
             response = super().formset_valid(formset)
 
         # If AJAX submission, don't redirect but reload the basket content HTML
-        if self.request.headers.get('x-requested-with') == 'XMLHttpRequest':
+        if is_ajax(self.request):
             # Reload basket and apply offers again
             self.request.basket = get_model('basket', 'Basket').objects.get(
                 id=self.request.basket.id)
@@ -247,7 +247,7 @@ class BasketView(ModelFormSetView):
             "Your basket has got some issues. "
             "Please correct any validation errors below."))
 
-        if self.request.headers.get('x-requested-with') == 'XMLHttpRequest':
+        if is_ajax(self.request):
             ctx = self.get_context_data(formset=formset,
                                         basket=self.request.basket)
             return self.json_response(ctx, flash_messages)

--- a/src/oscar/core/utils.py
+++ b/src/oscar/core/utils.py
@@ -183,3 +183,15 @@ def round_half_up(money):
     Decimal('1.01')
     """
     return money.quantize(decimal.Decimal('0.01'), decimal.ROUND_HALF_UP)
+
+
+def is_ajax(request):
+    """
+    Django 3.1 deprecated the  HttpRequest.is_ajax method as it relies on
+    a jQuery-specific way of signifying AJAX calls.
+
+    https://docs.djangoproject.com/en/3.1/releases/3.1/#id2
+
+    For Oscar projects that's usually not a concern though.
+    """
+    return request.META.get("HTTP_X_REQUESTED_WITH") == "XMLHttpRequest"


### PR DESCRIPTION
closes #3740

I'd also want to add a release note, but wasn't sure where to put it. the latest release note file is for 3.1, but that one seems to be already out.