### PR TITLE
Avoid KeyError in BulkEditMixin if objects matching filters no longer exist

### DIFF
--- a/src/oscar/views/generic.py
+++ b/src/oscar/views/generic.py
@@ -8,7 +8,7 @@ from django.views.generic.base import View
 from oscar.core.utils import safe_referrer
 
 
-class PostActionMixin(object):
+class PostActionMixin:
     """
     Simple mixin to forward POST request that contain a key 'action'
     onto a method of form "do_{action}".
@@ -37,7 +37,7 @@ class PostActionMixin(object):
             return self.get(request, *args, **kwargs)
 
 
-class BulkEditMixin(object):
+class BulkEditMixin:
     """
     Mixin for views that have a bulk editing facility.  This is normally in the
     form of tabular data where each row has a checkbox.  The UI allows a number
@@ -85,7 +85,7 @@ class BulkEditMixin(object):
     def get_objects(self, ids):
         object_dict = self.get_object_dict(ids)
         # Rearrange back into the original order
-        return [object_dict[id] for id in ids]
+        return [object_dict[id] for id in ids if id in object_dict]
 
     def get_object_dict(self, ids):
         return self.get_queryset().in_bulk(ids)


### PR DESCRIPTION
This small changes ensure that we don't cause an unhandled `KeyError` in views subclassing `BulkEditMixin` when they try to access objects that no longer match the filters applied in `get_queryset()` . An example of when this happens is when bulk editing orders in the dashboard, when they are filtered on status. If one of those orders had it's status changed independently since the view was loaded, a `KeyError` is raised when you try to submit a bulk status changed.