### PR TITLE
[FIX] Show address update button only if there exists one

### DIFF
--- a/src/oscar/templates/oscar/dashboard/orders/order_detail.html
+++ b/src/oscar/templates/oscar/dashboard/orders/order_detail.html
@@ -522,9 +522,11 @@
                                     {% for field in order.shipping_address.active_address_fields %}
                                         {{ field }}<br/>
                                     {% endfor %}
-                                    <a class="btn btn-secondary" href="{% url 'dashboard:order-shipping-address' order.number %}">
-                                        {% trans "Update" %}
-                                    </a>
+                                    {% if order.shipping_address %}
+                                        <a class="btn btn-secondary" href="{% url 'dashboard:order-shipping-address' order.number %}">
+                                            {% trans "Update" %}
+                                        </a>
+                                    {% endif %}
                                 </td>
                             </tr>
                             <tr>


### PR DESCRIPTION
If a shipping address button is not associated with the order, update button should not be visible. Currently clicking on the button shows 404 page if an address is not assigned to the order.