### PR TITLE
Only change order line status when status is available

### DIFF
--- a/src/oscar/apps/order/abstract_models.py
+++ b/src/oscar/apps/order/abstract_models.py
@@ -135,8 +135,9 @@ class AbstractOrder(models.Model):
         self.status = new_status
         if new_status in self.cascade:
             for line in self.lines.all():
-                line.status = self.cascade[self.status]
-                line.save()
+                if new_status in line.available_statuses():
+                    line.status = self.cascade[self.status]
+                    line.save()
         self.save()
 
         # Send signal for handling status changed

--- a/src/oscar/apps/order/abstract_models.py
+++ b/src/oscar/apps/order/abstract_models.py
@@ -134,9 +134,10 @@ class AbstractOrder(models.Model):
                    'status': self.status})
         self.status = new_status
         if new_status in self.cascade:
+            new_line_status = self.cascade[new_status]
             for line in self.lines.all():
-                if new_status in line.available_statuses():
-                    line.status = self.cascade[self.status]
+                if new_line_status in line.available_statuses():
+                    line.status = new_line_status
                     line.save()
         self.save()
 

--- a/tests/integration/order/test_models.py
+++ b/tests/integration/order/test_models.py
@@ -79,7 +79,14 @@ class OrderStatusPipelineTests(TestCase):
         self.order.set_status('SHIPPED')
         self.assertEqual('SHIPPED', self.order.status)
 
-    def test_cascading_status_change(self):
+    def test_cascading_line_status_not_allowed(self):
+        self.order = create_order(status='PENDING')
+        self.order.set_status('SHIPPED')
+        for line in self.order.lines.all():
+            self.assertEqual('a', line.status)
+
+    def test_cascading_status_change_allowed(self):
+        Line.pipeline['a'] = ('SHIPPED',)
         self.order = create_order(status='PENDING')
         self.order.set_status('SHIPPED')
         for line in self.order.lines.all():


### PR DESCRIPTION
It's possible for lines to have a completely different status than the order.
When a line is at an "end status" where it cannot change anymore this will result in the line being changed to something you might not want.