### PR TITLE
Query optimization in dashboard user detail page

### DIFF
--- a/src/oscar/apps/dashboard/users/views.py
+++ b/src/oscar/apps/dashboard/users/views.py
@@ -124,6 +124,12 @@ class UserDetailView(DetailView):
     model = User
     context_object_name = 'customer'
 
+    def get_queryset(self):
+        queryset = self.model.objects.prefetch_related(
+            'orders__lines', 'orders__surcharges'
+        )
+        return queryset
+
 
 class PasswordResetView(SingleObjectMixin, FormView):
     form_class = PasswordResetForm


### PR DESCRIPTION
Based on the number of orders by user, django oscar made some unnecessary db calls. In this PR, I have prefetched the related order lines and surcharges to reduce query count.