### PR TITLE
Support Django 3.2 automatic "AppConfig" discovery

### DIFF
--- a/docs/source/howto/how_to_disable_an_app_or_feature.rst
+++ b/docs/source/howto/how_to_disable_an_app_or_feature.rst
@@ -25,7 +25,6 @@ the dashboard app::
 
     # myproject/config.py
     from oscar.config import Shop
-    from oscar.core.application import OscarConfig
 
     class MyShop(Shop):
 
@@ -59,9 +58,9 @@ Currently supported "reviews" and "wishlists" features. You can make your custom
 hidable by setting ``hidable_feature_name`` property of the ``OscarConfig`` class::
 
     # myproject/apps/lottery/apps.py
-    from oscar.core.application import OscarConfig
+    from oscar.core import application
 
-    class LotterConfig(OscarConfig):
+    class LotterConfig(application.OscarConfig):
         hidable_feature_name = 'lottery'
 
 

--- a/src/oscar/apps/address/apps.py
+++ b/src/oscar/apps/address/apps.py
@@ -1,9 +1,9 @@
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarConfig
+from oscar.core import application
 
 
-class AddressConfig(OscarConfig):
+class AddressConfig(application.OscarConfig):
     label = 'address'
     name = 'oscar.apps.address'
     verbose_name = _('Address')

--- a/src/oscar/apps/analytics/apps.py
+++ b/src/oscar/apps/analytics/apps.py
@@ -1,9 +1,9 @@
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarConfig
+from oscar.core import application
 
 
-class AnalyticsConfig(OscarConfig):
+class AnalyticsConfig(application.OscarConfig):
     label = 'analytics'
     name = 'oscar.apps.analytics'
     verbose_name = _('Analytics')

--- a/src/oscar/apps/basket/apps.py
+++ b/src/oscar/apps/basket/apps.py
@@ -2,11 +2,11 @@ from django.contrib.auth.decorators import login_required
 from django.urls import path
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarConfig
+from oscar.core import application
 from oscar.core.loading import get_class
 
 
-class BasketConfig(OscarConfig):
+class BasketConfig(application.OscarConfig):
     label = 'basket'
     name = 'oscar.apps.basket'
     verbose_name = _('Basket')

--- a/src/oscar/apps/catalogue/apps.py
+++ b/src/oscar/apps/catalogue/apps.py
@@ -2,11 +2,11 @@ from django.apps import apps
 from django.urls import include, path, re_path
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarConfig
+from oscar.core import application
 from oscar.core.loading import get_class
 
 
-class CatalogueOnlyConfig(OscarConfig):
+class CatalogueOnlyConfig(application.OscarConfig):
     label = 'catalogue'
     name = 'oscar.apps.catalogue'
     verbose_name = _('Catalogue')
@@ -38,7 +38,7 @@ class CatalogueOnlyConfig(OscarConfig):
         return self.post_process_urls(urls)
 
 
-class CatalogueReviewsOnlyConfig(OscarConfig):
+class CatalogueReviewsOnlyConfig(application.OscarConfig):
     label = 'catalogue'
     name = 'oscar.apps.catalogue'
     verbose_name = _('Catalogue')
@@ -62,3 +62,4 @@ class CatalogueConfig(CatalogueOnlyConfig, CatalogueReviewsOnlyConfig):
     """
     Composite class combining Products with Reviews
     """
+    default = True

--- a/src/oscar/apps/catalogue/reviews/apps.py
+++ b/src/oscar/apps/catalogue/reviews/apps.py
@@ -2,11 +2,11 @@ from django.contrib.auth.decorators import login_required
 from django.urls import path
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarConfig
+from oscar.core import application
 from oscar.core.loading import get_class
 
 
-class CatalogueReviewsConfig(OscarConfig):
+class CatalogueReviewsConfig(application.OscarConfig):
     label = 'reviews'
     name = 'oscar.apps.catalogue.reviews'
     verbose_name = _('Catalogue reviews')

--- a/src/oscar/apps/checkout/apps.py
+++ b/src/oscar/apps/checkout/apps.py
@@ -3,11 +3,11 @@ from django.contrib.auth.decorators import login_required
 from django.urls import path
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarConfig
+from oscar.core import application
 from oscar.core.loading import get_class
 
 
-class CheckoutConfig(OscarConfig):
+class CheckoutConfig(application.OscarConfig):
     label = 'checkout'
     name = 'oscar.apps.checkout'
     verbose_name = _('Checkout')

--- a/src/oscar/apps/communication/apps.py
+++ b/src/oscar/apps/communication/apps.py
@@ -1,9 +1,9 @@
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarConfig
+from oscar.core import application
 
 
-class CommunicationConfig(OscarConfig):
+class CommunicationConfig(application.OscarConfig):
     label = 'communication'
     name = 'oscar.apps.communication'
     verbose_name = _('Communication')

--- a/src/oscar/apps/customer/apps.py
+++ b/src/oscar/apps/customer/apps.py
@@ -3,11 +3,11 @@ from django.urls import path, re_path
 from django.utils.translation import gettext_lazy as _
 from django.views import generic
 
-from oscar.core.application import OscarConfig
+from oscar.core import application
 from oscar.core.loading import get_class
 
 
-class CustomerConfig(OscarConfig):
+class CustomerConfig(application.OscarConfig):
     label = 'customer'
     name = 'oscar.apps.customer'
     verbose_name = _('Customer')

--- a/src/oscar/apps/dashboard/apps.py
+++ b/src/oscar/apps/dashboard/apps.py
@@ -2,11 +2,11 @@ from django.apps import apps
 from django.urls import include, path
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarDashboardConfig
+from oscar.core import application
 from oscar.core.loading import get_class
 
 
-class DashboardConfig(OscarDashboardConfig):
+class DashboardConfig(application.OscarDashboardConfig):
     label = 'dashboard'
     name = 'oscar.apps.dashboard'
     verbose_name = _('Dashboard')

--- a/src/oscar/apps/dashboard/catalogue/apps.py
+++ b/src/oscar/apps/dashboard/catalogue/apps.py
@@ -1,11 +1,11 @@
 from django.urls import path
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarDashboardConfig
+from oscar.core import application
 from oscar.core.loading import get_class
 
 
-class CatalogueDashboardConfig(OscarDashboardConfig):
+class CatalogueDashboardConfig(application.OscarDashboardConfig):
     label = 'catalogue_dashboard'
     name = 'oscar.apps.dashboard.catalogue'
     verbose_name = _('Catalogue')

--- a/src/oscar/apps/dashboard/communications/apps.py
+++ b/src/oscar/apps/dashboard/communications/apps.py
@@ -1,11 +1,11 @@
 from django.urls import path
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarDashboardConfig
+from oscar.core import application
 from oscar.core.loading import get_class
 
 
-class CommunicationsDashboardConfig(OscarDashboardConfig):
+class CommunicationsDashboardConfig(application.OscarDashboardConfig):
     label = 'communications_dashboard'
     name = 'oscar.apps.dashboard.communications'
     verbose_name = _('Communications dashboard')

--- a/src/oscar/apps/dashboard/offers/apps.py
+++ b/src/oscar/apps/dashboard/offers/apps.py
@@ -1,11 +1,11 @@
 from django.urls import path
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarDashboardConfig
+from oscar.core import application
 from oscar.core.loading import get_class
 
 
-class OffersDashboardConfig(OscarDashboardConfig):
+class OffersDashboardConfig(application.OscarDashboardConfig):
     label = 'offers_dashboard'
     name = 'oscar.apps.dashboard.offers'
     verbose_name = _('Offers dashboard')

--- a/src/oscar/apps/dashboard/orders/apps.py
+++ b/src/oscar/apps/dashboard/orders/apps.py
@@ -1,11 +1,11 @@
 from django.urls import path
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarDashboardConfig
+from oscar.core import application
 from oscar.core.loading import get_class
 
 
-class OrdersDashboardConfig(OscarDashboardConfig):
+class OrdersDashboardConfig(application.OscarDashboardConfig):
     label = 'orders_dashboard'
     name = 'oscar.apps.dashboard.orders'
     verbose_name = _('Orders dashboard')

--- a/src/oscar/apps/dashboard/pages/apps.py
+++ b/src/oscar/apps/dashboard/pages/apps.py
@@ -1,11 +1,11 @@
 from django.urls import path
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarDashboardConfig
+from oscar.core import application
 from oscar.core.loading import get_class
 
 
-class PagesDashboardConfig(OscarDashboardConfig):
+class PagesDashboardConfig(application.OscarDashboardConfig):
     label = 'pages_dashboard'
     name = 'oscar.apps.dashboard.pages'
     verbose_name = _('Pages dashboard')

--- a/src/oscar/apps/dashboard/partners/apps.py
+++ b/src/oscar/apps/dashboard/partners/apps.py
@@ -1,11 +1,11 @@
 from django.urls import path
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarDashboardConfig
+from oscar.core import application
 from oscar.core.loading import get_class
 
 
-class PartnersDashboardConfig(OscarDashboardConfig):
+class PartnersDashboardConfig(application.OscarDashboardConfig):
     label = 'partners_dashboard'
     name = 'oscar.apps.dashboard.partners'
     verbose_name = _('Partners dashboard')

--- a/src/oscar/apps/dashboard/ranges/apps.py
+++ b/src/oscar/apps/dashboard/ranges/apps.py
@@ -1,11 +1,11 @@
 from django.urls import path
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarDashboardConfig
+from oscar.core import application
 from oscar.core.loading import get_class
 
 
-class RangesDashboardConfig(OscarDashboardConfig):
+class RangesDashboardConfig(application.OscarDashboardConfig):
     label = 'ranges_dashboard'
     name = 'oscar.apps.dashboard.ranges'
     verbose_name = _('Ranges dashboard')

--- a/src/oscar/apps/dashboard/reports/apps.py
+++ b/src/oscar/apps/dashboard/reports/apps.py
@@ -1,11 +1,11 @@
 from django.urls import path
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarDashboardConfig
+from oscar.core import application
 from oscar.core.loading import get_class
 
 
-class ReportsDashboardConfig(OscarDashboardConfig):
+class ReportsDashboardConfig(application.OscarDashboardConfig):
     label = 'reports_dashboard'
     name = 'oscar.apps.dashboard.reports'
     verbose_name = _('Reports dashboard')

--- a/src/oscar/apps/dashboard/reviews/apps.py
+++ b/src/oscar/apps/dashboard/reviews/apps.py
@@ -1,11 +1,11 @@
 from django.urls import path
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarDashboardConfig
+from oscar.core import application
 from oscar.core.loading import get_class
 
 
-class ReviewsDashboardConfig(OscarDashboardConfig):
+class ReviewsDashboardConfig(application.OscarDashboardConfig):
     label = 'reviews_dashboard'
     name = 'oscar.apps.dashboard.reviews'
     verbose_name = _('Reviews dashboard')

--- a/src/oscar/apps/dashboard/shipping/apps.py
+++ b/src/oscar/apps/dashboard/shipping/apps.py
@@ -1,11 +1,11 @@
 from django.urls import path
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarDashboardConfig
+from oscar.core import application
 from oscar.core.loading import get_class
 
 
-class ShippingDashboardConfig(OscarDashboardConfig):
+class ShippingDashboardConfig(application.OscarDashboardConfig):
     label = 'shipping_dashboard'
     name = 'oscar.apps.dashboard.shipping'
     verbose_name = _('Shipping dashboard')

--- a/src/oscar/apps/dashboard/users/apps.py
+++ b/src/oscar/apps/dashboard/users/apps.py
@@ -1,11 +1,11 @@
 from django.urls import path, re_path
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarDashboardConfig
+from oscar.core import application
 from oscar.core.loading import get_class
 
 
-class UsersDashboardConfig(OscarDashboardConfig):
+class UsersDashboardConfig(application.OscarDashboardConfig):
     label = 'users_dashboard'
     name = 'oscar.apps.dashboard.users'
     verbose_name = _('Users dashboard')

--- a/src/oscar/apps/dashboard/vouchers/apps.py
+++ b/src/oscar/apps/dashboard/vouchers/apps.py
@@ -1,11 +1,11 @@
 from django.urls import path
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarDashboardConfig
+from oscar.core import application
 from oscar.core.loading import get_class
 
 
-class VouchersDashboardConfig(OscarDashboardConfig):
+class VouchersDashboardConfig(application.OscarDashboardConfig):
     label = 'vouchers_dashboard'
     name = 'oscar.apps.dashboard.vouchers'
     verbose_name = _('Vouchers dashboard')

--- a/src/oscar/apps/offer/apps.py
+++ b/src/oscar/apps/offer/apps.py
@@ -1,11 +1,11 @@
 from django.urls import path
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarConfig
+from oscar.core import application
 from oscar.core.loading import get_class
 
 
-class OfferConfig(OscarConfig):
+class OfferConfig(application.OscarConfig):
     label = 'offer'
     name = 'oscar.apps.offer'
     verbose_name = _('Offer')

--- a/src/oscar/apps/order/apps.py
+++ b/src/oscar/apps/order/apps.py
@@ -1,9 +1,9 @@
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarConfig
+from oscar.core import application
 
 
-class OrderConfig(OscarConfig):
+class OrderConfig(application.OscarConfig):
     label = 'order'
     name = 'oscar.apps.order'
     verbose_name = _('Order')

--- a/src/oscar/apps/partner/apps.py
+++ b/src/oscar/apps/partner/apps.py
@@ -1,9 +1,9 @@
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarConfig
+from oscar.core import application
 
 
-class PartnerConfig(OscarConfig):
+class PartnerConfig(application.OscarConfig):
     label = 'partner'
     name = 'oscar.apps.partner'
     verbose_name = _('Partner')

--- a/src/oscar/apps/payment/apps.py
+++ b/src/oscar/apps/payment/apps.py
@@ -1,9 +1,9 @@
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarConfig
+from oscar.core import application
 
 
-class PaymentConfig(OscarConfig):
+class PaymentConfig(application.OscarConfig):
     label = 'payment'
     name = 'oscar.apps.payment'
     verbose_name = _('Payment')

--- a/src/oscar/apps/search/apps.py
+++ b/src/oscar/apps/search/apps.py
@@ -1,11 +1,11 @@
 from django.urls import path
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarConfig
+from oscar.core import application
 from oscar.core.loading import get_class
 
 
-class SearchConfig(OscarConfig):
+class SearchConfig(application.OscarConfig):
     label = 'search'
     name = 'oscar.apps.search'
     verbose_name = _('Search')

--- a/src/oscar/apps/shipping/apps.py
+++ b/src/oscar/apps/shipping/apps.py
@@ -1,9 +1,9 @@
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarConfig
+from oscar.core import application
 
 
-class ShippingConfig(OscarConfig):
+class ShippingConfig(application.OscarConfig):
     label = 'shipping'
     name = 'oscar.apps.shipping'
     verbose_name = _('Shipping')

--- a/src/oscar/apps/voucher/apps.py
+++ b/src/oscar/apps/voucher/apps.py
@@ -1,9 +1,9 @@
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarConfig
+from oscar.core import application
 
 
-class VoucherConfig(OscarConfig):
+class VoucherConfig(application.OscarConfig):
     label = 'voucher'
     name = 'oscar.apps.voucher'
     verbose_name = _('Voucher')

--- a/src/oscar/apps/wishlists/apps.py
+++ b/src/oscar/apps/wishlists/apps.py
@@ -1,9 +1,9 @@
 from django.utils.translation import gettext_lazy as _
 
-from oscar.core.application import OscarConfig
+from oscar.core import application
 
 
-class WishlistsConfig(OscarConfig):
+class WishlistsConfig(application.OscarConfig):
     label = 'wishlists'
     name = 'oscar.apps.wishlists'
     verbose_name = _('Wishlists')

--- a/tests/_site/apps/myapp/apps.py
+++ b/tests/_site/apps/myapp/apps.py
@@ -1,7 +1,7 @@
-from oscar.core.application import OscarConfig
+from oscar.core import application
 
 
-class TestConfig(OscarConfig):
+class TestConfig(application.OscarConfig):
     name = 'tests._site.apps.myapp'
 
     namespace = 'testapp'

--- a/tests/_site/thirdparty_package/apps/myapp/apps.py
+++ b/tests/_site/thirdparty_package/apps/myapp/apps.py
@@ -1,5 +1,5 @@
-from oscar.core.application import OscarConfig
+from oscar.core import application
 
 
-class MyAppConfig(OscarConfig):
+class MyAppConfig(application.OscarConfig):
     name = 'thirdparty_package.apps.myapp'


### PR DESCRIPTION
Importing "oscar.core.application.OscarConfig" directly into an app's
"apps.py" results in Django 3.2. finding multiple "AppConfig"
subclasses, and requiring us to specify the default one.