### PR TITLE
Fix output of OfferReportGenerator and generate its data more efficiently

### DIFF
--- a/src/oscar/apps/offer/reports.py
+++ b/src/oscar/apps/offer/reports.py
@@ -1,5 +1,5 @@
-from decimal import Decimal as D
-
+from django.db.models import OuterRef, Subquery, Sum
+from django.db.models.functions import Coalesce
 from django.utils.translation import gettext_lazy as _
 
 from oscar.core.loading import get_class, get_model
@@ -16,16 +16,15 @@ OrderDiscount = get_model('order', 'OrderDiscount')
 class OfferReportCSVFormatter(ReportCSVFormatter):
     filename_template = 'conditional-offer-performance.csv'
 
-    def generate_csv(self, response, offers):
+    def generate_csv(self, response, offer_discounts):
         writer = self.get_csv_writer(response)
         header_row = [_('Offer'),
                       _('Total discount')
                       ]
         writer.writerow(header_row)
 
-        for offer in offers:
-            row = [offer, offer['total_discount']]
-            writer.writerow(row)
+        for discount in offer_discounts:
+            writer.writerow([discount["display_offer_name"], discount["total_discount"]])
 
 
 class OfferReportHTMLFormatter(ReportHTMLFormatter):
@@ -42,20 +41,18 @@ class OfferReportGenerator(ReportGenerator):
         'HTML_formatter': OfferReportHTMLFormatter,
     }
 
-    def generate(self):
-        offer_discounts = {}
-        for discount in self.queryset:
-            if discount.offer_id not in offer_discounts:
-                try:
-                    all_offers = ConditionalOffer._default_manager
-                    offer = all_offers.get(id=discount.offer_id)
-                except ConditionalOffer.DoesNotExist:
-                    continue
-                offer_discounts[discount.offer_id] = {
-                    'offer': offer,
-                    'total_discount': D('0.00')
-                }
-            offer_discounts[discount.offer_id]['total_discount'] \
-                += discount.amount
-
-        return self.formatter.generate_response(list(offer_discounts.values()))
+    def get_queryset(self):
+        offers = ConditionalOffer.objects.filter(pk=OuterRef("offer_id"))
+        return super().get_queryset().order_by().values("offer_id").annotate(
+            total_discount=Sum("amount"),
+            # Used to add a link to the offer in the report template, if the offer still exists.
+            offer=Subquery(offers.values("pk")[:1]),
+            # Find the name of the attached offer if it exists, otherwise the offer_name on a matching OrderDiscount
+            # This is used to display the most appropriate name in the report template.
+            display_offer_name=Coalesce(
+                Subquery(offers.values("name")[:1]),
+                Subquery(
+                    OrderDiscount.objects.filter(pk=OuterRef("pk")).values("offer_name")[:1]
+                )
+            ),
+        ).values("offer_id", "offer", "total_discount", "display_offer_name").order_by("-total_discount")

--- a/src/oscar/templates/oscar/dashboard/reports/partials/offer_report.html
+++ b/src/oscar/templates/oscar/dashboard/reports/partials/offer_report.html
@@ -11,7 +11,7 @@
         </tr>
         {% for offer_discount in objects %}
         <tr>
-            <td><a href="{% url 'dashboard:offer-detail' offer_discount.offer.pk %}">{{ offer_discount.offer.name }}</a></td>
+            <td><a {% if offer_discount.offer %}href="{% url 'dashboard:offer-detail' offer_discount.offer_id %}"{% endif %}>{{ offer_discount.display_offer_name }}</a></td>
             <td>{{ offer_discount.total_discount|currency }}</td>
         </tr>
     {% endfor %}

--- a/tests/unit/offer/test_reports.py
+++ b/tests/unit/offer/test_reports.py
@@ -1,0 +1,26 @@
+from django.test import TestCase
+
+from oscar.apps.offer.reports import OfferReportGenerator
+from oscar.test.factories import (
+    ConditionalOfferFactory, OrderDiscountFactory, create_order)
+
+
+class OfferReportGeneratorTestCase(TestCase):
+
+    def test_generator_queryset_and_annotation(self):
+        offer = ConditionalOfferFactory(pk=2)
+        OrderDiscountFactory(offer_id=offer.pk, offer_name=offer.name, amount=2, order=create_order())
+        OrderDiscountFactory(offer_id=offer.pk, offer_name=offer.name, amount=3, order=create_order())
+        # Discount on a deleted offer
+        OrderDiscountFactory(offer_id=1, offer_name="Deleted offer", amount=4, order=create_order())
+        queryset = OfferReportGenerator().generate()
+
+        self.assertEqual(queryset.count(), 2)
+        self.assertEqual(queryset[0]["offer_id"], 2)
+        self.assertEqual(queryset[0]["display_offer_name"], offer.name)
+        self.assertEqual(queryset[0]["total_discount"], 5)
+        self.assertEqual(queryset[0]["offer"], offer.pk)
+        self.assertEqual(queryset[1]["offer_id"], 1)
+        self.assertEqual(queryset[1]["display_offer_name"], "Deleted offer")
+        self.assertEqual(queryset[1]["total_discount"], 4)
+        self.assertEqual(queryset[1]["offer"], None)


### PR DESCRIPTION
The "offer performance" report has been broken since the changes to the `ReportGenerator` introduced in Oscar 3.0 . 

This fixes the `OfferReportGenerator` to work with those changes, and also reimplements the data processing itself to do it via a database query instead of iterating over all the `OrderDiscount` objects. It also fixes the HTML template not to link to deleted offers, and orders the report by discount value.