### PR TITLE
[FIX] Exclude suspended offers when is_active filter is applied

### DIFF
--- a/src/oscar/apps/dashboard/offers/views.py
+++ b/src/oscar/apps/dashboard/offers/views.py
@@ -64,7 +64,8 @@ class OfferListView(ListView):
             if is_active:
                 qs = qs.filter(
                     (Q(start_datetime__lte=now) | Q(start_datetime__isnull=True))
-                    & (Q(end_datetime__gte=now) | Q(end_datetime__isnull=True))
+                    & (Q(end_datetime__gte=now) | Q(end_datetime__isnull=True)),
+                    status=ConditionalOffer.OPEN
                 )
                 self.search_filters.append(_("Is active"))
             else:


### PR DESCRIPTION
In the offer listing page, suspended offers also appear when we use the "is_active" filter. With this PR, only offers having 'OPEN' status appear when 'is_active' filter is applied.