### PR TITLE
Speed up Range.product_queryset()

### DIFF
--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -984,7 +984,8 @@ class AbstractRange(models.Model):
                 ~Q(parent__excludes=self)
             )
         # check if products in included categories have children
-        if self.included_categories.exclude(product__parent_id=None).exists():
+        if self.included_categories.filter(
+                product__structure=Product.CHILD).exists():
             return Product.objects.filter(
                 Q(categories__in=expanded_range_categories)
                 | Q(includes=self)
@@ -1017,7 +1018,7 @@ class AbstractRange(models.Model):
                 ~Q(parent__excludes=self)
             )
         # check if included products have children
-        if self.included_products.exclude(parent_id=None).exists():
+        if self.included_products.filter(structure=Product.CHILD).exists():
             return Product.objects.filter(
                 Q(includes=self)
                 | Q(parent__includes=self),

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -984,7 +984,7 @@ class AbstractRange(models.Model):
                 ~Q(parent__excludes=self)
             )
         # check if products in included categories have children
-        if self.included_categories.exclude(product__children=None).exists():
+        if self.included_categories.filter(product__structure='child').exists():
             return Product.objects.filter(
                 Q(categories__in=expanded_range_categories)
                 | Q(includes=self)
@@ -1017,7 +1017,7 @@ class AbstractRange(models.Model):
                 ~Q(parent__excludes=self)
             )
         # check if included products have children
-        if self.included_products.exclude(children=None).exists():
+        if self.included_products.filter(structure='child').exists():
             return Product.objects.filter(
                 Q(includes=self)
                 | Q(parent__includes=self),

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -1051,8 +1051,8 @@ class AbstractRange(models.Model):
                 id__in=self.excluded_products.values("id")
             )
         # start with empty filter (if included_products do not exist)
-        _filter = Q(True)
-        _exclude_filter = Q(True)
+        _filter = Q()
+        _exclude_filter = Q()
         # extend filter for included products
         if self.included_products.exists():
             _filter |= Q(includes=self)

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -984,7 +984,7 @@ class AbstractRange(models.Model):
                 ~Q(parent__excludes=self)
             )
         # check if products in included categories have children
-        if self.included_categories.filter(product__structure='child').exists():
+        if self.included_categories.exclude(product__parent_id=None).exists():
             return Product.objects.filter(
                 Q(categories__in=expanded_range_categories)
                 | Q(includes=self)
@@ -1017,7 +1017,7 @@ class AbstractRange(models.Model):
                 ~Q(parent__excludes=self)
             )
         # check if included products have children
-        if self.included_products.filter(structure='child').exists():
+        if self.included_products.exclude(parent_id=None).exists():
             return Product.objects.filter(
                 Q(includes=self)
                 | Q(parent__includes=self),

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -983,8 +983,8 @@ class AbstractRange(models.Model):
                 ~Q(excludes=self),
                 ~Q(parent__excludes=self)
             )
-        # check if products in included categories have children
-        if self.included_categories.exclude(product__parent=None).exists():
+        # check if included_products have children
+        if Product.objects.filter(parent__includes=self).exists():
             return Product.objects.filter(
                 Q(categories__in=expanded_range_categories)
                 | Q(includes=self)
@@ -993,7 +993,7 @@ class AbstractRange(models.Model):
                 ~Q(excludes=self),
                 ~Q(parent__excludes=self)
             )
-        # products in included categories have no children, use fastest query
+        # included_productss have no children, use fastest query
         return Product.objects.filter(
             Q(categories__in=expanded_range_categories)
             | Q(includes=self)
@@ -1016,15 +1016,15 @@ class AbstractRange(models.Model):
                 ~Q(excludes=self),
                 ~Q(parent__excludes=self)
             )
-        # check if included products have children
-        if self.included_products.exclude(parent=None).exists():
+        # check if included_products have children
+        if Product.objects.filter(parent__includes=self).exists():
             return Product.objects.filter(
                 Q(includes=self)
                 | Q(parent__includes=self),
                 ~Q(excludes=self),
                 ~Q(parent__excludes=self)
             )
-        # included products have no children, use fastest query
+        # included_products have no children, use fastest query
         return Product.objects.filter(
             id__in=self.included_products.values("id")
         ).exclude(

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -1030,6 +1030,7 @@ class AbstractRange(models.Model):
         ).exclude(
             id__in=self.excluded_products.values("id")
         )
+
     @cached_property
     def product_queryset(self):
         "cached queryset of all the products in the Range"
@@ -1044,42 +1045,6 @@ class AbstractRange(models.Model):
             selected_products = self.included_categories_queryset()
         else:
             selected_products = self.included_products_queryset()
-        return selected_products.distinct()
-
-    @cached_property
-    def product_queryset(self):
-        "cached queryset of all the products in the Range"
-        Product = self.included_products.model
-
-        if self.includes_all_products:
-            # Filter out blacklisted
-            return Product.objects.exclude(
-                id__in=self.excluded_products.values("id")
-            )
-
-        if self.included_categories.exists():
-            expanded_range_categories = ExpandDownwardsCategoryQueryset(
-                self.included_categories.values("id")
-            )
-            selected_products = Product.objects.filter(
-                Q(categories__in=expanded_range_categories)
-                | Q(product_class__classes=self)
-                | Q(includes=self)
-                | Q(parent__categories__in=expanded_range_categories)
-                | Q(parent__product_class__classes=self)
-                | Q(parent__includes=self),
-                ~Q(excludes=self),
-                ~Q(parent__excludes=self)
-            )
-        else:
-            selected_products = Product.objects.filter(
-                Q(product_class__classes=self)
-                | Q(includes=self)
-                | Q(parent__product_class__classes=self)
-                | Q(parent__includes=self),
-                ~Q(excludes=self),
-                ~Q(parent__excludes=self)
-            )
         return selected_products.distinct()
 
     @property

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -983,13 +983,21 @@ class AbstractRange(models.Model):
                 ~Q(excludes=self),
                 ~Q(parent__excludes=self)
             )
-        # check if included_products have children
-        if Product.objects.filter(parent__includes=self).exists():
+        # check if included_categories have children
+        if Product.objects.filter(
+                parent__categories__in=expanded_range_categories).exists():
+            if self.included_products.exists():
+                return Product.objects.filter(
+                    Q(categories__in=expanded_range_categories)
+                    | Q(includes=self)
+                    | Q(parent__categories__in=expanded_range_categories)
+                    | Q(parent__includes=self),
+                    ~Q(excludes=self),
+                    ~Q(parent__excludes=self)
+                )
             return Product.objects.filter(
                 Q(categories__in=expanded_range_categories)
-                | Q(includes=self)
-                | Q(parent__categories__in=expanded_range_categories)
-                | Q(parent__includes=self),
+                | Q(parent__categories__in=expanded_range_categories),
                 ~Q(excludes=self),
                 ~Q(parent__excludes=self)
             )

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -1050,13 +1050,9 @@ class AbstractRange(models.Model):
             return Product.objects.exclude(
                 id__in=self.excluded_products.values("id")
             )
-        # start with empty filter (if included_products do not exist)
-        _filter = Q()
-        _exclude_filter = Q()
-        # extend filter for included products
-        if self.included_products.exists():
-            _filter |= Q(includes=self)
-            _exclude_filter |= Q(excludes=self)
+        # start with filter clause that always applies
+        _filter = Q(includes=self)
+        _exclude_filter = Q(excludes=self)
         # extend filter for included classes:
         if self.classes.exists():
             _filter |= Q(product_class__classes=self)

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -984,8 +984,7 @@ class AbstractRange(models.Model):
                 ~Q(parent__excludes=self)
             )
         # check if products in included categories have children
-        if self.included_categories.filter(
-                product__structure=Product.CHILD).exists():
+        if self.included_categories.exclude(product__parent=None).exists():
             return Product.objects.filter(
                 Q(categories__in=expanded_range_categories)
                 | Q(includes=self)
@@ -1018,7 +1017,7 @@ class AbstractRange(models.Model):
                 ~Q(parent__excludes=self)
             )
         # check if included products have children
-        if self.included_products.filter(structure=Product.CHILD).exists():
+        if self.included_products.exclude(parent=None).exists():
             return Product.objects.filter(
                 Q(includes=self)
                 | Q(parent__includes=self),


### PR DESCRIPTION
Reduce joins in Range.product_queryset() if there are no classes in the range and / or included products have no children. 

see #4043 for more details, this patch fixes the issue

rebased #4042