### PR TITLE
Fix browsable recommended products in product detail

### DIFF
--- a/src/oscar/apps/catalogue/managers.py
+++ b/src/oscar/apps/catalogue/managers.py
@@ -121,6 +121,12 @@ class ProductQuerySet(models.query.QuerySet):
         """
         return self.filter(parent=None)
 
+    def browsable_dashboard_recommended(self):
+        """
+        Products that should be shown when adding recommended products in product detail.
+        """
+        return self.filter(is_public=True)
+
 
 class CategoryQuerySet(MP_NodeQuerySet):
 

--- a/src/oscar/apps/dashboard/catalogue/views.py
+++ b/src/oscar/apps/dashboard/catalogue/views.py
@@ -636,7 +636,7 @@ class ProductLookupView(ObjectLookupView):
     model = Product
 
     def get_queryset(self):
-        return self.model.objects.browsable().all()
+        return self.model.objects.public()
 
     def lookup_filter(self, qs, term):
         return qs.filter(Q(title__icontains=term)


### PR DESCRIPTION
I felt like it might be useful to create separate QuerySet method `browsable_dashboard_recommended` for it.. it might seem little duplicate with `public` but for my scenario it was useful.