### PR TITLE
Update abstract_models.py: speeding up Range.product_queryset()

### DIFF
--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -1007,15 +1007,15 @@ class AbstractRange(models.Model):
                 ~Q(parent__excludes=self)
             )
         else:
-            # check if there are children
-            if self.included_products.values('children').exists():
+            # check if the included products have children
+            if self.included_products.exclude(children=None).exists():
                 return Product.objects.filter(
                     Q(includes=self)
                     | Q(parent__includes=self),
                     ~Q(excludes=self),
                     ~Q(parent__excludes=self)
                 )
-            # no children, use fastest query
+            # included products have no children, use fastest query
             return Product.objects.filter(
                 id__in=self.included_products.values("id")
             ).exclude(

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -1008,7 +1008,7 @@ class AbstractRange(models.Model):
             )
         else:
             # check if there are children
-            if self.included_products.exclude(parent_id=None).exists():
+            if self.included_products.filter(structure='child').exists():
                 return Product.objects.filter(
                     Q(includes=self)
                     | Q(parent__includes=self),

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -1007,7 +1007,7 @@ class AbstractRange(models.Model):
                 ~Q(parent__excludes=self)
             )
         else:
-            return (Product.objects.filter(
+            return Product.objects.filter(
                 Q(includes=self)
                 | Q(parent__includes=self),
                 ~Q(excludes=self),

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -985,7 +985,7 @@ class AbstractRange(models.Model):
         return Product.objects.filter(
             Q(categories__in=expanded_range_categories)
             | Q(includes=self)
-            ~Q(excludes=self))
+            ~Q(excludes=self)
         )
 
     def included_products_queryset(self):
@@ -1004,7 +1004,7 @@ class AbstractRange(models.Model):
         else:
             return Product.objects.filter(
                 | Q(includes=self)
-                ~Q(excludes=self),
+                ~Q(excludes=self)
             )
 
     @cached_property

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -1004,7 +1004,7 @@ class AbstractRange(models.Model):
                 ~Q(parent__excludes=self)
             )
         else:
-            return (Product.objects.filter(
+            return Product.objects.filter(
                 id__in=self.included_products.values("id").exclude(
                 id__in=self.excluded_products.values("id")
             )

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -964,22 +964,15 @@ class AbstractRange(models.Model):
 
         return self.product_queryset
 
-    @cached_property
-    def product_queryset(self):
-        "cached queryset of all the products in the Range"
-        Product = self.included_products.model
-
-        if self.includes_all_products:
-            # Filter out blacklisted products
-            return Product.objects.all().exclude(
-                id__in=self.excluded_products.values("id")
-            )
-
-        if self.included_categories.exists():
-            expanded_range_categories = ExpandDownwardsCategoryQueryset(
-                self.included_categories.values("id")
-            )
-            selected_products = Product.objects.filter(
+    def included_categories_queryset(self):
+        """
+        reduce joins if there are no classes in the range
+        """
+        expanded_range_categories = ExpandDownwardsCategoryQueryset(
+            self.included_categories.values("id")
+        )
+        if self.classes.exists():
+            return Product.objects.filter(
                 Q(categories__in=expanded_range_categories)
                 | Q(product_class__classes=self)
                 | Q(includes=self)
@@ -989,8 +982,18 @@ class AbstractRange(models.Model):
                 ~Q(excludes=self),
                 ~Q(parent__excludes=self)
             )
-        else:
-            selected_products = Product.objects.filter(
+        return Product.objects.filter(
+            Q(categories__in=expanded_range_categories)
+            | Q(includes=self)
+            ~Q(excludes=self))
+        )
+
+    def included_products_queryset(self):
+        """
+        reduce joins if there are no classes in the range
+        """
+        if self.classes.exists():
+            return Product.objects.filter(
                 Q(product_class__classes=self)
                 | Q(includes=self)
                 | Q(parent__product_class__classes=self)
@@ -998,7 +1001,26 @@ class AbstractRange(models.Model):
                 ~Q(excludes=self),
                 ~Q(parent__excludes=self)
             )
+        else:
+            return Product.objects.filter(
+                | Q(includes=self)
+                ~Q(excludes=self),
+            )
 
+    @cached_property
+    def product_queryset(self):
+        "cached queryset of all the products in the Range"
+        Product = self.included_products.model
+        if self.includes_all_products:
+            # Filter out blacklisted products
+            return Product.objects.all().exclude(
+                id__in=self.excluded_products.values("id")
+            )
+        # reducing joins without having classes
+        if self.included_categories.exists():
+            selected_products = self.included_categories_queryset()
+        else:
+            selected_products = self.included_products_queryset()
         return selected_products.distinct()
 
     @property

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -1008,8 +1008,7 @@ class AbstractRange(models.Model):
             )
         else:
             # check if there are children
-            if self.included_products.filter(structure='child').exists() and \
-                    self.included_products.exclude(parent_id=None).exists():
+            if self.included_products.values('children').exists():
                 return Product.objects.filter(
                     Q(includes=self)
                     | Q(parent__includes=self),

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -985,8 +985,11 @@ class AbstractRange(models.Model):
             )
         return Product.objects.filter(
             Q(categories__in=expanded_range_categories)
-            | Q(includes=self),
-            ~Q(excludes=self)
+            | Q(includes=self)
+            | Q(parent__categories__in=expanded_range_categories)
+            | Q(parent__includes=self),
+            ~Q(excludes=self),
+            ~Q(parent__excludes=self)
         )
 
     def included_products_queryset(self):
@@ -1004,10 +1007,11 @@ class AbstractRange(models.Model):
                 ~Q(parent__excludes=self)
             )
         else:
-            return Product.objects.filter(
-                id__in=self.included_products.values("id")
-            ).exclude(
-                id__in=self.excluded_products.values("id")
+            return (Product.objects.filter(
+                Q(includes=self)
+                | Q(parent__includes=self),
+                ~Q(excludes=self),
+                ~Q(parent__excludes=self)
             )
 
     @cached_property

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -963,7 +963,7 @@ class AbstractRange(models.Model):
             return self.proxy.all_products()
 
         return self.product_queryset
-
+    
     def included_categories_queryset(self):
         """
         reduce joins if there are no classes in the range
@@ -984,7 +984,7 @@ class AbstractRange(models.Model):
             )
         return Product.objects.filter(
             Q(categories__in=expanded_range_categories)
-            | Q(includes=self)
+            | Q(includes=self),
             ~Q(excludes=self)
         )
 
@@ -1002,9 +1002,9 @@ class AbstractRange(models.Model):
                 ~Q(parent__excludes=self)
             )
         else:
-            return Product.objects.filter(
-                | Q(includes=self)
-                ~Q(excludes=self)
+            included = self.included_products.values_list('id', flat=True)
+            return Product.objects.filter(id__in=included)
+                | Product.objects.filter(parent_id__in=included)
             )
 
     @cached_property

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -1008,7 +1008,8 @@ class AbstractRange(models.Model):
             )
         else:
             # check if there are children
-            if self.included_products.filter(structure='child').exists():
+            if self.included_products.filter(structure='child').exists() and \
+                    self.included_products.exclude(parent_id=None).exists():
                 return Product.objects.filter(
                     Q(includes=self)
                     | Q(parent__includes=self),

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -1038,7 +1038,7 @@ class AbstractRange(models.Model):
         if self.includes_all_products:
             # Filter out blacklisted products
             Product = self.included_products.model
-            return Product.objects.all().exclude(
+            return Product.objects.filter(is_public=True).exclude(
                 id__in=self.excluded_products.values("id")
             )
         # reducing joins without having classes
@@ -1046,7 +1046,7 @@ class AbstractRange(models.Model):
             selected_products = self.included_categories_queryset()
         else:
             selected_products = self.included_products_queryset()
-        return selected_products.distinct()
+        return selected_products.filter(is_public=True).distinct()
 
     @property
     def is_editable(self):

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -1003,7 +1003,7 @@ class AbstractRange(models.Model):
             )
         else:
             included = self.included_products.values_list('id', flat=True)
-            return Product.objects.filter(id__in=included)
+            return (Product.objects.filter(id__in=included)
                 | Product.objects.filter(parent_id__in=included)
             )
 

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -996,7 +996,8 @@ class AbstractRange(models.Model):
         # included products have no children, use fastest query
         return Product.objects.filter(
             Q(categories__in=expanded_range_categories)
-            | Q(includes=self),
+            | Q(includes=self)
+            | Q(parent__categories__in=expanded_range_categories),
             ~Q(excludes=self)
         )
 

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -1005,7 +1005,8 @@ class AbstractRange(models.Model):
             )
         else:
             return Product.objects.filter(
-                id__in=self.included_products.values("id").exclude(
+                id__in=self.included_products.values("id")
+            ).exclude(
                 id__in=self.excluded_products.values("id")
             )
 

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -451,8 +451,7 @@ class AbstractConditionalOffer(models.Model):
             return Product.objects.none()
 
         queryset = self.condition.range.all_products()
-        return queryset.filter(is_discountable=True).exclude(
-            structure=Product.CHILD)
+        return queryset.filter(is_discountable=True).browsable()
 
     @cached_property
     def combined_offers(self):
@@ -1036,9 +1035,9 @@ class AbstractRange(models.Model):
     def product_queryset(self):
         "cached queryset of all the products in the Range"
         if self.includes_all_products:
-            # Filter out blacklisted and non-public products
+            # Filter out blacklisted
             Product = self.included_products.model
-            return Product.objects.filter(is_public=True).exclude(
+            return Product.objects.exclude(
                 id__in=self.excluded_products.values("id")
             )
         # reducing joins without having classes
@@ -1046,8 +1045,7 @@ class AbstractRange(models.Model):
             selected_products = self.included_categories_queryset()
         else:
             selected_products = self.included_products_queryset()
-        # Filter out non-public products
-        return selected_products.filter(is_public=True).distinct()
+        return selected_products.distinct()
 
     @property
     def is_editable(self):

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -967,6 +967,7 @@ class AbstractRange(models.Model):
     def included_categories_queryset(self):
         """
         reduce joins if there are no classes in the range
+        or if included products have no children
         """
         Product = self.included_products.model
         expanded_range_categories = ExpandDownwardsCategoryQueryset(
@@ -983,8 +984,8 @@ class AbstractRange(models.Model):
                 ~Q(excludes=self),
                 ~Q(parent__excludes=self)
             )
-        # check if included products have children
-        if self.included_products.exclude(children=None).exists():
+        # check if products in included categories have children
+        if self.included_categories.exclude(product__children=None).exists():
             return Product.objects.filter(
                 Q(categories__in=expanded_range_categories)
                 | Q(includes=self)
@@ -993,7 +994,7 @@ class AbstractRange(models.Model):
                 ~Q(excludes=self),
                 ~Q(parent__excludes=self)
             )
-        # included products have no children, use fastest query
+        # products in included categories have no children, use fastest query
         return Product.objects.filter(
             Q(categories__in=expanded_range_categories)
             | Q(includes=self)
@@ -1004,6 +1005,7 @@ class AbstractRange(models.Model):
     def included_products_queryset(self):
         """
         reduce joins if there are no classes in the range
+        or included products have no children
         """
         Product = self.included_products.model
         if self.classes.exists():

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -1036,7 +1036,7 @@ class AbstractRange(models.Model):
     def product_queryset(self):
         "cached queryset of all the products in the Range"
         if self.includes_all_products:
-            # Filter out blacklisted products
+            # Filter out blacklisted and non-public products
             Product = self.included_products.model
             return Product.objects.filter(is_public=True).exclude(
                 id__in=self.excluded_products.values("id")
@@ -1046,6 +1046,7 @@ class AbstractRange(models.Model):
             selected_products = self.included_categories_queryset()
         else:
             selected_products = self.included_products_queryset()
+        # Filter out non-public products
         return selected_products.filter(is_public=True).distinct()
 
     @property

--- a/src/oscar/apps/offer/views.py
+++ b/src/oscar/apps/offer/views.py
@@ -68,7 +68,7 @@ class RangeDetailView(ListView):
         Return a queryset of all :py:class:`Product <oscar.apps.catalogue.abstract_models.AbstractProduct>`
         instances related to the :py:class:`Range <oscar.apps.offer.abstract_models.AbstractRange>`.
         """  # noqa
-        products = self.range.all_products()
+        products = self.range.all_products().browsable()
         return products.order_by('rangeproduct__display_order')
 
     def get_context_data(self, **kwargs):

--- a/tests/integration/offer/test_offer.py
+++ b/tests/integration/offer/test_offer.py
@@ -1,0 +1,13 @@
+from django.test import TestCase
+
+from oscar.test.factories import create_product
+from oscar.test.factories.offer import ConditionalOfferFactory
+
+
+class TestOffer(TestCase):
+
+    def test_non_public_product_not_in_offer(self):
+        offer = ConditionalOfferFactory()
+        product = create_product(is_public=False)
+        offer.condition.range.add_product(product)
+        self.assertFalse(product in offer.products())

--- a/tests/integration/offer/test_offer.py
+++ b/tests/integration/offer/test_offer.py
@@ -1,13 +1,21 @@
 from django.test import TestCase
 
+from oscar.apps.offer.views import RangeDetailView
 from oscar.test.factories import create_product
 from oscar.test.factories.offer import ConditionalOfferFactory
 
 
 class TestOffer(TestCase):
 
+    def setUp(self):
+        self.offer = ConditionalOfferFactory()
+        self.non_public_product = create_product(is_public=False)
+        self.offer.condition.range.add_product(self.non_public_product)
+
     def test_non_public_product_not_in_offer(self):
-        offer = ConditionalOfferFactory()
-        product = create_product(is_public=False)
-        offer.condition.range.add_product(product)
-        self.assertFalse(product in offer.products())
+        self.assertFalse(self.non_public_product in self.offer.products())
+
+    def test_non_public_product_not_in_range_detail_view(self):
+        view = RangeDetailView()
+        view.range = self.offer.condition.range
+        self.assertFalse(self.non_public_product in view.get_queryset())


### PR DESCRIPTION
Reduce joins in Range.product_queryset() if there are no classes in the range.
Reduce even more joins, if the included products have no children.
Speedup: 1000 times faster if there are no children!

see https://github.com/django-oscar/django-oscar/issues/4043 for more details, this patch fixes the issue