### PR TITLE
fix use get_is_discountable instead is_discountable attribute from product

### DIFF
--- a/sandbox/settings_postgres.py
+++ b/sandbox/settings_postgres.py
@@ -5,8 +5,8 @@ DATABASES = {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'oscar_travis',
         'USER': 'travis',
-        'PASSWORD': 'travis',
+        'PASSWORD': '',
         'HOST': '127.0.0.1',
-        'PORT': '5432',
+        'PORT': '',
     }
 }

--- a/sandbox/settings_postgres.py
+++ b/sandbox/settings_postgres.py
@@ -5,8 +5,8 @@ DATABASES = {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'oscar_travis',
         'USER': 'travis',
-        'PASSWORD': '',
+        'PASSWORD': 'travis',
         'HOST': '127.0.0.1',
-        'PORT': '',
+        'PORT': '5432',
     }
 }

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -655,7 +655,7 @@ class AbstractBenefit(BaseOfferMixin, models.Model):
         """
         Determines whether the benefit can be applied to a given basket line
         """
-        return line.stockrecord and line.product.is_discountable
+        return line.stockrecord and line.product.get_is_discountable()
 
     def get_applicable_lines(self, offer, basket, range=None):
         """

--- a/tests/integration/offer/test_absolute_benefit.py
+++ b/tests/integration/offer/test_absolute_benefit.py
@@ -406,6 +406,9 @@ class TestAnAbsoluteDiscountBenefit(TestCase):
         child = factories.create_product(
             title="Variant 1", structure='child', parent=parent_product, is_discountable=False)
 
+        basket.add_product(prod1, quantity=1)
+        basket.add_product(child, quantity=1)
+
         Applicator().apply(basket)
         line = basket.all_lines()
         product_actual = benefit.can_apply_benefit(line[0])

--- a/tests/integration/offer/test_absolute_benefit.py
+++ b/tests/integration/offer/test_absolute_benefit.py
@@ -388,21 +388,19 @@ class TestAnAbsoluteDiscountBenefit(TestCase):
         assert basket.total_incl_tax == 0
 
     def test_apply_benefit_with_product_variant_is_discountable_true(self):
-        benefit = factories.BenefitFactory()
+        rng = factories.RangeFactory(includes_all_products=True)
+        benefit = factories.BenefitFactory(
+            range=rng, type=models.Benefit.PERCENTAGE, value=5, max_affected_items=1
+        )
         factories.ConditionalOfferFactory(
             priority=99999,
             exclusive=True,
-
             condition__type=models.Condition.COUNT,
             condition__value=1,
-
-            benefit__type=models.Benefit.PERCENTAGE,
-            benefit__value=5,
-            benefit__max_affected_items=1
+            benefit=benefit
         )
 
         basket = factories.create_basket(empty=True)
-
         prod1 = factories.create_product(is_discountable=True)
         parent_product = factories.create_product(structure='parent', is_discountable=False)
         child = factories.create_product(
@@ -416,7 +414,7 @@ class TestAnAbsoluteDiscountBenefit(TestCase):
         assert line[0].discount_percentage == 5
 
         variant_actual = benefit.can_apply_benefit(line[1])
-        assert variant_actual
+        assert variant_actual is False
         assert parent_product.is_discountable is False
         assert child.is_discountable is False
         assert line[1].discount_percentage == 0


### PR DESCRIPTION
When there are product discountable true and variant discountable false in cart in the same time, discount is calculated for variant which is incorrect.