### PR TITLE
In the new tinymce styleselect has been renamed to styles.

### DIFF
--- a/src/oscar/static_src/oscar/js/oscar/dashboard.js
+++ b/src/oscar/static_src/oscar/js/oscar/dashboard.js
@@ -101,7 +101,7 @@ var oscar = (function(o, $) {
                         {title: 'Heading', block: 'h2'},
                         {title: 'Subheading', block: 'h3'}
                     ],
-                    toolbar: "styleselect | bold italic blockquote | bullist numlist | link"
+                    toolbar: "styles | bold italic blockquote | bullist numlist | link"
                 }
             };
             o.dashboard.options = $.extend(true, defaults, options);


### PR DESCRIPTION
The style_formats where not showing because of this.