### PR TITLE
Show boolean not required error

### DIFF
--- a/src/oscar/templates/oscar/dashboard/catalogue/product_class_form.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/product_class_form.html
@@ -117,7 +117,7 @@
 
                                                         {% include 'oscar/dashboard/partials/form_field.html' with field=attribute_form.option_group nolabel=True %}
                                                     </td>
-                                                    <td>{% include 'oscar/dashboard/partials/form_field.html' with field=attribute_form.required nolabel=True %}</td>
+                                                    <td>{% include 'oscar/dashboard/partials/form_field.html' with field=attribute_form.required nolabel=True %}{{ attribute_form.non_field_errors }}</td>
                                                     <td>{% include 'oscar/dashboard/partials/form_field.html' with field=attribute_form.DELETE nolabel=True %}</td>
                                                 </tr>
                                             {% endfor %}


### PR DESCRIPTION
It makes no sense to have a boolean attribute that is required, because it makes people have to check that box for every product they edit. Now let's also show people the error that will be thrown when that happens, for clarity.