### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/source/releases/v0.5.rst
+++ b/docs/source/releases/v0.5.rst
@@ -203,7 +203,7 @@ There are new migrations in the following apps to be aware of.
 
 * Offer:
 
-    - ``0007``: Add ``max_global_appliations`` field to ``ConditionalOffer`` model
+    - ``0007``: Add ``max_global_applications`` field to ``ConditionalOffer`` model
     - ``0008``: Add ``num_applications`` field to ``ConditionalOffer`` model
     - ``0009``: Rename ``max_applications`` field to ``max_basket_applications``
     - ``0010``: Add ``max_user_applications`` field to ``ConditionalOffer`` model

--- a/docs/source/releases/v3.2.rst
+++ b/docs/source/releases/v3.2.rst
@@ -41,7 +41,7 @@ Backwards incompatible changes
 - The interface for the OPTION_FIELD_FACTORIES has changed and now receives the
   form, the product and the option. Update your overrides as required.
 
-- The ``value`` field on the ``BasketLineAttribute`` and ``OrderLineAttribute`` models is a JSONField now. If you have overidden the ``description`` property on the ``BasketLine`` and ``OrderLine`` models, you'll need to change this to make sure options/multi options are displayed normally in the basket and order.
+- The ``value`` field on the ``BasketLineAttribute`` and ``OrderLineAttribute`` models is a JSONField now. If you have overridden the ``description`` property on the ``BasketLine`` and ``OrderLine`` models, you'll need to change this to make sure options/multi options are displayed normally in the basket and order.
 
 - The wishlist create and update view now inherits from a new mixin that shares functionality. If you've overrides on those views, you should check to see if everything works as intended.
 

--- a/src/oscar/apps/offer/queryset.py
+++ b/src/oscar/apps/offer/queryset.py
@@ -40,7 +40,7 @@ class RangeQuerySet(models.query.QuerySet):
 
     def _get_category_ids(self, product):
         if product.structure == product.CHILD:
-            # Since a child can not be in a catagory, it must be determined
+            # Since a child can not be in a category, it must be determined
             # which category the parent is in
             ProductCategory = product.productcategory_set.model
             return ProductCategory.objects.filter(product_id=product.parent_id).values("category_id")

--- a/tests/integration/basket/test_models.py
+++ b/tests/integration/basket/test_models.py
@@ -274,7 +274,7 @@ class TestANonEmptyBasket(TestCase):
             self.assertIsNotNone(message)
 
         with self.settings(OSCAR_MAX_BASKET_QUANTITY_THRESHOLD=None):
-            # with the treshold disabled all quantities are possible
+            # with the threshold disabled all quantities are possible
             allowed, message = self.basket.is_quantity_allowed(qty=7)
             self.assertTrue(allowed)
             self.assertIsNone(message)


### PR DESCRIPTION
There are small typos in:
- docs/source/releases/v0.5.rst
- docs/source/releases/v3.2.rst
- src/oscar/apps/offer/queryset.py
- tests/integration/basket/test_models.py

Fixes:
- Should read `threshold` rather than `treshold`.
- Should read `overridden` rather than `overidden`.
- Should read `category` rather than `catagory`.
- Should read `applications` rather than `appliations`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md