### PR TITLE
Link to Oscar 2.2 from release notes

### DIFF
--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -23,6 +23,14 @@ Release notes for each version of Oscar published to PyPI.
     v3.0.2
 
 
+2.2 release branch
+
+.. toctree::
+    :maxdepth: 1
+
+    v2.2
+
+
 2.1 release branch
 
 .. toctree::
@@ -30,7 +38,6 @@ Release notes for each version of Oscar published to PyPI.
 
     v2.1
     v2.1.1
-    v2.2
 
 
 2.0 release branch


### PR DESCRIPTION
Currently on https://django-oscar.readthedocs.io/en/latest/releases/index.html, information about the 2.2 release is missing. The entry exists, but it isn't linked properly. This PR fixes that.