### PR TITLE
Fixed ProductImage is saved after deletion

### DIFF
--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -1414,8 +1414,10 @@ class AbstractProductImage(models.Model):
         """
         Always keep the display_order as consecutive integers. This avoids
         issue #855.
+        After deletion refresh product from db to avoid #3890.
         """
         super().delete(*args, **kwargs)
+        self.product.refresh_from_db()
         for idx, image in enumerate(self.product.images.all()):
             image.display_order = idx
             image.save()


### PR DESCRIPTION
Re-evaluate the product from db before reordering the images in
AbstractProductImage.delete().

This avoids accidentaly recreation of the image.
#3890