### PR TITLE
Add `search_fields` to `AbstractAddress` model

### DIFF
--- a/src/oscar/apps/address/abstract_models.py
+++ b/src/oscar/apps/address/abstract_models.py
@@ -235,10 +235,11 @@ class AbstractAddress(models.Model):
         on_delete=models.CASCADE,
         verbose_name=_("Country"))
 
-    #: A field only used for searching addresses - this contains all the
-    #: relevant fields.  This is effectively a poor man's Solr text field.
+    # A field only used for searching addresses - this contains all the
+    # `search_fields`.  This is effectively a poor man's Solr text field.
     search_text = models.TextField(
         _("Search text - used only for searching addresses"), editable=False)
+    search_fields = ['first_name', 'last_name', 'line1', 'line2', 'line3', 'line4', 'state', 'postcode', 'country']
 
     # Fields, used for `summary` property definition and hash generation.
     base_fields = hash_fields = ['salutation', 'line1', 'line2', 'line3', 'line4', 'state', 'postcode', 'country']
@@ -295,11 +296,7 @@ class AbstractAddress(models.Model):
                     {'postcode': [msg]})
 
     def _update_search_text(self):
-        search_fields = filter(
-            bool, [self.first_name, self.last_name,
-                   self.line1, self.line2, self.line3, self.line4,
-                   self.state, self.postcode, self.country.name])
-        self.search_text = ' '.join(search_fields)
+        self.search_text = self.join_fields(self.search_fields, separator=' ')
 
     # Properties
 

--- a/tests/integration/address/test_models.py
+++ b/tests/integration/address/test_models.py
@@ -210,6 +210,10 @@ class TestUserAddress(TestCase):
             "Terry Barrington, 75 Smith Road, N4 8TY, UNITED KINGDOM",
             a.summary)
 
+    def test_search_text_value(self):
+        a = factories.UserAddressFactory()
+        self.assertEqual("Barry Barrington 1 King Road London SW1 9RE UNITED KINGDOM", a.search_text)
+
 
 VALID_POSTCODES = [
     ('GB', 'N1 9RT'),


### PR DESCRIPTION
Similar to `base_fields` and `hash_fields`, it will be easier to override fields for the search text.

Without this change to add/remove fields from search text we need to override the `_update_search_text` method.