### PR TITLE
Vertical side categories list

### DIFF
--- a/src/oscar/templates/oscar/catalogue/browse.html
+++ b/src/oscar/templates/oscar/catalogue/browse.html
@@ -25,7 +25,7 @@
     {% if tree_categories %}
         <h4>{% trans "Show results for" %}</h4>
         <div class="side_categories card card-body bg-light">
-            <ul class="nav nav-list">
+            <ul class="nav nav-list flex-column">
                 {% for tree_category in tree_categories %}
                     <li class="mt-2">
                         <a href="{{ tree_category.url }}">


### PR DESCRIPTION
This PR fixes a bug where side categories are listed horizontally when there are no nested categories.

Screenshot from Oscar sandbox when subcategories are removed:

![side_categories](https://user-images.githubusercontent.com/490260/133931994-1c8c68a0-ca1d-4312-a0cb-029a03ca7384.jpg)

Screenshot after this fix:
![side_categories_fixed](https://user-images.githubusercontent.com/490260/133932001-44651dc5-1c63-4182-9d57-af909c06681d.jpg)


