### PR TITLE
Allow higher version of django-phonenumber-field

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ install_requires = [
     'purl>=0.7',
     # For phone number field
     'phonenumbers',
-    'django-phonenumber-field>=3.0.0,<4.0.0',
+    'django-phonenumber-field>=3.0.0,<5.1.0',
     # Used for oscar.test.newfactories
     'factory-boy>=2.4.1,<3.0',
     # Used for automatically building larger HTML tables


### PR DESCRIPTION
I'm running into a severe issue breaking checkout with an existing Oscar deployment where django-phonenumber-field's decision to raise `ValueError`s for phone numbers deemed invalid is causing the checkout to fail hard with an `TransactionManagementError`. 

![image](https://user-images.githubusercontent.com/509427/138251186-f7915503-2ca0-4168-be37-1f50fab7c463.png)
![image](https://user-images.githubusercontent.com/509427/138251222-cf80b664-c906-4199-a209-2fe975849d1d.png)

I think the authors of phonenumber field realized themselves that this was not a good change, because they backtracked on their decision with the next release: https://github.com/stefanfoulis/django-phonenumber-field/blob/main/CHANGELOG.rst#400-2019-12-06

Oscar 2.1 forces version 3.0, which I'd like to avoid using. That's why I was happy to see that adding Django 3.2 for 2.1 LTS is being looked at in https://github.com/django-oscar/django-oscar/pull/3792. I suggest we should merge my PR as well, and then prep a release. This achieves both complete Django 3.2 support for Oscar 2.1 (because phonenumber-field only adds it in version 5.1), and it gives users the option to avoid the problematic django-phonenumber-field version 3. 