### PR TITLE
The rich text editor was broken in 3.2 alpha. This restores it.

### DIFF
--- a/gulpfile.js/subtasks/copy.js
+++ b/gulpfile.js/subtasks/copy.js
@@ -1,4 +1,5 @@
 const gulp = require("gulp");
+var rename = require('gulp-rename');
 
 module.exports = function(done) {
     // Copy all tracked static files into the build directory
@@ -39,7 +40,11 @@ module.exports = function(done) {
         "node_modules/tinymce/**/*.min.css",
         "node_modules/tinymce/**/fonts/*",
         "node_modules/tinymce/**/img/*",
-    ]).pipe(gulp.dest("src/oscar/static/oscar/js/tinymce"));
+    ]).pipe(gulp.dest("src/oscar/static/oscar/js/tinymce/"));
+
+    gulp.src([
+      "node_modules/@tinymce/tinymce-jquery/dist/tinymce-jquery.min.js"
+    ]).pipe(rename("jquery.tinymce.min.js")).pipe(gulp.dest("src/oscar/static/oscar/js/tinymce/"));
 
     gulp.src([
         "node_modules/select2/dist/js/select2.min.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,13 @@
       "license": "MIT",
       "devDependencies": {
         "@fortawesome/fontawesome-free": "^6.1.2",
+        "@tinymce/tinymce-jquery": "^2.0.0",
         "bootstrap": "^4.6.2",
         "eslint": "^8.22.0",
         "extend": ">=3.0.2",
         "gulp": "^4.0.2",
         "gulp-concat": "^2.6.1",
+        "gulp-rename": "^2.0.0",
         "gulp-sass": "^5.1.0",
         "gulp-sourcemaps": "^3.0.0",
         "inputmask": "^5.0.7",
@@ -343,6 +345,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@tinymce/tinymce-jquery": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tinymce/tinymce-jquery/-/tinymce-jquery-2.0.0.tgz",
+      "integrity": "sha512-afxm4UVIsi8roxyFiZu+SX4pARyYRWDw3XsMFu4E2eQwuTNpO+jA7qdbqCx3zzcl68clie4jAPmxSUUiJMabEQ==",
+      "dev": true
     },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
@@ -3304,6 +3312,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/gulp-rename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-2.0.0.tgz",
+      "integrity": "sha512-97Vba4KBzbYmR5VBs9mWmK+HwIf5mj+/zioxfZhOKeXtx5ZjBk57KFlePf5nxq9QsTtFl0ejnHE3zTC9MHXqyQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/gulp-sass": {
@@ -8294,6 +8311,12 @@
         "rimraf": "^3.0.2"
       }
     },
+    "@tinymce/tinymce-jquery": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tinymce/tinymce-jquery/-/tinymce-jquery-2.0.0.tgz",
+      "integrity": "sha512-afxm4UVIsi8roxyFiZu+SX4pARyYRWDw3XsMFu4E2eQwuTNpO+jA7qdbqCx3zzcl68clie4jAPmxSUUiJMabEQ==",
+      "dev": true
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -10753,6 +10776,12 @@
           }
         }
       }
+    },
+    "gulp-rename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-2.0.0.tgz",
+      "integrity": "sha512-97Vba4KBzbYmR5VBs9mWmK+HwIf5mj+/zioxfZhOKeXtx5ZjBk57KFlePf5nxq9QsTtFl0ejnHE3zTC9MHXqyQ==",
+      "dev": true
     },
     "gulp-sass": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "3.2.0-alpha",
   "description": "A domain-driven e-commerce framework for Django",
   "main": "index.js",
-  "dependencies": {},
+  "dependencies": {
+  },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^6.1.2",
     "bootstrap": "^4.6.2",
@@ -13,19 +14,21 @@
     "gulp-concat": "^2.6.1",
     "gulp-sass": "^5.1.0",
     "gulp-sourcemaps": "^3.0.0",
+    "gulp-rename": "^2.0.0",
     "inputmask": "^5.0.7",
     "jquery": "^3.6.0",
     "jquery-mousewheel": "^3.1.13",
     "jquery-sortable": "^0.9.13",
-    "node-sass": "^7.0.1",
     "nan": "^2.16.0",
+    "node-sass": "^7.0.1",
     "popper.js": "^1.16.1",
     "pump": "^3.0.0",
     "sass": "^1.54.0",
     "select2": "4.0.13",
     "select2-bootstrap-theme": "0.1.0-beta.10",
     "tempusdominus-bootstrap-4": "^5.39.2",
-    "tinymce": "^6.1.2"
+    "tinymce": "^6.1.2",
+    "@tinymce/tinymce-jquery": "^2.0.0"
   },
   "scripts": {
     "build": "gulp copy && gulp scss",

--- a/src/oscar/static_src/oscar/scss/dashboard/base.scss
+++ b/src/oscar/static_src/oscar/scss/dashboard/base.scss
@@ -5,7 +5,7 @@ body {
 // TYPES CHANGES
 // -------------
 h1, h2, h3, h4, h5, h6 {
-  margin-bottom: $line-height-base / 2;
+  margin-bottom: calc($line-height-base / 2);
   margin-top: 0;
   font-weight: normal;
 }

--- a/src/oscar/static_src/oscar/scss/page/plugins.scss
+++ b/src/oscar/static_src/oscar/scss/page/plugins.scss
@@ -69,7 +69,7 @@
       height: auto;
       display: block;
       float: left;
-      margin: $base-margin-bottom/4;
+      margin: calc($base-margin-bottom / 4);
       text-indent: 0;
       background-color: $white;
       opacity: .50;

--- a/src/oscar/static_src/oscar/scss/page/product_lists.scss
+++ b/src/oscar/static_src/oscar/scss/page/product_lists.scss
@@ -30,7 +30,7 @@
   .image_container,
   .availability,
   .price_color {
-    margin-bottom: $base-margin-bottom / 2;
+    margin-bottom: calc($base-margin-bottom / 2);
   }
 
   .product_price {


### PR DESCRIPTION
Since jquery.tinymce.min.js was removed from tinymce in this commit:

tinymce/tinymce@cefd238fa588652d254b10e53082e22ad9f516f9

but we do need it, we need to explicitly add it as a dependency.
