### PR TITLE
Drop support for Django 2.2 and Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
-        django-version: [2.2, 3.1, 3.2]
+        python-version: [3.7, 3.8, 3.9]
+        django-version: [3.1, 3.2]
     services:
       postgres:
         image: postgres:10
@@ -59,7 +59,7 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3.7
+FROM python:3.8
 ENV PYTHONUNBUFFERED 1
 
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt-get install -y nodejs
 
 COPY ./requirements.txt /requirements.txt

--- a/docs/source/internals/contributing/running-tests.rst
+++ b/docs/source/internals/contributing/running-tests.rst
@@ -8,7 +8,7 @@ Testing requirements
 You'll need:
 
 - A running SQL server (PostgreSQL, or SQLite with `--sqlite` parameters)
-- python3.6 or python3.7
+- python3.7 or higher.
 
 Running tests
 -------------

--- a/docs/source/ref/settings.rst
+++ b/docs/source/ref/settings.rst
@@ -99,13 +99,12 @@ sorting, filtering, etc.
 The default is::
 
     OSCAR_SEARCH_FACETS = {
-        'fields': OrderedDict([
-            ('product_class', {'name': _('Type'), 'field': 'product_class'}),
-            ('rating', {'name': _('Rating'), 'field': 'rating'}),
-        ]),
-        'queries': OrderedDict([
-            ('price_range',
-             {
+        'fields': {
+            'product_class': {'name': _('Type'), 'field': 'product_class'},
+            'rating': {'name': _('Rating'), 'field': 'rating'},
+        },
+        'queries': {
+            'price_range': {
                  'name': _('Price range'),
                  'field': 'price',
                  'queries': [
@@ -116,8 +115,8 @@ The default is::
                      (_('40 to 60'), '[40 TO 60]'),
                      (_('60+'), '[60 TO *]'),
                  ]
-             }),
-        ]),
+             },
+        },
     }
 
 ``OSCAR_PRODUCT_SEARCH_HANDLER``

--- a/docs/source/releases/v3.2.rst
+++ b/docs/source/releases/v3.2.rst
@@ -14,6 +14,9 @@ Oscar 3.2 release notes (in development)
 Compatibility
 ~~~~~~~~~~~~~
 
+Oscar 3.2 is compatible with Django 3.1 and Django 3.2 and Python versions 3.7 to 3.9.
+
+Support for Django 2.2 has been dropped. Support for Python 3.6 has been dropped.
 
 .. _new_in_3.2:
 
@@ -46,3 +49,10 @@ Python package dependencies:
 
 
 Javascript and CSS dependencies:
+
+
+Deprecated features
+~~~~~~~~~~~~~~~~~~~
+
+- The ``annotate_form_field`` template tag is deprecated. It's functionality of annotating form fields with
+  their widget type is now built in to Django.

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ sys.path.append(os.path.join(PROJECT_DIR, 'src'))
 from oscar import get_version  # noqa isort:skip
 
 install_requires = [
-    'django>=2.2,<3.3',
+    'django>=3.1,<3.3',
     # PIL is required for image fields, Pillow is the "friendly" PIL fork
     'pillow>=6.0',
     # We use the ModelFormSetView from django-extra-views for the basket page
@@ -87,6 +87,7 @@ setup(
     package_dir={'': 'src'},
     packages=find_packages('src'),
     include_package_data=True,
+    python_requires='>=3.7',
     install_requires=install_requires,
     extras_require={
         'docs': docs_requires,
@@ -98,7 +99,6 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.1',
         'Framework :: Django :: 3.2',
         'Intended Audience :: Developers',
@@ -106,7 +106,6 @@ setup(
         'Operating System :: Unix',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/src/oscar/apps/basket/views.py
+++ b/src/oscar/apps/basket/views.py
@@ -5,6 +5,7 @@ from django.http import JsonResponse, QueryDict
 from django.shortcuts import redirect
 from django.template.loader import render_to_string
 from django.urls import reverse
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView, View
 from extra_views import ModelFormSetView
@@ -12,7 +13,6 @@ from extra_views import ModelFormSetView
 from oscar.apps.basket.signals import (
     basket_addition, voucher_addition, voucher_removal)
 from oscar.core import ajax
-from oscar.core.compat import url_has_allowed_host_and_scheme
 from oscar.core.loading import get_class, get_classes, get_model
 from oscar.core.utils import is_ajax, redirect_to_referrer, safe_referrer
 

--- a/src/oscar/apps/customer/forms.py
+++ b/src/oscar/apps/customer/forms.py
@@ -9,12 +9,12 @@ from django.contrib.auth.password_validation import validate_password
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import ValidationError
 from django.utils.crypto import get_random_string
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import pgettext_lazy
 
 from oscar.apps.customer.utils import get_password_reset_url, normalise_email
-from oscar.core.compat import (
-    existing_user_fields, get_user_model, url_has_allowed_host_and_scheme)
+from oscar.core.compat import existing_user_fields, get_user_model
 from oscar.core.loading import get_class, get_model, get_profile_class
 from oscar.core.utils import datetime_combine
 from oscar.forms import widgets

--- a/src/oscar/apps/dashboard/orders/views.py
+++ b/src/oscar/apps/dashboard/orders/views.py
@@ -1,5 +1,4 @@
 import datetime
-from collections import OrderedDict
 from decimal import Decimal as D
 from decimal import InvalidOperation
 
@@ -117,16 +116,16 @@ class OrderListView(BulkEditMixin, ListView):
     form_class = OrderSearchForm
     paginate_by = settings.OSCAR_DASHBOARD_ITEMS_PER_PAGE
     actions = ('download_selected_orders', 'change_order_statuses')
-    CSV_COLUMNS = (
-        ('number', _('Order number')),
-        ('value', _('Order value')),
-        ('date', _('Date of purchase')),
-        ('num_items', _('Number of items')),
-        ('status', _('Order status')),
-        ('customer', _('Customer email address')),
-        ('shipping_address_name', _('Deliver to name')),
-        ('billing_address_name', _('Bill to name')),
-    )
+    CSV_COLUMNS = {
+        'number', _('Order number'),
+        'value', _('Order value'),
+        'date', _('Date of purchase'),
+        'num_items', _('Number of items'),
+        'status', _('Order status'),
+        'customer', _('Customer email address'),
+        'shipping_address_name', _('Deliver to name'),
+        'billing_address_name', _('Bill to name'),
+    }
 
     def dispatch(self, request, *args, **kwargs):
         # base_queryset is equal to all orders the user is allowed to access
@@ -382,11 +381,10 @@ class OrderListView(BulkEditMixin, ListView):
             % self.get_download_filename(request)
         writer = UnicodeCSVWriter(open_file=response)
 
-        ordered_columns = OrderedDict(self.CSV_COLUMNS)
-        writer.writerow(ordered_columns.values())
+        writer.writerow(self.CSV_COLUMNS.values())
         for order in orders:
             row_values = self.get_row_values(order)
-            writer.writerow([row_values.get(column, "") for column in ordered_columns])
+            writer.writerow([row_values.get(column, "") for column in self.CSV_COLUMNS])
         return response
 
     def change_order_statuses(self, request, orders):

--- a/src/oscar/apps/order/abstract_models.py
+++ b/src/oscar/apps/order/abstract_models.py
@@ -1,5 +1,4 @@
 import logging
-from collections import OrderedDict
 from decimal import Decimal as D
 
 from django.conf import settings
@@ -260,7 +259,7 @@ class AbstractOrder(models.Model):
             return ''
 
         # Collect all events by event-type
-        event_map = OrderedDict()
+        event_map = {}
         for event in events:
             event_name = event.event_type.name
             if event_name not in event_map:
@@ -719,7 +718,7 @@ class AbstractLine(models.Model):
         """
         Returns a dict of shipping events that this line has been through
         """
-        status_map = OrderedDict()
+        status_map = {}
         for event in self.shipping_events.all():
             event_type = event.event_type
             event_name = event_type.name

--- a/src/oscar/apps/search/facets.py
+++ b/src/oscar/apps/search/facets.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 from django.conf import settings
 from haystack.query import SearchQuerySet
 from purl import URL
@@ -27,7 +25,7 @@ class FacetMunger(object):
         self.facet_counts = facet_counts
 
     def facet_data(self):
-        facet_data = OrderedDict()
+        facet_data = {}
         # Haystack can return an empty dict for facet_counts when e.g. Solr
         # isn't running. Skip facet munging in that case.
         if self.facet_counts:

--- a/src/oscar/core/compat.py
+++ b/src/oscar/core/compat.py
@@ -1,7 +1,5 @@
 import csv
-import re
 
-from django import template
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ImproperlyConfigured
@@ -15,14 +13,6 @@ try:
 except ValueError:
     raise ImproperlyConfigured("AUTH_USER_MODEL must be of the form"
                                " 'app_label.model_name'")
-
-
-# Backward-compatible import for url_has_allowed_host_and_scheme.
-try:
-    # Django 3.0 and above
-    from django.utils.http import url_has_allowed_host_and_scheme  # noqa F401
-except ImportError:
-    from django.utils.http import is_safe_url as url_has_allowed_host_and_scheme  # noqa F401 isort:skip
 
 
 def get_user_model():
@@ -129,19 +119,3 @@ class UnicodeCSVWriter:
     def writerows(self, rows):
         for row in rows:
             self.writerow(row)
-
-
-class FormFieldNode(template.Node):
-    """"
-    Add the widget type to a BoundField. Until 3.1, Django did not make this available by default.
-
-    Used by `oscar.templatetags.form_tags.annotate_form_field`
-    """
-    def __init__(self, field_str):
-        self.field = template.Variable(field_str)
-
-    def render(self, context):
-        field = self.field.resolve(context)
-        if not hasattr(field, 'widget_type') and hasattr(field, 'field'):
-            field.widget_type = re.sub(r'widget$|input$', '', field.field.widget.__class__.__name__.lower())
-        return ''

--- a/src/oscar/core/utils.py
+++ b/src/oscar/core/utils.py
@@ -8,12 +8,11 @@ from babel.dates import format_timedelta as format_td
 from django.conf import settings
 from django.shortcuts import redirect, resolve_url
 from django.template.defaultfilters import date as date_filter
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.module_loading import import_string
 from django.utils.text import slugify as django_slugify
 from django.utils.timezone import get_current_timezone, is_naive, make_aware
 from django.utils.translation import get_language, to_locale
-
-from oscar.core.compat import url_has_allowed_host_and_scheme
 
 SLUGIFY_RE = re.compile(r'[^\w\s-]', re.UNICODE)
 

--- a/src/oscar/defaults.py
+++ b/src/oscar/defaults.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 from django.urls import reverse_lazy
 from django.utils.translation import gettext_lazy as _
 
@@ -216,11 +214,11 @@ OSCAR_DASHBOARD_DEFAULT_ACCESS_FUNCTION = 'oscar.apps.dashboard.nav.default_acce
 
 # Search facets
 OSCAR_SEARCH_FACETS = {
-    'fields': OrderedDict([
+    'fields': {
         # The key for these dicts will be used when passing facet data
         # to the template. Same for the 'queries' dict below.
-        ('product_class', {'name': _('Type'), 'field': 'product_class'}),
-        ('rating', {'name': _('Rating'), 'field': 'rating'}),
+        'product_class': {'name': _('Type'), 'field': 'product_class'},
+        'rating': {'name': _('Rating'), 'field': 'rating'},
         # You can specify an 'options' element that will be passed to the
         # SearchQuerySet.facet() call.
         # For instance, with Elasticsearch backend, 'options': {'order': 'term'}
@@ -230,22 +228,21 @@ OSCAR_SEARCH_FACETS = {
         # items without a specific facet:
         # http://wiki.apache.org/solr/SimpleFacetParameters#facet.method
         # 'options': {'missing': 'true'}
-    ]),
-    'queries': OrderedDict([
-        ('price_range',
-         {
-             'name': _('Price range'),
-             'field': 'price',
-             'queries': [
-                 # This is a list of (name, query) tuples where the name will
-                 # be displayed on the front-end.
-                 (_('0 to 20'), '[0 TO 20]'),
-                 (_('20 to 40'), '[20 TO 40]'),
-                 (_('40 to 60'), '[40 TO 60]'),
-                 (_('60+'), '[60 TO *]'),
-             ]
-         }),
-    ]),
+    },
+    'queries': {
+        'price_range': {
+            'name': _('Price range'),
+            'field': 'price',
+            'queries': [
+                # This is a list of (name, query) tuples where the name will
+                # be displayed on the front-end.
+                (_('0 to 20'), '[0 TO 20]'),
+                (_('20 to 40'), '[20 TO 40]'),
+                (_('40 to 60'), '[40 TO 60]'),
+                (_('60+'), '[60 TO *]'),
+            ]
+        },
+    },
 }
 
 OSCAR_PRODUCT_SEARCH_HANDLER = None

--- a/src/oscar/templates/oscar/dashboard/catalogue/product_update.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/product_update.html
@@ -1,5 +1,4 @@
 {% extends 'oscar/dashboard/layout.html' %}
-{% load form_tags %}
 {% load i18n %}
 
 {% block body_class %}{{ block.super }} create-page catalogue{% endblock %}

--- a/src/oscar/templates/oscar/dashboard/partials/form_field.html
+++ b/src/oscar/templates/oscar/dashboard/partials/form_field.html
@@ -1,4 +1,3 @@
-{% load form_tags %}
 {% load widget_tweaks %}
 
 {% if field.is_hidden %}
@@ -8,7 +7,6 @@
         Make the field widget type available to templates so we can mark-up
         checkbox and radio inputs differently to other widgets.
     {% endcomment %}
-    {% annotate_form_field field %}
 
     {% block control_group %}
         <div class="form-group{% if style == 'horizontal' %} row{% endif %}{% if field.errors %} error{% endif %}">

--- a/src/oscar/templates/oscar/partials/form_field.html
+++ b/src/oscar/templates/oscar/partials/form_field.html
@@ -1,4 +1,3 @@
-{% load form_tags %}
 {% load widget_tweaks %}
 
 {% if field.is_hidden %}
@@ -8,7 +7,6 @@
         Make the field widget type available to templates so we can mark-up
         checkbox and radio inputs differently to other widgets.
     {% endcomment %}
-    {% annotate_form_field field %}
 
     {% block control_group %}
         <div class="form-group{% if style == "horizontal" %} row{% endif %}">

--- a/src/oscar/templatetags/category_tags.py
+++ b/src/oscar/templatetags/category_tags.py
@@ -67,8 +67,8 @@ class CheapCategoryInfo(dict, metaclass=CategoryFieldPassThroughMetaClass):
         yield self
 
 
-@register.simple_tag(name="category_tree")   # noqa: C901 too complex
-def get_annotated_list(depth=None, parent=None):
+@register.simple_tag(name="category_tree")
+def get_annotated_list(depth=None, parent=None):    # noqa: C901 too complex
     """
     Gets an annotated list from a tree branch.
 

--- a/src/oscar/templatetags/form_tags.py
+++ b/src/oscar/templatetags/form_tags.py
@@ -1,8 +1,9 @@
-import django
+import warnings
+
 from django import template
 from django.template.base import TextNode
 
-from oscar.core.compat import FormFieldNode
+from oscar.utils.deprecation import RemovedInOscar32Warning
 
 register = template.Library()
 
@@ -10,15 +11,12 @@ register = template.Library()
 @register.tag
 def annotate_form_field(parser, token):
     """
-    Set an attribute on a form field with the widget type
-
-    This means templates can use the widget type to render things differently
-    if they want to. Until 3.1, Django did not make this available by default.
+    Used to set an attribute on a form field with the widget type. This is now
+    done by Django itself.
     """
-    args = token.split_contents()
-    if len(args) < 2:
-        raise template.TemplateSyntaxError(
-            "annotate_form_field tag requires a form field to be passed")
-    if django.VERSION < (3, 1):
-        return FormFieldNode(args[1])
+    warnings.warn(
+        "The annotate_form_field template tag is deprecated and will be removed in the next version of django-oscar",
+        RemovedInOscar32Warning,
+        stacklevel=2
+    )
     return TextNode('')

--- a/src/oscar/templatetags/history_tags.py
+++ b/src/oscar/templatetags/history_tags.py
@@ -26,8 +26,8 @@ def recently_viewed_products(context, current_product=None):
             'request': request}
 
 
-@register.simple_tag(takes_context=True)  # noqa (too complex (11))
-def get_back_button(context):
+@register.simple_tag(takes_context=True)
+def get_back_button(context):   # noqa (too complex (11))
     """
     Show back button, custom title available for different urls, for
     example 'Back to search results', no back button if user came from other

--- a/tests/integration/search/test_munger.py
+++ b/tests/integration/search/test_munger.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils.translation import gettext_lazy as _
@@ -39,24 +37,23 @@ FACET_COUNTS_WITH_PRICE_RANGE_SELECTED = {
 
 
 SEARCH_FACETS = {
-    'fields': OrderedDict([
-        ('product_class', {'name': _('Type'), 'field': 'product_class'}),
-        ('rating', {'name': _('Rating'), 'field': 'rating'}),
-        ('category', {'name': _('Category'), 'field': 'category'}),
-    ]),
-    'queries': OrderedDict([
-        ('price_range',
-         {
-             'name': _('Price range'),
-             'field': 'price',
-             'queries': [
-                 (_('0 to 20'), '[0 TO 20]'),
-                 (_('20 to 40'), '[20 TO 40]'),
-                 (_('40 to 60'), '[40 TO 60]'),
-                 (_('60+'), '[60 TO *]'),
-             ]
-         }),
-    ]),
+    'fields': {
+        'product_class': {'name': _('Type'), 'field': 'product_class'},
+        'rating': {'name': _('Rating'), 'field': 'rating'},
+        'category': {'name': _('Category'), 'field': 'category'},
+    },
+    'queries': {
+        'price_range': {
+            'name': _('Price range'),
+            'field': 'price',
+            'queries': [
+                (_('0 to 20'), '[0 TO 20]'),
+                (_('20 to 40'), '[20 TO 40]'),
+                (_('40 to 60'), '[40 TO 60]'),
+                (_('60+'), '[60 TO *]'),
+            ]
+        },
+    },
 }
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39}-django{22,31,32}
+    py{37,38,39}-django{31,32}
     lint
     sandbox
     docs
@@ -11,12 +11,11 @@ commands = coverage run --parallel -m pytest {posargs}
 extras = test
 pip_pre = true
 deps =
-    django22: django>=2.2,<2.3
     django31: django>=3.1,<3.2
     django32: django>=3.2,<3.3
 
 [testenv:lint]
-basepython = python3.7
+basepython = python3.8
 deps =
     -r{toxinidir}/requirements.txt
 allowlist_externals = npm
@@ -29,16 +28,16 @@ commands =
 
 
 [testenv:sandbox]
-basepython = python3.7
+basepython = python3.8
 deps =
     -r{toxinidir}/requirements.txt
-    django>=2.2,<2.3
+    django>=3.2,<3.3
 allowlist_externals = make
 commands =
     make build_sandbox
 
 [testenv:docs]
-basepython = python3.7
+basepython = python3.8
 allowlist_externals = make
 changedir = {toxinidir}/docs
 pip_pre = false


### PR DESCRIPTION
Both Django 2.2 and Python 3.6 reach end of life in December 2021 - which is around the time we will be shipping the next release of Oscar.

Dropping support for Python 3.6 also means we can remove all uses of `collections.OrderedDict`, because dictionaries are ordered in Python 3.7.