### PR TITLE
[#3848] Fix table layout on anon order page

### DIFF
--- a/src/oscar/templates/oscar/customer/anon_order.html
+++ b/src/oscar/templates/oscar/customer/anon_order.html
@@ -88,9 +88,11 @@
         {% endfor %}
         {% for discount in order.discounts.all %}
             <tr>
-                <td colspan="5">{{ discount.description }}</td>
+                <td colspan="4">{{ discount.description }}</td>
                 <td>-{{ discount.amount|currency:order.currency }}</td>
-                <td colspan="1"></td>
+                {% iffeature "reviews" %}
+                    <td colspan="1"></td>
+                {% endiffeature %}
             </tr>
         {% endfor %}
     </table>


### PR DESCRIPTION
closes #3848

This is how it's looking now:

Reviews enabled:
<img width="1096" alt="new_with_reviews" src="https://user-images.githubusercontent.com/17853006/149322295-3592cb22-e213-46a3-9e87-555e61d4815b.png">

Reviews disabled:
<img width="1134" alt="new_without_reviews" src="https://user-images.githubusercontent.com/17853006/149322312-fc6be779-605d-400c-94dc-3bcb323c38e5.png">

