### PR TITLE
Fix OrderFactory.date_placed attribute

### DIFF
--- a/docs/source/releases/v3.2.rst
+++ b/docs/source/releases/v3.2.rst
@@ -39,6 +39,7 @@ Minor changes
 
 - Added a new helper ``core.utils.is_ajax`` which replicates the logic of Django's ``HttpRequest.is_ajax``
   method that was deprecated in Django 3.1.
+- Persisted ``OrderFactory.date_placed`` to the database when set, instead of just setting it on the object without saving it.
 
 .. _dependency_changes_in_3.2:
 

--- a/src/oscar/test/factories/order.py
+++ b/src/oscar/test/factories/order.py
@@ -82,16 +82,6 @@ class OrderFactory(factory.django.DjangoModelFactory):
     shipping_address = factory.SubFactory(ShippingAddressFactory)
     billing_address = factory.SubFactory(BillingAddressFactory)
 
-    @classmethod
-    def _create(cls, target_class, *args, **kwargs):
-        date_placed = kwargs.pop('date_placed', None)
-        instance = super(OrderFactory, cls)._create(
-            target_class, *args, **kwargs)
-
-        if date_placed:
-            instance.date_placed = date_placed
-        return instance
-
     @factory.post_generation
     def create_line_models(obj, create, extracted, **kwargs):
         if not create:

--- a/src/oscar/test/factories/payment.py
+++ b/src/oscar/test/factories/payment.py
@@ -32,14 +32,3 @@ class TransactionFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = get_model('payment', 'Transaction')
-
-    @classmethod
-    def _create(cls, target_class, *args, **kwargs):
-        date_created = kwargs.pop('date_created', None)
-        instance = super(TransactionFactory, cls)._create(
-            target_class, *args, **kwargs)
-
-        if date_created:
-            instance.date_created = date_created
-            instance.save()
-        return instance


### PR DESCRIPTION
The attribute wasn’t persisted to database because the `save()` method was not called. This was inconsistent with other fields.

I added a mention in the release notes because I thought this change might break test code that would rely on this bug, to help people identify any issue.

Fixes #3767.