### PR TITLE
Add pagination partial to the stock alert list template

### DIFF
--- a/src/oscar/templates/oscar/dashboard/catalogue/stockalert_list.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/stockalert_list.html
@@ -76,5 +76,6 @@
 
     {% endif %}
 </table>
+{% include "oscar/dashboard/partials/pagination.html" %}
 
 {% endblock dashboard_content %}


### PR DESCRIPTION
This allows user to paginate through stockalerts, before this it would only show the first page of alerts.