### PR TITLE
Fix combination offer removal bug

### DIFF
--- a/src/oscar/apps/dashboard/offers/forms.py
+++ b/src/oscar/apps/dashboard/offers/forms.py
@@ -74,6 +74,11 @@ class RestrictionsForm(forms.ModelForm):
         """
         instance = super().save(*args, **kwargs)
         if instance.id:
+
+            for offer in instance.combinations.all():
+                if offer not in self.cleaned_data['combinations']:
+                    offer.combinations.remove(instance)
+
             instance.combinations.clear()
             for offer in self.cleaned_data['combinations']:
                 if offer != instance:


### PR DESCRIPTION
- Closes https://github.com/django-oscar/django-oscar/issues/3811

### What I changed:
Before clearing the instance's combination offers field, I added a loop to find removed offers and removed the current instance from the combination offer field of the removed offer

### Tests:
- Tested manually via dashboard and admin panel
- Passed all tests in [tests/integration/offer/](https://github.com/django-oscar/django-oscar/blob/master/tests/integration/offer)