### PR TITLE
Remove links for editing/deleting related objects from RelatedMultipleWidgetWrapper

### DIFF
--- a/src/oscar/static_src/oscar/js/oscar/dashboard.js
+++ b/src/oscar/static_src/oscar/js/oscar/dashboard.js
@@ -166,32 +166,6 @@ var oscar = (function(o, $) {
                 width: 'resolve'
             });
             $selects.filter('.related-widget-wrapper.multiple select').select2({
-                templateResult: function (data) {
-                    return $(data.element).text();
-                },
-                templateSelection: function (data) {
-                    var $this = $(data.element).closest('.related-widget-wrapper');
-                    var siblings = $this.find('.change-related, .delete-related');
-                    if (!siblings.length) {
-                        return;
-                    }
-                    var value = data.id;
-                    var label = $(data.element).text();
-                    if (value) {
-                        siblings.each(function() {
-                            var elm = $(this);
-                            elm.attr('href', elm.attr('data-href-template').replace('__fk__', value));
-                            label += ' ';
-                            label += elm[0].outerHTML;
-                        });
-                    } else {
-                        siblings.removeAttr('href');
-                    }
-                    return label;
-                },
-                escapeMarkup: function(markup) {
-                    return markup;
-                },
                 width: '95%'
             });
             $(el).find('select.select2').each(function(i, e) {

--- a/src/oscar/templates/oscar/dashboard/widgets/related_multiple_widget_wrapper.html
+++ b/src/oscar/templates/oscar/dashboard/widgets/related_multiple_widget_wrapper.html
@@ -3,18 +3,6 @@
     {{ rendered_widget }}
     {% block links %}
         {% spaceless %}
-        <div class="d-none">
-            <a class="related-widget-wrapper-link change-related" id="change_id_{{ name }}"
-                data-href-template="{{ change_related_template_url }}?{{ url_params }}"
-                title="{% blocktrans %}Change selected {{ model }}{% endblocktrans %}">
-                <i class="fas fa-pencil-alt"></i>
-            </a>
-            <a class="related-widget-wrapper-link delete-related" id="delete_id_{{ name }}"
-                data-href-template="{{ delete_related_template_url }}?{{ url_params }}"
-                title="{% blocktrans %}Delete selected {{ model }}{% endblocktrans %}">
-                <i class="fas fa-trash-alt"></i>
-            </a>
-        </div>
         <a class="related-widget-wrapper-link add-related" id="create_id_{{ name }}"
             href="{{ add_related_url }}?{{ url_params }}"
             title="{% blocktrans %}Add another {{ model }}{% endblocktrans %}">


### PR DESCRIPTION
Adding HTML markup into each option requires disabling HTML escaping on
the option, which means the option name is also not escaped. While this
is not a very high risk, these extra links add marginal extra utility
and require a fair bit of Javascript, so it seems to be better just to
remove them.

This widget is only used in one place in the dashboard - on the product class edit form.

Closes #3828.