### PR TITLE
Check checkout-view skip conditions before pre conditions

### DIFF
--- a/src/oscar/apps/checkout/session.py
+++ b/src/oscar/apps/checkout/session.py
@@ -53,18 +53,18 @@ class CheckoutSessionMixin(object):
         # views.
         self.checkout_session = CheckoutSessionData(request)
 
+        # Check if this view should be skipped
+        try:
+            self.check_skip_conditions(request)
+        except exceptions.PassedSkipCondition as e:
+            return http.HttpResponseRedirect(e.url)
+
         # Enforce any pre-conditions for the view.
         try:
             self.check_pre_conditions(request)
         except exceptions.FailedPreCondition as e:
             for message in e.messages:
                 messages.warning(request, message)
-            return http.HttpResponseRedirect(e.url)
-
-        # Check if this view should be skipped
-        try:
-            self.check_skip_conditions(request)
-        except exceptions.PassedSkipCondition as e:
             return http.HttpResponseRedirect(e.url)
 
         return super().dispatch(

--- a/src/oscar/apps/checkout/views.py
+++ b/src/oscar/apps/checkout/views.py
@@ -251,9 +251,9 @@ class ShippingMethodView(CheckoutSessionMixin, generic.FormView):
         return super().post(request, *args, **kwargs)
 
     def get(self, request, *args, **kwargs):
-        # These pre-conditions can't easily be factored out into the normal
-        # pre-conditions as they do more than run a test and then raise an
-        # exception on failure.
+        # These skip and pre conditions can't easily be factored out into the
+        # normal pre-conditions as they do more than run a test and then raise
+        # an exception on failure.
 
         # Check that shipping is required at all
         if not request.basket.is_shipping_required():

--- a/tests/functional/checkout/__init__.py
+++ b/tests/functional/checkout/__init__.py
@@ -1,13 +1,23 @@
 from decimal import Decimal as D
+from http import client as http_client
+from unittest import mock
 
 from django.urls import reverse
 
-from oscar.core.loading import get_class, get_model
+from oscar.apps.shipping import methods
+from oscar.core.loading import get_class, get_classes, get_model
 from oscar.test import factories
 
-UserAddress = get_model('address', 'UserAddress')
-Country = get_model('address', 'Country')
+Basket = get_model('basket', 'Basket')
+ConditionalOffer = get_model('offer', 'ConditionalOffer')
+Order = get_model('order', 'Order')
+
+FailedPreCondition = get_class('checkout.exceptions', 'FailedPreCondition')
 GatewayForm = get_class('checkout.forms', 'GatewayForm')
+UnableToPlaceOrder = get_class('order.exceptions', 'UnableToPlaceOrder')
+RedirectRequired, UnableToTakePayment, PaymentError = get_classes(
+    'payment.exceptions', ['RedirectRequired', 'UnableToTakePayment', 'PaymentError'])
+NoShippingRequired = get_class('shipping.methods', 'NoShippingRequired')
 
 
 class CheckoutMixin(object):
@@ -20,12 +30,12 @@ class CheckoutMixin(object):
             num_in_stock=None, price=D('12.00'), product=product)
         return product
 
-    def add_product_to_basket(self, product=None):
+    def add_product_to_basket(self, product=None, **kwargs):
         if product is None:
             product = factories.ProductFactory()
             factories.StockRecordFactory(
                 num_in_stock=10, price=D('12.00'), product=product)
-        detail_page = self.get(product.get_absolute_url())
+        detail_page = self.get(product.get_absolute_url(), user=kwargs.get('logged_in_user', self.user))
         form = detail_page.forms['add_to_basket_form']
         form.submit()
 
@@ -39,9 +49,10 @@ class CheckoutMixin(object):
 
     def enter_guest_details(self, email='guest@example.com'):
         index_page = self.get(reverse('checkout:index'))
-        index_page.form['username'] = email
-        index_page.form.select('options', GatewayForm.GUEST)
-        return index_page.form.submit()
+        if index_page.status_code == 200:
+            index_page.form['username'] = email
+            index_page.form.select('options', GatewayForm.GUEST)
+            index_page.form.submit()
 
     def create_shipping_country(self):
         return factories.CountryFactory(
@@ -50,13 +61,14 @@ class CheckoutMixin(object):
     def enter_shipping_address(self):
         self.create_shipping_country()
         address_page = self.get(reverse('checkout:shipping-address'))
-        form = address_page.forms['new_shipping_address']
-        form['first_name'] = 'John'
-        form['last_name'] = 'Doe'
-        form['line1'] = '1 Egg Road'
-        form['line4'] = 'Shell City'
-        form['postcode'] = 'N12 9RT'
-        form.submit()
+        if address_page.status_code == 200:
+            form = address_page.forms['new_shipping_address']
+            form['first_name'] = 'John'
+            form['last_name'] = 'Doe'
+            form['line1'] = '1 Egg Road'
+            form['line4'] = 'Shell City'
+            form['postcode'] = 'N12 9RT'
+            form.submit()
 
     def enter_shipping_method(self):
         self.get(reverse('checkout:shipping-method'))
@@ -67,14 +79,477 @@ class CheckoutMixin(object):
         preview = payment_details.click(linkid="view_preview")
         return preview.forms['place_order_form'].submit().follow()
 
-    def reach_payment_details_page(self, is_guest=False):
+    def reach_payment_details_page(self):
         self.add_product_to_basket()
-        if is_guest:
+        if self.is_anonymous:
             self.enter_guest_details('hello@egg.com')
         self.enter_shipping_address()
         return self.get(
             reverse('checkout:shipping-method')).follow().follow()
 
-    def ready_to_place_an_order(self, is_guest=False):
-        payment_details = self.reach_payment_details_page(is_guest)
+    def ready_to_place_an_order(self):
+        payment_details = self.reach_payment_details_page()
         return payment_details.click(linkid="view_preview")
+
+
+class IndexViewPreConditionsMixin:
+
+    view_name = None
+
+    # Disable skip conditions, so that we do not first get redirected forwards
+    @mock.patch('oscar.apps.checkout.session.CheckoutSessionMixin.skip_unless_payment_is_required')
+    @mock.patch('oscar.apps.checkout.session.CheckoutSessionMixin.skip_unless_basket_requires_shipping')
+    def test_check_basket_is_not_empty(
+        self,
+        mock_skip_unless_basket_requires_shipping,
+        mock_skip_unless_payment_is_required,
+    ):
+        response = self.get(reverse(self.view_name))
+        self.assertRedirectsTo(response, 'basket:summary')
+
+    # Disable skip conditions, so that we do not first get redirected forwards
+    @mock.patch('oscar.apps.checkout.session.CheckoutSessionMixin.skip_unless_payment_is_required')
+    @mock.patch('oscar.apps.checkout.session.CheckoutSessionMixin.skip_unless_basket_requires_shipping')
+    def test_check_basket_is_valid(
+        self,
+        mock_skip_unless_basket_requires_shipping,
+        mock_skip_unless_payment_is_required,
+    ):
+        # Add product to basket but then remove its stock so it is not
+        # purchasable.
+        product = factories.ProductFactory()
+        self.add_product_to_basket(product)
+        product.stockrecords.all().update(num_in_stock=0)
+        if self.is_anonymous:
+            self.enter_guest_details()
+
+        response = self.get(reverse(self.view_name))
+        self.assertRedirectsTo(response, 'basket:summary')
+
+
+class ShippingAddressViewSkipConditionsMixin:
+
+    view_name = None
+    next_view_name = None
+
+    def test_skip_unless_basket_requires_shipping(self):
+        product = self.create_digital_product()
+        self.add_product_to_basket(product)
+        if self.is_anonymous:
+            self.enter_guest_details()
+
+        response = self.get(reverse(self.view_name))
+        self.assertRedirectsTo(response, self.next_view_name)
+
+
+class ShippingAddressViewPreConditionsMixin(IndexViewPreConditionsMixin):
+
+    view_name = None
+
+    # Disable skip conditions, so that we do not first get redirected forwards
+    @mock.patch('oscar.apps.checkout.session.CheckoutSessionMixin.skip_unless_payment_is_required')
+    @mock.patch('oscar.apps.checkout.session.CheckoutSessionMixin.skip_unless_basket_requires_shipping')
+    def test_check_user_email_is_captured(
+        self,
+        mock_skip_unless_basket_requires_shipping,
+        mock_skip_unless_payment_is_required,
+    ):
+        if self.is_anonymous:
+            self.add_product_to_basket()
+            response = self.get(reverse(self.view_name))
+            self.assertRedirectsTo(response, 'checkout:index')
+
+
+class ShippingAddressViewMixin(ShippingAddressViewSkipConditionsMixin, ShippingAddressViewPreConditionsMixin):
+
+    def test_submitting_valid_form_adds_data_to_session(self):
+        self.add_product_to_basket()
+        if self.is_anonymous:
+            self.enter_guest_details()
+        self.create_shipping_country()
+
+        page = self.get(reverse('checkout:shipping-address'))
+        form = page.forms['new_shipping_address']
+        form['first_name'] = 'Barry'
+        form['last_name'] = 'Chuckle'
+        form['line1'] = '1 King Street'
+        form['line4'] = 'Gotham City'
+        form['postcode'] = 'N1 7RR'
+        response = form.submit()
+        self.assertRedirectsTo(response, 'checkout:shipping-method')
+
+        session_data = self.app.session['checkout_data']
+        session_fields = session_data['shipping']['new_address_fields']
+        self.assertEqual('Barry', session_fields['first_name'])
+        self.assertEqual('Chuckle', session_fields['last_name'])
+        self.assertEqual('1 King Street', session_fields['line1'])
+        self.assertEqual('Gotham City', session_fields['line4'])
+        self.assertEqual('N1 7RR', session_fields['postcode'])
+
+    def test_shows_initial_data_if_the_form_has_already_been_submitted(self):
+        self.add_product_to_basket()
+        if self.is_anonymous:
+            self.enter_guest_details()
+        self.enter_shipping_address()
+        page = self.get(reverse('checkout:shipping-address'), user=self.user)
+        form = page.forms['new_shipping_address']
+        self.assertEqual('John', form['first_name'].value)
+        self.assertEqual('Doe', form['last_name'].value)
+        self.assertEqual('1 Egg Road', form['line1'].value)
+        self.assertEqual('Shell City', form['line4'].value)
+        self.assertEqual('N12 9RT', form['postcode'].value)
+
+
+class ShippingMethodViewSkipConditionsMixin:
+
+    view_name = None
+    next_view_name = None
+
+    def test_skip_unless_basket_requires_shipping(self):
+        # This skip condition is not a "normal" one, but is implemented in the
+        # view's "get" method
+        product = self.create_digital_product()
+        self.add_product_to_basket(product)
+        if self.is_anonymous:
+            self.enter_guest_details()
+
+        response = self.get(reverse(self.view_name))
+        self.assertRedirectsTo(response, self.next_view_name)
+        self.assertEqual(self.app.session['checkout_data']['shipping']['method_code'], NoShippingRequired.code)
+
+    @mock.patch('oscar.apps.checkout.views.Repository')
+    def test_skip_if_single_shipping_method_is_available(self, mock_repo):
+        # This skip condition is not a "normal" one, but is implemented in the
+        # view's "get" method
+        self.add_product_to_basket()
+        if self.is_anonymous:
+            self.enter_guest_details()
+        self.enter_shipping_address()
+
+        # Ensure one shipping method available
+        instance = mock_repo.return_value
+        instance.get_shipping_methods.return_value = [methods.Free()]
+
+        response = self.get(reverse('checkout:shipping-method'))
+        self.assertRedirectsTo(response, 'checkout:payment-method')
+
+
+class ShippingMethodViewPreConditionsMixin(ShippingAddressViewPreConditionsMixin):
+
+    view_name = None
+
+    # Disable skip conditions, so that we do not first get redirected forwards
+    @mock.patch('oscar.apps.checkout.session.CheckoutSessionMixin.skip_unless_payment_is_required')
+    @mock.patch('oscar.apps.checkout.session.CheckoutSessionMixin.skip_unless_basket_requires_shipping')
+    @mock.patch('oscar.apps.checkout.views.Repository')
+    def test_check_shipping_methods_are_available(
+        self,
+        mock_repo,
+        mock_skip_unless_basket_requires_shipping,
+        mock_skip_unless_payment_is_required,
+    ):
+        # This pre condition is not a "normal" one, but is implemented in the
+        # view's "get" method
+        self.add_product_to_basket()
+        if self.is_anonymous:
+            self.enter_guest_details()
+        self.enter_shipping_address()
+
+        # Ensure no shipping methods available
+        instance = mock_repo.return_value
+        instance.get_shipping_methods.return_value = []
+
+        response = self.get(reverse('checkout:shipping-method'))
+        self.assertRedirectsTo(response, 'checkout:shipping-address')
+
+    # Disable skip conditions, so that we do not first get redirected forwards
+    @mock.patch('oscar.apps.checkout.session.CheckoutSessionMixin.skip_unless_payment_is_required')
+    @mock.patch('oscar.apps.checkout.session.CheckoutSessionMixin.skip_unless_basket_requires_shipping')
+    def test_check_shipping_data_is_captured(
+        self,
+        mock_skip_unless_basket_requires_shipping,
+        mock_skip_unless_payment_is_required,
+    ):
+        # This pre condition is not a "normal" one, but is implemented in the
+        # view's "get" method
+        self.add_product_to_basket()
+        if self.is_anonymous:
+            self.enter_guest_details()
+
+        response = self.get(reverse(self.view_name))
+        self.assertRedirectsTo(response, 'checkout:shipping-address')
+
+
+class ShippingMethodViewMixin(ShippingMethodViewSkipConditionsMixin, ShippingMethodViewPreConditionsMixin):
+
+    @mock.patch('oscar.apps.checkout.views.Repository')
+    def test_shows_form_when_multiple_shipping_methods_available(self, mock_repo):
+        self.add_product_to_basket()
+        if self.is_anonymous:
+            self.enter_guest_details()
+        self.enter_shipping_address()
+
+        # Ensure multiple shipping methods available
+        method = mock.MagicMock()
+        method.code = 'm'
+        instance = mock_repo.return_value
+        instance.get_shipping_methods.return_value = [methods.Free(), method]
+        form_page = self.get(reverse('checkout:shipping-method'))
+        self.assertIsOk(form_page)
+
+        response = form_page.forms[0].submit()
+        self.assertRedirectsTo(response, 'checkout:payment-method')
+
+    # Disable skip conditions, so that we do not first get redirected forwards
+    @mock.patch('oscar.apps.checkout.session.CheckoutSessionMixin.skip_unless_payment_is_required')
+    @mock.patch('oscar.apps.checkout.session.CheckoutSessionMixin.skip_unless_basket_requires_shipping')
+    @mock.patch('oscar.apps.checkout.views.Repository')
+    def test_check_user_can_submit_only_valid_shipping_method(
+        self,
+        mock_repo,
+        mock_skip_unless_basket_requires_shipping,
+        mock_skip_unless_payment_is_required,
+    ):
+        self.add_product_to_basket()
+        if self.is_anonymous:
+            self.enter_guest_details()
+        self.enter_shipping_address()
+        method = mock.MagicMock()
+        method.code = 'm'
+        instance = mock_repo.return_value
+        instance.get_shipping_methods.return_value = [methods.Free(), method]
+        form_page = self.get(reverse('checkout:shipping-method'))
+        # a malicious attempt?
+        form_page.forms[0]['method_code'].value = 'super-free-shipping'
+        response = form_page.forms[0].submit()
+        self.assertIsNotRedirect(response)
+        response.mustcontain('Your submitted shipping method is not permitted')
+
+
+class PaymentMethodViewSkipConditionsMixin:
+
+    @mock.patch('oscar.apps.checkout.session.SurchargeApplicator.get_surcharges')
+    def test_skip_unless_payment_is_required(self, mock_get_surcharges):
+        mock_get_surcharges.return_value = []
+
+        product = factories.create_product(price=D('0.00'), num_in_stock=100)
+        self.add_product_to_basket(product)
+        if self.is_anonymous:
+            self.enter_guest_details()
+        self.enter_shipping_address()
+        # The shipping method is set automatically, as there is only one (free)
+        # available
+
+        response = self.get(reverse('checkout:payment-method'))
+        self.assertRedirectsTo(response, 'checkout:preview')
+
+
+class PaymentMethodViewPreConditionsMixin(ShippingMethodViewPreConditionsMixin):
+
+    view_name = None
+
+    # Disable skip conditions, so that we do not first get redirected forwards
+    @mock.patch('oscar.apps.checkout.session.CheckoutSessionMixin.skip_unless_payment_is_required')
+    @mock.patch('oscar.apps.checkout.session.CheckoutSessionMixin.skip_unless_basket_requires_shipping')
+    def test_check_shipping_data_is_captured(
+        self,
+        mock_skip_unless_basket_requires_shipping,
+        mock_skip_unless_payment_is_required,
+    ):
+        super().test_check_shipping_data_is_captured()
+
+        self.enter_shipping_address()
+
+        response = self.get(reverse(self.view_name))
+        self.assertRedirectsTo(response, 'checkout:shipping-method')
+
+
+class PaymentMethodViewMixin(PaymentMethodViewSkipConditionsMixin, PaymentMethodViewPreConditionsMixin):
+
+    pass
+
+
+class PaymentDetailsViewSkipConditionsMixin:
+
+    @mock.patch('oscar.apps.checkout.session.SurchargeApplicator.get_surcharges')
+    def test_skip_unless_payment_is_required(self, mock_get_surcharges):
+        mock_get_surcharges.return_value = []
+
+        product = factories.create_product(price=D('0.00'), num_in_stock=100)
+        self.add_product_to_basket(product)
+        if self.is_anonymous:
+            self.enter_guest_details()
+        self.enter_shipping_address()
+        # The shipping method is set automatically, as there is only one (free)
+        # available
+
+        response = self.get(reverse('checkout:payment-details'))
+        self.assertRedirectsTo(response, 'checkout:preview')
+
+
+class PaymentDetailsViewPreConditionsMixin(PaymentMethodViewPreConditionsMixin):
+    """
+    Does not add any new pre conditions.
+    """
+
+
+class PaymentDetailsViewMixin(PaymentDetailsViewSkipConditionsMixin, PaymentDetailsViewPreConditionsMixin):
+
+    @mock.patch('oscar.apps.checkout.views.PaymentDetailsView.handle_payment')
+    def test_redirects_customers_when_using_bank_gateway(self, mock_method):
+
+        bank_url = 'https://bank-website.com'
+        e = RedirectRequired(url=bank_url)
+        mock_method.side_effect = e
+        preview = self.ready_to_place_an_order()
+        bank_redirect = preview.forms['place_order_form'].submit()
+
+        assert bank_redirect.status_code == 302
+        assert bank_redirect.url == bank_url
+
+    @mock.patch('oscar.apps.checkout.views.PaymentDetailsView.handle_payment')
+    def test_handles_anticipated_payments_errors_gracefully(self, mock_method):
+        msg = 'Submitted expiration date is wrong'
+        e = UnableToTakePayment(msg)
+        mock_method.side_effect = e
+        preview = self.ready_to_place_an_order()
+        response = preview.forms['place_order_form'].submit()
+        self.assertIsOk(response)
+        # check user is warned
+        response.mustcontain(msg)
+        # check basket is restored
+        basket = Basket.objects.get()
+        self.assertEqual(basket.status, Basket.OPEN)
+
+    @mock.patch('oscar.apps.checkout.views.logger')
+    @mock.patch('oscar.apps.checkout.views.PaymentDetailsView.handle_payment')
+    def test_handles_unexpected_payment_errors_gracefully(
+            self, mock_method, mock_logger):
+        msg = 'This gateway is down for maintenance'
+        e = PaymentError(msg)
+        mock_method.side_effect = e
+        preview = self.ready_to_place_an_order()
+        response = preview.forms['place_order_form'].submit()
+        self.assertIsOk(response)
+        # check user is warned with a generic error
+        response.mustcontain(
+            'A problem occurred while processing payment for this order',
+            no=[msg])
+        # admin should be warned
+        self.assertTrue(mock_logger.error.called)
+        # check basket is restored
+        basket = Basket.objects.get()
+        self.assertEqual(basket.status, Basket.OPEN)
+
+    @mock.patch('oscar.apps.checkout.views.logger')
+    @mock.patch('oscar.apps.checkout.views.PaymentDetailsView.handle_payment')
+    def test_handles_bad_errors_during_payments(
+            self, mock_method, mock_logger):
+        e = Exception()
+        mock_method.side_effect = e
+        preview = self.ready_to_place_an_order()
+        response = preview.forms['place_order_form'].submit()
+        self.assertIsOk(response)
+        self.assertTrue(mock_logger.exception.called)
+        basket = Basket.objects.get()
+        self.assertEqual(basket.status, Basket.OPEN)
+
+    @mock.patch('oscar.apps.checkout.views.logger')
+    @mock.patch('oscar.apps.checkout.views.PaymentDetailsView.handle_order_placement')
+    def test_handles_unexpected_order_placement_errors_gracefully(
+            self, mock_method, mock_logger):
+        e = UnableToPlaceOrder()
+        mock_method.side_effect = e
+        preview = self.ready_to_place_an_order()
+        response = preview.forms['place_order_form'].submit()
+        self.assertIsOk(response)
+        self.assertTrue(mock_logger.error.called)
+        basket = Basket.objects.get()
+        self.assertEqual(basket.status, Basket.OPEN)
+
+    @mock.patch('oscar.apps.checkout.views.logger')
+    @mock.patch('oscar.apps.checkout.views.PaymentDetailsView.handle_order_placement')
+    def test_handles_all_other_exceptions_gracefully(self, mock_method, mock_logger):
+        mock_method.side_effect = Exception()
+        preview = self.ready_to_place_an_order()
+        response = preview.forms['place_order_form'].submit()
+        self.assertIsOk(response)
+        self.assertTrue(mock_logger.exception.called)
+        basket = Basket.objects.get()
+        self.assertEqual(basket.status, Basket.OPEN)
+
+
+class PaymentDetailsPreviewViewPreConditionsMixin(PaymentDetailsViewPreConditionsMixin):
+
+    # Disable skip conditions, so that we do not first get redirected forwards
+    @mock.patch('oscar.apps.checkout.session.CheckoutSessionMixin.skip_unless_payment_is_required')
+    @mock.patch('oscar.apps.checkout.session.CheckoutSessionMixin.skip_unless_basket_requires_shipping')
+    @mock.patch('oscar.apps.checkout.session.CheckoutSessionMixin.check_payment_data_is_captured')
+    def test_check_payment_data_is_captured(
+        self,
+        mock_check_payment_data_is_captured,
+        mock_skip_unless_basket_requires_shipping,
+        mock_skip_unless_payment_is_required,
+    ):
+        mock_check_payment_data_is_captured.side_effect = FailedPreCondition(url=reverse('checkout:payment-details'))
+        response = self.ready_to_place_an_order()
+        self.assertRedirectsTo(response, 'checkout:payment-details')
+
+
+class PaymentDetailsPreviewViewMixin(PaymentDetailsPreviewViewPreConditionsMixin):
+
+    def test_allows_order_to_be_placed(self):
+        self.add_product_to_basket()
+        if self.is_anonymous:
+            self.enter_guest_details()
+        self.enter_shipping_address()
+
+        payment_details = self.get(
+            reverse('checkout:shipping-method')).follow().follow()
+        preview = payment_details.click(linkid="view_preview")
+        preview.forms['place_order_form'].submit().follow()
+
+        self.assertEqual(1, Order.objects.all().count())
+
+    def test_payment_form_being_submitted_from_payment_details_view(self):
+        payment_details = self.reach_payment_details_page()
+        preview = payment_details.forms['sensible_data'].submit()
+        self.assertEqual(0, Order.objects.all().count())
+        preview.form.submit().follow()
+        self.assertEqual(1, Order.objects.all().count())
+
+    def test_handles_invalid_payment_forms(self):
+        payment_details = self.reach_payment_details_page()
+        form = payment_details.forms['sensible_data']
+        # payment forms should use the preview URL not the payment details URL
+        form.action = reverse('checkout:payment-details')
+        self.assertEqual(form.submit(status="*").status_code, http_client.BAD_REQUEST)
+
+    def test_placing_an_order_using_a_voucher_records_use(self):
+        self.add_product_to_basket()
+        self.add_voucher_to_basket()
+        if self.is_anonymous:
+            self.enter_guest_details()
+        self.enter_shipping_address()
+        thankyou = self.place_order()
+
+        order = thankyou.context['order']
+        self.assertEqual(1, order.discounts.all().count())
+
+        discount = order.discounts.all()[0]
+        voucher = discount.voucher
+        self.assertEqual(1, voucher.num_orders)
+
+    def test_placing_an_order_using_an_offer_records_use(self):
+        offer = factories.create_offer()
+        self.add_product_to_basket()
+        if self.is_anonymous:
+            self.enter_guest_details()
+        self.enter_shipping_address()
+        self.place_order()
+
+        # Reload offer
+        offer = ConditionalOffer.objects.get(id=offer.id)
+
+        self.assertEqual(1, offer.num_orders)
+        self.assertEqual(1, offer.num_applications)

--- a/tests/functional/checkout/test_customer_checkout.py
+++ b/tests/functional/checkout/test_customer_checkout.py
@@ -1,27 +1,34 @@
 from django.urls import reverse
 
-from oscar.core.loading import get_class, get_model
+from oscar.core.loading import get_model
 from oscar.test import factories
 from oscar.test.testcases import WebTestCase
 
-from . import CheckoutMixin
+from . import (
+    CheckoutMixin, IndexViewPreConditionsMixin, PaymentDetailsPreviewViewMixin,
+    PaymentDetailsViewMixin, PaymentMethodViewMixin, ShippingAddressViewMixin,
+    ShippingMethodViewMixin)
 
 Order = get_model('order', 'Order')
-OrderPlacementMixin = get_class('checkout.mixins', 'OrderPlacementMixin')
-ConditionalOffer = get_model('offer', 'ConditionalOffer')
 UserAddress = get_model('address', 'UserAddress')
-GatewayForm = get_class('checkout.forms', 'GatewayForm')
 
 
-class TestIndexView(CheckoutMixin, WebTestCase):
+class LoginRequiredMixin:
+
+    view_name = None
+    view_url = None
 
     def test_requires_login(self):
-        response = self.get(reverse('checkout:index'), user=None)
-        self.assertIsRedirect(response)
+        response = self.get(self.view_url or reverse(self.view_name), user=None)
+        expected_url = '{login_url}?next={forward}'.format(
+            login_url=reverse('customer:login'),
+            forward=self.view_url or reverse(self.view_name))
+        self.assertRedirects(response, expected_url)
 
-    def test_redirects_customers_with_empty_basket(self):
-        response = self.get(reverse('checkout:index'))
-        self.assertRedirectsTo(response, 'basket:summary')
+
+class TestIndexView(LoginRequiredMixin, IndexViewPreConditionsMixin, CheckoutMixin, WebTestCase):
+
+    view_name = 'checkout:index'
 
     def test_redirects_customers_to_shipping_address_view(self):
         self.add_product_to_basket()
@@ -29,36 +36,14 @@ class TestIndexView(CheckoutMixin, WebTestCase):
         self.assertRedirectsTo(response, 'checkout:shipping-address')
 
 
-class TestShippingAddressView(CheckoutMixin, WebTestCase):
+class TestShippingAddressView(LoginRequiredMixin, ShippingAddressViewMixin, CheckoutMixin, WebTestCase):
+
+    view_name = 'checkout:shipping-address'
+    next_view_name = 'checkout:shipping-method'
 
     def setUp(self):
         super().setUp()
-        self.user_address = factories.UserAddressFactory(
-            user=self.user, country=self.create_shipping_country())
-
-    def test_requires_login(self):
-        response = self.get(reverse('checkout:shipping-address'), user=None)
-        self.assertIsRedirect(response)
-
-    def test_submitting_valid_form_adds_data_to_session(self):
-        self.add_product_to_basket()
-        page = self.get(reverse('checkout:shipping-address'))
-        form = page.forms['new_shipping_address']
-        form['first_name'] = 'Barry'
-        form['last_name'] = 'Chuckle'
-        form['line1'] = '1 King Street'
-        form['line4'] = 'Gotham City'
-        form['postcode'] = 'N1 7RR'
-        response = form.submit()
-        self.assertRedirectsTo(response, 'checkout:shipping-method')
-
-        session_data = self.app.session['checkout_data']
-        session_fields = session_data['shipping']['new_address_fields']
-        self.assertEqual('Barry', session_fields['first_name'])
-        self.assertEqual('Chuckle', session_fields['last_name'])
-        self.assertEqual('1 King Street', session_fields['line1'])
-        self.assertEqual('Gotham City', session_fields['line4'])
-        self.assertEqual('N1 7RR', session_fields['postcode'])
+        self.user_address = factories.UserAddressFactory(user=self.user, country=self.create_shipping_country())
 
     def test_only_shipping_addresses_are_shown(self):
         not_shipping_country = factories.CountryFactory(
@@ -81,28 +66,15 @@ class TestShippingAddressView(CheckoutMixin, WebTestCase):
         self.assertRedirectsTo(response, 'checkout:shipping-method')
 
 
-class TestUserAddressUpdateView(CheckoutMixin, WebTestCase):
+class TestUserAddressUpdateView(LoginRequiredMixin, CheckoutMixin, WebTestCase):
 
     def setUp(self):
-        country = self.create_shipping_country()
         super().setUp()
-        self.user_address = factories.UserAddressFactory(
-            user=self.user, country=country)
-
-    def test_requires_login(self):
-        response = self.get(
-            reverse('checkout:user-address-update',
-                    kwargs={'pk': self.user_address.pk}),
-            user=None)
-        self.assertIsRedirect(response)
+        user_address = factories.UserAddressFactory(user=self.user, country=self.create_shipping_country())
+        self.view_url = reverse('checkout:user-address-update', kwargs={'pk': user_address.pk})
 
     def test_submitting_valid_form_modifies_user_address(self):
-        page = self.get(
-            reverse(
-                'checkout:user-address-update',
-                kwargs={'pk': self.user_address.pk}),
-            user=self.user)
-
+        page = self.get(self.view_url, user=self.user)
         form = page.forms['update_user_address']
         form['first_name'] = 'Tom'
         response = form.submit()
@@ -110,40 +82,17 @@ class TestUserAddressUpdateView(CheckoutMixin, WebTestCase):
         self.assertEqual('Tom', UserAddress.objects.get().first_name)
 
 
-class TestShippingMethodView(CheckoutMixin, WebTestCase):
-
-    def test_requires_login(self):
-        response = self.get(reverse('checkout:shipping-method'), user=None)
-        self.assertIsRedirect(response)
-
-    def test_redirects_when_only_one_shipping_method(self):
-        self.add_product_to_basket()
-        self.enter_shipping_address()
-        response = self.get(reverse('checkout:shipping-method'))
-        self.assertRedirectsTo(response, 'checkout:payment-method')
-
-
-class TestDeleteUserAddressView(CheckoutMixin, WebTestCase):
+class TestUserAddressDeleteView(LoginRequiredMixin, CheckoutMixin, WebTestCase):
 
     def setUp(self):
         super().setUp()
-        self.country = self.create_shipping_country()
-        self.user_address = factories.UserAddressFactory(
-            user=self.user, country=self.country)
-
-    def test_requires_login(self):
-        response = self.get(
-            reverse('checkout:user-address-delete',
-                    kwargs={'pk': self.user_address.pk}),
-            user=None)
-        self.assertIsRedirect(response)
+        self.user_address = factories.UserAddressFactory(user=self.user, country=self.create_shipping_country())
+        self.view_url = reverse('checkout:user-address-delete', kwargs={'pk': self.user_address.pk})
 
     def test_can_delete_a_user_address_from_shipping_address_page(self):
         self.add_product_to_basket()
         page = self.get(reverse('checkout:shipping-address'), user=self.user)
-        delete_confirm = page.click(
-            href=reverse('checkout:user-address-delete',
-                         kwargs={'pk': self.user_address.pk}))
+        delete_confirm = page.click(href=self.view_url)
         form = delete_confirm.forms["delete_address_%s" % self.user_address.id]
         form.submit()
 
@@ -152,49 +101,25 @@ class TestDeleteUserAddressView(CheckoutMixin, WebTestCase):
         self.assertEqual(0, len(user_addresses))
 
 
-class TestPreviewView(CheckoutMixin, WebTestCase):
+class TestShippingMethodView(LoginRequiredMixin, ShippingMethodViewMixin, CheckoutMixin, WebTestCase):
 
-    def test_allows_order_to_be_placed(self):
-        self.add_product_to_basket()
-        self.enter_shipping_address()
-
-        payment_details = self.get(
-            reverse('checkout:shipping-method')).follow().follow()
-        preview = payment_details.click(linkid="view_preview")
-        preview.forms['place_order_form'].submit().follow()
-
-        self.assertEqual(1, Order.objects.all().count())
+    view_name = 'checkout:shipping-method'
+    next_view_name = 'checkout:payment-method'
 
 
-class TestPlacingAnOrderUsingAVoucher(CheckoutMixin, WebTestCase):
+class TestPaymentMethodView(LoginRequiredMixin, PaymentMethodViewMixin, CheckoutMixin, WebTestCase):
 
-    def test_records_use(self):
-        self.add_product_to_basket()
-        self.add_voucher_to_basket()
-        self.enter_shipping_address()
-        thankyou = self.place_order()
-
-        order = thankyou.context['order']
-        self.assertEqual(1, order.discounts.all().count())
-
-        discount = order.discounts.all()[0]
-        voucher = discount.voucher
-        self.assertEqual(1, voucher.num_orders)
+    view_name = 'checkout:payment-method'
 
 
-class TestPlacingAnOrderUsingAnOffer(CheckoutMixin, WebTestCase):
+class TestPaymentDetailsView(LoginRequiredMixin, PaymentDetailsViewMixin, CheckoutMixin, WebTestCase):
 
-    def test_records_use(self):
-        offer = factories.create_offer()
-        self.add_product_to_basket()
-        self.enter_shipping_address()
-        self.place_order()
+    view_name = 'checkout:payment-details'
 
-        # Reload offer
-        offer = ConditionalOffer.objects.get(id=offer.id)
 
-        self.assertEqual(1, offer.num_orders)
-        self.assertEqual(1, offer.num_applications)
+class TestPaymentDetailsPreviewView(LoginRequiredMixin, PaymentDetailsPreviewViewMixin, CheckoutMixin, WebTestCase):
+
+    view_name = 'checkout:preview'
 
 
 class TestThankYouView(CheckoutMixin, WebTestCase):

--- a/tests/functional/checkout/test_guest_checkout.py
+++ b/tests/functional/checkout/test_guest_checkout.py
@@ -1,5 +1,4 @@
 import sys
-from http import client as http_client
 from importlib import import_module, reload
 from unittest import mock
 from urllib.parse import quote
@@ -8,24 +7,16 @@ from django.conf import settings
 from django.test.utils import override_settings
 from django.urls import clear_url_caches, reverse
 
-from oscar.apps.shipping import methods
-from oscar.core.compat import get_user_model
-from oscar.core.loading import get_class, get_classes, get_model
+from oscar.core.loading import get_class
 from oscar.test import factories
 from oscar.test.testcases import WebTestCase
 
-from . import CheckoutMixin
+from . import (
+    CheckoutMixin, IndexViewPreConditionsMixin, PaymentDetailsPreviewViewMixin,
+    PaymentDetailsViewMixin, PaymentMethodViewMixin, ShippingAddressViewMixin,
+    ShippingMethodViewMixin)
 
 GatewayForm = get_class('checkout.forms', 'GatewayForm')
-CheckoutSessionData = get_class('checkout.utils', 'CheckoutSessionData')
-RedirectRequired, UnableToTakePayment, PaymentError = get_classes(
-    'payment.exceptions', [
-        'RedirectRequired', 'UnableToTakePayment', 'PaymentError'])
-UnableToPlaceOrder = get_class('order.exceptions', 'UnableToPlaceOrder')
-
-Basket = get_model('basket', 'Basket')
-Order = get_model('order', 'Order')
-User = get_user_model()
 
 
 def reload_url_conf():
@@ -36,27 +27,30 @@ def reload_url_conf():
     clear_url_caches()
 
 
-@override_settings(OSCAR_ALLOW_ANON_CHECKOUT=True)
-class TestIndexView(CheckoutMixin, WebTestCase):
+class AnonymousMixin:
+
     is_anonymous = True
 
     def setUp(self):
         reload_url_conf()
         super().setUp()
 
-    def test_redirects_customers_with_empty_basket(self):
-        response = self.get(reverse('checkout:index'))
+    # Disable skip conditions, so that we do not first get redirected forwards
+    @mock.patch('oscar.apps.checkout.session.CheckoutSessionMixin.skip_unless_basket_requires_shipping')
+    @mock.patch('oscar.apps.checkout.session.CheckoutSessionMixin.skip_unless_payment_is_required')
+    def test_does_not_require_login(
+        self,
+        mock_skip_unless_payment_is_required,
+        mock_skip_unless_basket_requires_shipping,
+    ):
+        response = self.get(reverse(self.view_name))
         self.assertRedirectsTo(response, 'basket:summary')
 
-    def test_redirects_customers_with_invalid_basket(self):
-        # Add product to basket but then remove its stock so it is not
-        # purchasable.
-        product = factories.ProductFactory()
-        self.add_product_to_basket(product)
-        product.stockrecords.all().update(num_in_stock=0)
 
-        response = self.get(reverse('checkout:index'))
-        self.assertRedirectsTo(response, 'basket:summary')
+@override_settings(OSCAR_ALLOW_ANON_CHECKOUT=True)
+class TestIndexView(AnonymousMixin, IndexViewPreConditionsMixin, CheckoutMixin, WebTestCase):
+
+    view_name = 'checkout:index'
 
     def test_redirects_new_customers_to_registration_page(self):
         self.add_product_to_basket()
@@ -70,25 +64,29 @@ class TestIndexView(CheckoutMixin, WebTestCase):
 
         expected_url = '{register_url}?next={forward}&email={email}'.format(
             register_url=reverse('customer:register'),
-            forward='/checkout/shipping-address/',
+            forward=reverse('checkout:shipping-address'),
             email=quote(new_user_email))
         self.assertRedirects(response, expected_url)
 
     def test_redirects_existing_customers_to_shipping_address_page(self):
-        existing_user = User.objects.create_user(
-            username=self.username, email=self.email, password=self.password)
+        password = 'password'
+        user = factories.UserFactory(password=password)
         self.add_product_to_basket()
         page = self.get(reverse('checkout:index'))
         form = page.form
         form.select('options', GatewayForm.EXISTING)
-        form['username'].value = existing_user.email
-        form['password'].value = self.password
+        form['username'].value = user.email
+        form['password'].value = password
         response = form.submit()
         self.assertRedirectsTo(response, 'checkout:shipping-address')
 
     def test_redirects_guest_customers_to_shipping_address_page(self):
         self.add_product_to_basket()
-        response = self.enter_guest_details()
+        page = self.get(reverse('checkout:index'))
+        form = page.form
+        form.select('options', GatewayForm.GUEST)
+        form['username'] = 'guest@example.com'
+        response = form.submit()
         self.assertRedirectsTo(response, 'checkout:shipping-address')
 
     def test_prefill_form_with_email_for_returning_guest(self):
@@ -100,367 +98,38 @@ class TestIndexView(CheckoutMixin, WebTestCase):
 
 
 @override_settings(OSCAR_ALLOW_ANON_CHECKOUT=True)
-class TestShippingAddressView(CheckoutMixin, WebTestCase):
-    is_anonymous = True
+class TestShippingAddressView(AnonymousMixin, ShippingAddressViewMixin, CheckoutMixin, WebTestCase):
 
-    def setUp(self):
-        reload_url_conf()
-        super().setUp()
-
-    def test_redirects_customers_with_empty_basket(self):
-        response = self.get(reverse('checkout:shipping-address'))
-        self.assertRedirectsTo(response, 'basket:summary')
-
-    def test_redirects_customers_who_have_skipped_guest_form(self):
-        self.add_product_to_basket()
-        response = self.get(reverse('checkout:shipping-address'))
-        self.assertRedirectsTo(response, 'checkout:index')
-
-    def test_redirects_customers_whose_basket_doesnt_require_shipping(self):
-        product = self.create_digital_product()
-        self.add_product_to_basket(product)
-        self.enter_guest_details()
-
-        response = self.get(reverse('checkout:shipping-address'))
-        self.assertRedirectsTo(response, 'checkout:shipping-method')
-
-    def test_redirects_customers_with_invalid_basket(self):
-        # Add product to basket but then remove its stock so it is not
-        # purchasable.
-        product = factories.create_product(num_in_stock=1)
-        self.add_product_to_basket(product)
-        self.enter_guest_details()
-
-        product.stockrecords.all().update(num_in_stock=0)
-
-        response = self.get(reverse('checkout:shipping-address'))
-        self.assertRedirectsTo(response, 'basket:summary')
-
-    def test_shows_initial_data_if_the_form_has_already_been_submitted(self):
-        self.add_product_to_basket()
-        self.enter_guest_details('hello@egg.com')
-        self.enter_shipping_address()
-        page = self.get(reverse('checkout:shipping-address'), user=self.user)
-        self.assertEqual('John', page.form['first_name'].value)
-        self.assertEqual('Doe', page.form['last_name'].value)
-        self.assertEqual('1 Egg Road', page.form['line1'].value)
-        self.assertEqual('Shell City', page.form['line4'].value)
-        self.assertEqual('N12 9RT', page.form['postcode'].value)
+    view_name = 'checkout:shipping-address'
+    next_view_name = 'checkout:shipping-method'
 
 
 @override_settings(OSCAR_ALLOW_ANON_CHECKOUT=True)
-class TestShippingMethodView(CheckoutMixin, WebTestCase):
-    is_anonymous = True
+class TestShippingMethodView(AnonymousMixin, ShippingMethodViewMixin, CheckoutMixin, WebTestCase):
 
-    def setUp(self):
-        reload_url_conf()
-        super().setUp()
-
-    def test_redirects_customers_with_empty_basket(self):
-        response = self.get(reverse('checkout:shipping-method'))
-        self.assertRedirectsTo(response, 'basket:summary')
-
-    def test_redirects_customers_with_invalid_basket(self):
-        product = factories.create_product(num_in_stock=1)
-        self.add_product_to_basket(product)
-        self.enter_guest_details()
-        self.enter_shipping_address()
-        product.stockrecords.all().update(num_in_stock=0)
-
-        response = self.get(reverse('checkout:shipping-method'))
-        self.assertRedirectsTo(response, 'basket:summary')
-
-    def test_redirects_customers_who_have_skipped_guest_form(self):
-        self.add_product_to_basket()
-
-        response = self.get(reverse('checkout:shipping-method'))
-        self.assertRedirectsTo(response, 'checkout:index')
-
-    def test_redirects_customers_whose_basket_doesnt_require_shipping(self):
-        product = self.create_digital_product()
-        self.add_product_to_basket(product)
-        self.enter_guest_details()
-
-        response = self.get(reverse('checkout:shipping-method'))
-        self.assertRedirectsTo(response, 'checkout:payment-method')
-
-    def test_redirects_customers_who_have_skipped_shipping_address_form(self):
-        self.add_product_to_basket()
-        self.enter_guest_details()
-
-        response = self.get(reverse('checkout:shipping-method'))
-        self.assertRedirectsTo(response, 'checkout:shipping-address')
-
-    @mock.patch('oscar.apps.checkout.views.Repository')
-    def test_redirects_customers_when_no_shipping_methods_available(
-            self, mock_repo):
-        self.add_product_to_basket()
-        self.enter_guest_details()
-        self.enter_shipping_address()
-
-        # Ensure no shipping methods available
-        instance = mock_repo.return_value
-        instance.get_shipping_methods.return_value = []
-
-        response = self.get(reverse('checkout:shipping-method'))
-        self.assertRedirectsTo(response, 'checkout:shipping-address')
-
-    @mock.patch('oscar.apps.checkout.views.Repository')
-    def test_redirects_customers_when_only_one_shipping_method_is_available(
-            self, mock_repo):
-        self.add_product_to_basket()
-        self.enter_guest_details()
-        self.enter_shipping_address()
-
-        # Ensure one shipping method available
-        instance = mock_repo.return_value
-        instance.get_shipping_methods.return_value = [methods.Free()]
-
-        response = self.get(reverse('checkout:shipping-method'))
-        self.assertRedirectsTo(response, 'checkout:payment-method')
-
-    @mock.patch('oscar.apps.checkout.views.Repository')
-    def test_shows_form_when_multiple_shipping_methods_available(
-            self, mock_repo):
-        self.add_product_to_basket()
-        self.enter_guest_details()
-        self.enter_shipping_address()
-
-        # Ensure multiple shipping methods available
-        method = mock.MagicMock()
-        method.code = 'm'
-        instance = mock_repo.return_value
-        instance.get_shipping_methods.return_value = [methods.Free(), method]
-        form_page = self.get(reverse('checkout:shipping-method'))
-        self.assertIsOk(form_page)
-
-        response = form_page.forms[0].submit()
-        self.assertRedirectsTo(response, 'checkout:payment-method')
-
-    @mock.patch('oscar.apps.checkout.views.Repository')
-    def test_check_user_can_submit_only_valid_shipping_method(self, mock_repo):
-        self.add_product_to_basket()
-        self.enter_guest_details()
-        self.enter_shipping_address()
-        method = mock.MagicMock()
-        method.code = 'm'
-        instance = mock_repo.return_value
-        instance.get_shipping_methods.return_value = [methods.Free(), method]
-        form_page = self.get(reverse('checkout:shipping-method'))
-        # a malicious attempt?
-        form_page.forms[0]['method_code'].value = 'super-free-shipping'
-        response = form_page.forms[0].submit()
-        self.assertIsNotRedirect(response)
-        response.mustcontain('Your submitted shipping method is not permitted')
+    view_name = 'checkout:shipping-method'
+    next_view_name = 'checkout:payment-method'
 
 
 @override_settings(OSCAR_ALLOW_ANON_CHECKOUT=True)
-class TestPaymentMethodView(CheckoutMixin, WebTestCase):
-    is_anonymous = True
+class TestPaymentMethodView(AnonymousMixin, PaymentMethodViewMixin, CheckoutMixin, WebTestCase):
 
-    def setUp(self):
-        reload_url_conf()
-        super().setUp()
-
-    def test_redirects_customers_with_empty_basket(self):
-        response = self.get(reverse('checkout:payment-method'))
-        self.assertRedirectsTo(response, 'basket:summary')
-
-    def test_redirects_customers_with_invalid_basket(self):
-        product = factories.create_product(num_in_stock=1)
-        self.add_product_to_basket(product)
-        self.enter_guest_details()
-        self.enter_shipping_address()
-
-        product.stockrecords.all().update(num_in_stock=0)
-
-        response = self.get(reverse('checkout:payment-method'))
-        self.assertRedirectsTo(response, 'basket:summary')
-
-    def test_redirects_customers_who_have_skipped_guest_form(self):
-        self.add_product_to_basket()
-
-        response = self.get(reverse('checkout:payment-method'))
-        self.assertRedirectsTo(response, 'checkout:index')
-
-    def test_redirects_customers_who_have_skipped_shipping_address_form(self):
-        self.add_product_to_basket()
-        self.enter_guest_details()
-
-        response = self.get(reverse('checkout:payment-method'))
-        self.assertRedirectsTo(response, 'checkout:shipping-address')
-
-    def test_redirects_customers_who_have_skipped_shipping_method_step(self):
-        self.add_product_to_basket()
-        self.enter_guest_details()
-        self.enter_shipping_address()
-
-        response = self.get(reverse('checkout:payment-method'))
-        self.assertRedirectsTo(response, 'checkout:shipping-method')
+    view_name = 'checkout:payment-method'
 
 
 @override_settings(OSCAR_ALLOW_ANON_CHECKOUT=True)
-class TestPaymentDetailsView(CheckoutMixin, WebTestCase):
-    is_anonymous = True
+class TestPaymentDetailsView(AnonymousMixin, PaymentDetailsViewMixin, CheckoutMixin, WebTestCase):
 
-    def setUp(self):
-        reload_url_conf()
-        super().setUp()
-
-    def test_redirects_customers_with_empty_basket(self):
-        response = self.get(reverse('checkout:payment-details'))
-        self.assertRedirectsTo(response, 'basket:summary')
-
-    def test_redirects_customers_with_invalid_basket(self):
-        product = factories.create_product(num_in_stock=1)
-        self.add_product_to_basket(product)
-        self.enter_guest_details()
-        self.enter_shipping_address()
-
-        product.stockrecords.all().update(num_in_stock=0)
-
-        response = self.get(reverse('checkout:payment-details'))
-        self.assertRedirectsTo(response, 'basket:summary')
-
-    def test_redirects_customers_who_have_skipped_guest_form(self):
-        self.add_product_to_basket()
-
-        response = self.get(reverse('checkout:payment-details'))
-        self.assertRedirectsTo(response, 'checkout:index')
-
-    def test_redirects_customers_who_have_skipped_shipping_address_form(self):
-        self.add_product_to_basket()
-        self.enter_guest_details()
-
-        response = self.get(reverse('checkout:payment-details'))
-        self.assertRedirectsTo(response, 'checkout:shipping-address')
-
-    def test_redirects_customers_who_have_skipped_shipping_method_step(self):
-        self.add_product_to_basket()
-        self.enter_guest_details()
-        self.enter_shipping_address()
-
-        response = self.get(reverse('checkout:payment-details'))
-        self.assertRedirectsTo(response, 'checkout:shipping-method')
-
-    @mock.patch('oscar.apps.checkout.views.PaymentDetailsView.handle_payment')
-    def test_redirects_customers_when_using_bank_gateway(self, mock_method):
-
-        bank_url = 'https://bank-website.com'
-        e = RedirectRequired(url=bank_url)
-        mock_method.side_effect = e
-        preview = self.ready_to_place_an_order(is_guest=True)
-        bank_redirect = preview.forms['place_order_form'].submit()
-
-        assert bank_redirect.status_code == 302
-        assert bank_redirect.url == bank_url
-
-    @mock.patch('oscar.apps.checkout.views.PaymentDetailsView.handle_payment')
-    def test_handles_anticipated_payments_errors_gracefully(self, mock_method):
-        msg = 'Submitted expiration date is wrong'
-        e = UnableToTakePayment(msg)
-        mock_method.side_effect = e
-        preview = self.ready_to_place_an_order(is_guest=True)
-        response = preview.forms['place_order_form'].submit()
-        self.assertIsOk(response)
-        # check user is warned
-        response.mustcontain(msg)
-        # check basket is restored
-        basket = Basket.objects.get()
-        self.assertEqual(basket.status, Basket.OPEN)
-
-    @mock.patch('oscar.apps.checkout.views.logger')
-    @mock.patch('oscar.apps.checkout.views.PaymentDetailsView.handle_payment')
-    def test_handles_unexpected_payment_errors_gracefully(
-            self, mock_method, mock_logger):
-        msg = 'This gateway is down for maintenance'
-        e = PaymentError(msg)
-        mock_method.side_effect = e
-        preview = self.ready_to_place_an_order(is_guest=True)
-        response = preview.forms['place_order_form'].submit()
-        self.assertIsOk(response)
-        # check user is warned with a generic error
-        response.mustcontain(
-            'A problem occurred while processing payment for this order',
-            no=[msg])
-        # admin should be warned
-        self.assertTrue(mock_logger.error.called)
-        # check basket is restored
-        basket = Basket.objects.get()
-        self.assertEqual(basket.status, Basket.OPEN)
-
-    @mock.patch('oscar.apps.checkout.views.logger')
-    @mock.patch('oscar.apps.checkout.views.PaymentDetailsView.handle_payment')
-    def test_handles_bad_errors_during_payments(
-            self, mock_method, mock_logger):
-        e = Exception()
-        mock_method.side_effect = e
-        preview = self.ready_to_place_an_order(is_guest=True)
-        response = preview.forms['place_order_form'].submit()
-        self.assertIsOk(response)
-        self.assertTrue(mock_logger.exception.called)
-        basket = Basket.objects.get()
-        self.assertEqual(basket.status, Basket.OPEN)
-
-    @mock.patch('oscar.apps.checkout.views.logger')
-    @mock.patch('oscar.apps.checkout.views.PaymentDetailsView.handle_order_placement')
-    def test_handles_unexpected_order_placement_errors_gracefully(
-            self, mock_method, mock_logger):
-        e = UnableToPlaceOrder()
-        mock_method.side_effect = e
-        preview = self.ready_to_place_an_order(is_guest=True)
-        response = preview.forms['place_order_form'].submit()
-        self.assertIsOk(response)
-        self.assertTrue(mock_logger.error.called)
-        basket = Basket.objects.get()
-        self.assertEqual(basket.status, Basket.OPEN)
-
-    @mock.patch('oscar.apps.checkout.views.logger')
-    @mock.patch('oscar.apps.checkout.views.PaymentDetailsView.handle_order_placement')
-    def test_handles_all_other_exceptions_gracefully(self, mock_method, mock_logger):
-        mock_method.side_effect = Exception()
-        preview = self.ready_to_place_an_order(is_guest=True)
-        response = preview.forms['place_order_form'].submit()
-        self.assertIsOk(response)
-        self.assertTrue(mock_logger.exception.called)
-        basket = Basket.objects.get()
-        self.assertEqual(basket.status, Basket.OPEN)
+    view_name = 'checkout:payment-details'
 
 
 @override_settings(OSCAR_ALLOW_ANON_CHECKOUT=True)
-class TestPaymentDetailsWithPreview(CheckoutMixin, WebTestCase):
-    is_anonymous = True
-    csrf_checks = False
+class TestPaymentDetailsPreviewView(AnonymousMixin, PaymentDetailsPreviewViewMixin, CheckoutMixin, WebTestCase):
 
-    def setUp(self):
-        reload_url_conf()
-        super().setUp()
+    view_name = 'checkout:preview'
 
-    def test_payment_form_being_submitted_from_payment_details_view(self):
-        payment_details = self.reach_payment_details_page(is_guest=True)
-        preview = payment_details.forms['sensible_data'].submit()
-        self.assertEqual(0, Order.objects.all().count())
-        preview.form.submit().follow()
-        self.assertEqual(1, Order.objects.all().count())
-
-    def test_handles_invalid_payment_forms(self):
-        payment_details = self.reach_payment_details_page(is_guest=True)
-        form = payment_details.forms['sensible_data']
-        # payment forms should use the preview URL not the payment details URL
-        form.action = reverse('checkout:payment-details')
-        self.assertEqual(form.submit(status="*").status_code, http_client.BAD_REQUEST)
-
-
-@override_settings(OSCAR_ALLOW_ANON_CHECKOUT=True)
-class TestPlacingOrder(CheckoutMixin, WebTestCase):
-    is_anonymous = True
-
-    def setUp(self):
-        reload_url_conf()
-        super().setUp()
-
-    def test_saves_guest_email_with_order(self):
-        preview = self.ready_to_place_an_order(is_guest=True)
+    def test_placing_order_saves_guest_email_with_order(self):
+        preview = self.ready_to_place_an_order()
         thank_you = preview.forms['place_order_form'].submit().follow()
         order = thank_you.context['order']
         self.assertEqual('hello@egg.com', order.guest_email)


### PR DESCRIPTION
This makes the views faster by not running the "pre-condition" code if a view is to be skipped. Also, pre conditions for a view always include those for previous views, so currently, when a view is skipped, the forwarded-to view reruns the pre conditions that were already run by the forwarding view.