### PR TITLE
Fix the issue where html5 validation errors were not obvious when editing a product

### DIFF
--- a/src/oscar/static_src/oscar/js/oscar/dashboard.js
+++ b/src/oscar/static_src/oscar/js/oscar/dashboard.js
@@ -264,11 +264,16 @@ var oscar = (function(o, $) {
                 }
             });
 
+            // Add href to url, so when the page is reloaded this tab will be displayed.
+            $('.nav-tabs a').on('shown.bs.tab', function (e) {
+                window.location.hash = e.target.hash;
+            });
+
             // Display tabs that have invalid input fields
             $('input').on('invalid', function(){
                 var id = $(this).closest('.tab-pane').attr('id');
                 if (id) {
-                    $('.nav-list a[href="#' + id + '"]').tab('show');
+                    $('.bs-docs-sidenav a[href="#' + id + '"]').tab('show');
                 }
             });
         },

--- a/src/oscar/templates/oscar/dashboard/layout.html
+++ b/src/oscar/templates/oscar/dashboard/layout.html
@@ -144,7 +144,7 @@
     // Javascript to enable link to tab
     var url = document.location.toString();
     if (url.match('#')) {
-        $('.nav-list a[href="#' + url.split('#')[1] + '"]').tab('show');
+        $('.bs-docs-sidenav a[href="#' + url.split('#')[1] + '"]').tab('show');
     }
 
     // Change hash for page-reload


### PR DESCRIPTION
This fixes #3791.

The error icon next to the tab appears on page reload and this was also the case before the bootstrap 4 port.

