### PR TITLE
Mark button/link text as translatable in email template

### DIFF
--- a/src/oscar/templates/oscar/communication/emails/commtype_email_changed_body.html
+++ b/src/oscar/templates/oscar/communication/emails/commtype_email_changed_body.html
@@ -17,7 +17,7 @@
 
 <tr>
     <td class="content-block">
-        <a href="{% absolute_url site.domain reset_url %}" class="btn-primary">Reset password</a>
+        <a href="{% absolute_url site.domain reset_url %}" class="btn-primary">{% trans "Reset password" %}</a>
     </td>
 </tr>
 


### PR DESCRIPTION
- i18n template tags are already loaded in this template ✅
- the string is already used in a few other places -> translations are readily available ✅