### PR TITLE
Fix typo in `prepare` method of `ProductIndex` class

### DIFF
--- a/src/oscar/apps/search/search_indexes.py
+++ b/src/oscar/apps/search/search_indexes.py
@@ -93,8 +93,8 @@ class ProductIndex(indexes.SearchIndex, indexes.Indexable):
         if is_solr_supported():
             prepared_data['title_s'] = prepared_data['title']
 
-        # Use title to for spelling suggestions
-        prepared_data['suggestions'] = prepared_data['text']
+        # Use title for spelling suggestions
+        prepared_data['suggestions'] = prepared_data['title']
 
         return prepared_data
 


### PR DESCRIPTION
Ref: https://github.com/django-oscar/django-oscar/commit/c3a058f72d887e9e8cfa4f06eedbca983aa7eeb5

As I can see, `text` should not be used for `suggestions` since `text` keeps a lot more data than we need for `suggestions`:
```
{{ object.upc|default:"" }}
{{ object.title }}
{{ object.description|default:"" }}
```