### PR TITLE
Correct site in communication events

### DIFF
--- a/src/oscar/apps/checkout/mixins.py
+++ b/src/oscar/apps/checkout/mixins.py
@@ -273,7 +273,8 @@ class OrderPlacementMixin(CheckoutSessionMixin):
         ctx = {
             'user': self.request.user,
             'order': order,
-            'lines': order.lines.all()
+            'lines': order.lines.all(),
+            'request': self.request,
         }
 
         # Attempt to add the order status URL to the email template ctx.

--- a/src/oscar/apps/communication/utils.py
+++ b/src/oscar/apps/communication/utils.py
@@ -156,18 +156,20 @@ class Dispatcher(object):
 
         return content_attachments, file_attachments
 
-    def get_base_context(self):
+    def get_base_context(self, **kwargs):
         """
         Return context that is common to all emails
         """
-        return {'site': Site.objects.get_current()}
+        request = kwargs.get("request")
+        return dict(kwargs, site=Site.objects.get_current(request))
 
     def get_messages(self, event_code, extra_context=None):
         """
         Return rendered messages
         """
-        context = self.get_base_context()
-        if extra_context is not None:
-            context.update(extra_context)
+        if extra_context is None:
+            extra_context = {}
+        context = self.get_base_context(**extra_context)
+
         msgs = CommunicationEventType.objects.get_and_render(event_code, context)
         return msgs

--- a/src/oscar/apps/customer/forms.py
+++ b/src/oscar/apps/customer/forms.py
@@ -49,13 +49,14 @@ class PasswordResetForm(auth_forms.PasswordResetForm):
         if domain_override is not None:
             site.domain = site.name = domain_override
         for user in self.get_users(self.cleaned_data['email']):
-            self.send_password_reset_email(site, user)
+            self.send_password_reset_email(site, user, request)
 
-    def send_password_reset_email(self, site, user):
+    def send_password_reset_email(self, site, user, request=None):
         extra_context = {
             'user': user,
             'site': site,
             'reset_url': get_password_reset_url(user),
+            'request': request,
         }
         CustomerDispatcher().send_password_reset_email_for_user(user, extra_context)
 

--- a/src/oscar/apps/customer/mixins.py
+++ b/src/oscar/apps/customer/mixins.py
@@ -82,5 +82,5 @@ class RegisterUserMixin(object):
         return user
 
     def send_registration_email(self, user):
-        extra_context = {'user': user}
+        extra_context = {'user': user, 'request': self.request}
         CustomerDispatcher().send_registration_email_for_user(user, extra_context)

--- a/src/oscar/apps/customer/views.py
+++ b/src/oscar/apps/customer/views.py
@@ -340,6 +340,7 @@ class ProfileUpdateView(PageTitleMixin, generic.FormView):
             'user': user,
             'reset_url': get_password_reset_url(old_user),
             'new_email': new_email,
+            'request': self.request,
         }
         CustomerDispatcher().send_email_changed_email_for_user(old_user, extra_context)
 
@@ -390,6 +391,7 @@ class ChangePasswordView(PageTitleMixin, generic.FormView):
         extra_context = {
             'user': user,
             'reset_url': get_password_reset_url(self.request.user),
+            'request': self.request,
         }
         CustomerDispatcher().send_password_changed_email_for_user(user, extra_context)
 

--- a/src/oscar/test/utils.py
+++ b/src/oscar/test/utils.py
@@ -99,10 +99,15 @@ class ThumbnailMixin:
 
 
 class EmailsMixin:
+    DJANGO_IMPROPERLY_CONFIGURED_MSG = 'You\'re using the Django "sites framework" '\
+        'without having set the SITE_ID setting. Create a site in your database and set '\
+        'the SITE_ID setting or pass a request to Site.objects.get_current() to fix this error.'
 
     def setUp(self):
         super().setUp()
         self.user = UserFactory()
+        factory = RequestFactory(SERVER_NAME="example.com")
+        self.request = factory.get("/")
 
     def _test_send_plain_text_and_html(self, outboxed_email):
         email = outboxed_email


### PR DESCRIPTION
In #3260, the site was no longer being retrieved with the request passed to get_current site. This results in multisites not being able to send out emails as it doesn't know what site to use. This pull request fixes this.