### PR TITLE
Optimize range products reordering

### DIFF
--- a/src/oscar/apps/dashboard/ranges/views.py
+++ b/src/oscar/apps/dashboard/ranges/views.py
@@ -222,9 +222,11 @@ class RangeReorderView(View):
         """
         Save the order of the products within range.
         """
-        range = get_object_or_404(Range, pk=self.kwargs['pk'])
-        for index, item in enumerate(order):
-            entry = RangeProduct.objects.get(range=range, product__pk=item)
-            if entry.display_order != index:
-                entry.display_order = index
-                entry.save()
+        range_products = RangeProduct.objects.filter(
+            range_id=self.kwargs['pk'], product_id__in=order
+        )
+        for range_product in range_products:
+            range_product.display_order = order.index(
+                str(range_product.product_id)
+            )
+        RangeProduct.objects.bulk_update(range_products, ["display_order"])

--- a/tests/functional/dashboard/test_range.py
+++ b/tests/functional/dashboard/test_range.py
@@ -207,3 +207,25 @@ class RangeProductViewTest(WebTestCase):
         self.assertTrue(self.range.contains_product(self.child1))
         self.assertTrue(self.range.contains_product(self.child2))
         self.assertFalse(self.range.contains_product(self.parent))
+
+
+class RangeReorderViewTest(WebTestCase):
+    is_staff = True
+    csrf_checks = False
+
+    def setUp(self):
+        super().setUp()
+        self.range = Range.objects.create(name='dummy')
+        self.url = reverse('dashboard:range-reorder', args=(self.range.id,))
+        self.product1 = create_product()
+        self.product2 = create_product()
+        self.product3 = create_product()
+        self.range.included_products.set([
+            self.product1, self.product2, self.product3])
+
+    def test_range_product_reordering(self):
+        data = {'product': [3, 1, 2]}
+        self.post(self.url, params=data)
+        product_order = self.range.rangeproduct_set.values_list(
+            'product_id', flat=True).order_by('display_order')
+        self.assertEqual(product_order, [3, 1, 2])

--- a/tests/functional/dashboard/test_range.py
+++ b/tests/functional/dashboard/test_range.py
@@ -1,3 +1,5 @@
+import random
+
 from django.contrib.messages.constants import SUCCESS, WARNING
 from django.test import TestCase
 from django.urls import reverse
@@ -224,8 +226,11 @@ class RangeReorderViewTest(WebTestCase):
             self.product1, self.product2, self.product3])
 
     def test_range_product_reordering(self):
-        data = {'product': [3, 1, 2]}
+        product_order = list(self.range.rangeproduct_set.values_list(
+            'product_id', flat=True))
+        random.shuffle(product_order)
+        data = {'product': product_order}
         self.post(self.url, params=data)
-        product_order = self.range.rangeproduct_set.values_list(
-            'product_id', flat=True).order_by('display_order')
-        self.assertEqual(product_order, [3, 1, 2])
+        new_product_order = list(self.range.rangeproduct_set.values_list(
+            'product_id', flat=True).order_by('display_order'))
+        self.assertEqual(new_product_order, product_order)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -173,3 +173,9 @@ SECRET_KEY = 'notverysecret'
 DEFAULT_HASHING_ALGORITHM = 'sha1'
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 FIXTURE_DIRS = [location('unit/fixtures')]
+
+# Try and import local settings which can be used to override any of the above.
+try:
+    from tests.settings_local import *
+except ImportError:
+    pass

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -173,9 +173,3 @@ SECRET_KEY = 'notverysecret'
 DEFAULT_HASHING_ALGORITHM = 'sha1'
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 FIXTURE_DIRS = [location('unit/fixtures')]
-
-# Try and import local settings which can be used to override any of the above.
-try:
-    from tests.settings_local import *
-except ImportError:
-    pass


### PR DESCRIPTION
If there are 20 products in the range, it takes 40 queries to change the order of a single product. With this PR it just takes 2 queries regardless of the number of products in the range.