### PR TITLE
Fixes a potential redirect loop in ProductDetailView if URL includes …

### DIFF
--- a/src/oscar/apps/catalogue/views.py
+++ b/src/oscar/apps/catalogue/views.py
@@ -67,7 +67,7 @@ class ProductDetailView(DetailView):
 
         if self.enforce_paths:
             expected_path = product.get_absolute_url()
-            if expected_path != quote(current_path):
+            if quote(expected_path) != quote(current_path):
                 return HttpResponsePermanentRedirect(expected_path)
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
…certain characters

If the URL includes a colon ':' then the ProductDetailView is getting
trapped into a redirect loop.