### PR TITLE
Extended Product Option:

### DIFF
--- a/src/oscar/apps/basket/forms.py
+++ b/src/oscar/apps/basket/forms.py
@@ -14,23 +14,37 @@ Product = get_model('catalogue', 'product')
 
 
 def _option_text_field(option):
-    return forms.CharField(label=option.name, required=option.required)
+    return forms.CharField(label=option.name, required=option.required, help_text=option.help_text, initial=option.default)
 
 
 def _option_integer_field(option):
-    return forms.IntegerField(label=option.name, required=option.required)
+    return forms.IntegerField(label=option.name, required=option.required, help_text=option.help_text, initial=option.default)
 
 
 def _option_boolean_field(option):
-    return forms.BooleanField(label=option.name, required=option.required)
+    return forms.BooleanField(label=option.name, required=option.required, help_text=option.help_text, initial=option.default)
 
 
 def _option_float_field(option):
-    return forms.FloatField(label=option.name, required=option.required)
+    return forms.FloatField(label=option.name, required=option.required, help_text=option.help_text, initial=option.default)
 
 
 def _option_date_field(option):
-    return forms.DateField(label=option.name, required=option.required, widget=forms.widgets.DateInput)
+    return forms.DateField(label=option.name, required=option.required, widget=forms.widgets.DateInput, help_text=option.help_text, initial=option.default)
+
+
+def _option_choice_field(option):
+    """ should return option list:
+      choices=(
+            ('original', _("Original size")),
+        ),
+    """
+    choices = option.choices.split(',')
+    choices = [
+            (field, field)
+            for field in choices
+        ]
+    return forms.ChoiceField(label=option.name, required=option.required, help_text=option.help_text, choices=choices)
 
 
 class BasketLineForm(forms.ModelForm):
@@ -149,6 +163,7 @@ class AddToBasketForm(forms.Form):
         Option.BOOLEAN: _option_boolean_field,
         Option.FLOAT: _option_float_field,
         Option.DATE: _option_date_field,
+        Option.CHOICE: _option_choice_field,
     }
 
     quantity = forms.IntegerField(initial=1, min_value=1, label=_('Quantity'))
@@ -215,6 +230,7 @@ class AddToBasketForm(forms.Form):
         """
         option_field = self.OPTION_FIELD_FACTORIES.get(option.type, _option_text_field)(option)
         self.fields[option.code] = option_field
+        #breakpoint()
 
     # Cleaning
 

--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -1227,6 +1227,7 @@ class AbstractOption(models.Model):
     FLOAT = "float"
     BOOLEAN = "boolean"
     DATE = "date"
+    CHOICE = "choice"
 
     TYPE_CHOICES = (
         (TEXT, _("Text")),
@@ -1234,17 +1235,24 @@ class AbstractOption(models.Model):
         (BOOLEAN, _("True / False")),
         (FLOAT, _("Float")),
         (DATE, _("Date")),
+        (CHOICE, _("Choice"))
     )
 
     name = models.CharField(_("Name"), max_length=128, db_index=True)
     code = AutoSlugField(_("Code"), max_length=128, unique=True, populate_from='name')
     type = models.CharField(_("Type"), max_length=255, default=TEXT, choices=TYPE_CHOICES)
     required = models.BooleanField(_("Is this option required?"), default=False)
+    default = models.CharField(_("Default initial data"), max_length=255, blank=True, null=True)
+    sequence = models.IntegerField(_("Sequence"), default=0, help_text='Compile show options in an ordered sequence' )
+    help_text = models.CharField(_("Help text"), max_length=255, blank=True, null=True)
+    choices = models.CharField( max_length=1024,
+        verbose_name=_('choices'),blank=True,help_text=_('Comma separated list of choices. Only applicable in checkboxes, radio and dropdown.')
+    )
 
     class Meta:
         abstract = True
         app_label = 'catalogue'
-        ordering = ['name']
+        ordering = ['sequence', 'name']
         verbose_name = _("Option")
         verbose_name_plural = _("Options")
 

--- a/src/oscar/apps/dashboard/catalogue/forms.py
+++ b/src/oscar/apps/dashboard/catalogue/forms.py
@@ -426,4 +426,4 @@ class OptionForm(forms.ModelForm):
 
     class Meta:
         model = Option
-        fields = ['name', 'type', 'required']
+        exclude =['pk']


### PR DESCRIPTION
- default: value that is shown as form initial data
- sequence: allow user sort of options
- help_text
- choices: new form field type show a select as result of comma separated input

Affect setup: host/dashboard/catalogue/option/ and product detail view.