### PR TITLE
[FEAT] Optimize order count calculation in user listing page

### DIFF
--- a/sandbox/fixtures/orders.json
+++ b/sandbox/fixtures/orders.json
@@ -91,5 +91,19 @@
     },
     "model": "order.orderdiscount",
     "pk": 1
+},
+{
+    "fields": {
+        "user": 1,
+        "num_product_views": 1,
+        "num_basket_additions": 1,
+        "num_orders": 1,
+        "num_order_lines": 1,
+        "num_order_items": 1,
+        "total_spent": 7.99,
+        "date_last_order": "2014-10-10T13:07:36.499Z"
+    },
+    "model": "analytics.userrecord",
+    "pk": 1
 }
 ]

--- a/src/oscar/apps/dashboard/users/tables.py
+++ b/src/oscar/apps/dashboard/users/tables.py
@@ -18,7 +18,7 @@ class UserTable(DashboardTable):
     staff = Column(accessor='is_staff')
     date_registered = Column(accessor='date_joined')
     num_orders = Column(accessor='userrecord__num_orders', default=0,
-                        orderable=False, verbose_name=_('Number of Orders'))
+                        verbose_name=_('Number of Orders'))
     actions = TemplateColumn(
         template_name='oscar/dashboard/users/user_row_actions.html',
         verbose_name=' ')

--- a/src/oscar/apps/dashboard/users/tables.py
+++ b/src/oscar/apps/dashboard/users/tables.py
@@ -17,7 +17,8 @@ class UserTable(DashboardTable):
     active = Column(accessor='is_active')
     staff = Column(accessor='is_staff')
     date_registered = Column(accessor='date_joined')
-    num_orders = Column(accessor='orders__count', orderable=False, verbose_name=_('Number of Orders'))
+    num_orders = Column(accessor='userrecord__num_orders', default=0,
+                        orderable=False, verbose_name=_('Number of Orders'))
     actions = TemplateColumn(
         template_name='oscar/dashboard/users/user_row_actions.html',
         verbose_name=' ')

--- a/src/oscar/apps/dashboard/users/views.py
+++ b/src/oscar/apps/dashboard/users/views.py
@@ -55,7 +55,7 @@ class IndexView(BulkEditMixin, FormMixin, SingleTableView):
         return kwargs
 
     def get_queryset(self):
-        queryset = self.model.objects.all().order_by('-date_joined')
+        queryset = self.model.objects.select_related('userrecord').order_by('-date_joined')
         return self.apply_search(queryset)
 
     def apply_search(self, queryset):


### PR DESCRIPTION
This PR reduces the amount of db calls in user listing page by using the number of orders from user record table. This also allows making users sortable based on their respective order count.