### PR TITLE
Add basket post data to the form when invalid

### DIFF
--- a/src/oscar/templatetags/basket_tags.py
+++ b/src/oscar/templatetags/basket_tags.py
@@ -1,4 +1,5 @@
 from django import template
+from django.contrib.sessions.serializers import JSONSerializer
 
 from oscar.core.loading import get_class, get_model
 
@@ -24,6 +25,11 @@ def basket_form(request, product, quantity_type='single'):
     if quantity_type == QNT_SINGLE:
         form_class = SimpleAddToBasketForm
 
-    form = form_class(request.basket, product=product, initial=initial)
+    basket_post_data = request.session.pop("add_to_basket_form_post_data_%s" % product.pk, None)
+
+    if basket_post_data is not None:
+        basket_post_data = JSONSerializer().loads(basket_post_data.encode("latin-1"))
+
+    form = form_class(request.basket, data=basket_post_data, product=product, initial=initial)
 
     return form

--- a/tests/functional/basket/test_manipulation.py
+++ b/tests/functional/basket/test_manipulation.py
@@ -1,6 +1,11 @@
 from oscar.apps.basket import models
+from oscar.core.loading import get_model
 from oscar.test import factories
 from oscar.test.testcases import WebTestCase
+
+Option = get_model("catalogue", "Option")
+AttributeOptionGroup = get_model("catalogue", "AttributeOptionGroup")
+AttributeOption = get_model("catalogue", "AttributeOption")
 
 
 class TestAddingToBasket(WebTestCase):
@@ -34,3 +39,33 @@ class TestAddingToBasket(WebTestCase):
 
         basket = baskets[0]
         self.assertEqual(3, basket.num_items)
+
+    def test_validation_errors_in_form(self):
+        product = factories.ProductFactory()
+        product_class = product.get_product_class()
+        group = AttributeOptionGroup.objects.create(name="checkbox options")
+        AttributeOption.objects.create(group=group, option="1")
+        AttributeOption.objects.create(group=group, option="2")
+
+        option = Option.objects.create(
+            type=Option.CHECKBOX,
+            required=True,
+            name="Required checkbox",
+            option_group=group
+        )
+        text_option = Option.objects.create(type=Option.TEXT, required=False, name="Open tekst")
+
+        product_class.options.add(option)
+        product_class.options.add(text_option)
+        product_class.save()
+
+        detail_page = self.get(product.get_absolute_url())
+        detail_page.forms["add_to_basket_form"]["open-tekst"] = "test harrie"
+        response = detail_page.forms['add_to_basket_form'].submit().follow()
+
+        self.assertEqual(response.forms["add_to_basket_form"]["open-tekst"].value, "test harrie")
+        baskets = models.Basket.objects.all()
+        self.assertEqual(1, len(baskets))
+
+        basket = baskets[0]
+        self.assertEqual(0, basket.lines.count())


### PR DESCRIPTION
So when you have a required checkbox option and you submit the add to basket form the selected / filled out data is not kept so you have to fill out everything over again.

For normal use this isn't that annoying but when adding lots of options (and making custom option widgets which are more complicated and need backend validation) this will become an issue.