### PR TITLE
[#3850] Fix user display name in Orders Placed report

### DIFF
--- a/src/oscar/templates/oscar/dashboard/reports/partials/order_report.html
+++ b/src/oscar/templates/oscar/dashboard/reports/partials/order_report.html
@@ -18,7 +18,7 @@
                     <td><a href="{% url 'dashboard:order-detail' order.number %}">{{ order.number }}</a></td>
                     <td>
                         {% if order.user %}
-                            <a href="{% url 'dashboard:user-detail' order.user.id %}">{{ order.user|default:"-" }}</a>
+                            <a href="{% url 'dashboard:user-detail' order.user.id %}">{{ order.user.get_full_name|default:"-" }}</a>
                         {% else %}
                             -
                         {% endif %}


### PR DESCRIPTION
closes #3850

This now uses the same logic [as the order list page view](https://github.com/django-oscar/django-oscar/blob/master/src/oscar/templates/oscar/dashboard/orders/order_list.html#L117)