### PR TITLE
Prevent unnecessary database query in UseFirstStockRecord strategy when passed an annotated product.

### DIFF
--- a/src/oscar/apps/partner/strategy.py
+++ b/src/oscar/apps/partner/strategy.py
@@ -185,17 +185,19 @@ class Structured(Base):
 # Mixins - these can be used to construct the appropriate strategy class
 
 
-class UseFirstStockRecord(object):
+class UseFirstStockRecord:
     """
     Stockrecord selection mixin for use with the ``Structured`` base strategy.
     This mixin picks the first (normally only) stockrecord to fulfil a product.
-
-    This is backwards compatible with Oscar<0.6 where only one stockrecord per
-    product was permitted.
     """
 
     def select_stockrecord(self, product):
-        return product.stockrecords.first()
+        # We deliberately fetch by index here, to ensure that no additional database queries are made
+        # when stockrecords have already been prefetched in a queryset annotated using ProductQuerySet.base_queryset
+        try:
+            return product.stockrecords.all()[0]
+        except IndexError:
+            pass
 
 
 class StockRequired(object):


### PR DESCRIPTION
Fixes #3875 . 

I checked [all the other changes](https://github.com/django-oscar/django-oscar/commit/3a826796d01e5cba345aa646dbc5c8ae466cbf4a) in the commit that introduced this regression and am not sure that any of the other instances need to be reverted - in all cases I can't see anywhere that we use `prefetch_related` with the associated models, or any likely use case for a project needing to do so - but open to feedback on this.

