### PR TITLE
Reduce db calls by counting offers in voucher listing

### DIFF
--- a/src/oscar/apps/dashboard/vouchers/views.py
+++ b/src/oscar/apps/dashboard/vouchers/views.py
@@ -3,6 +3,7 @@ import csv
 from django.conf import settings
 from django.contrib import messages
 from django.db import transaction
+from django.db.models import Count
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse, reverse_lazy
@@ -33,8 +34,9 @@ class VoucherListView(generic.ListView):
     def get_queryset(self):
         self.search_filters = []
         qs = self.model._default_manager.all()
+        qs = qs.annotate(num_offers=Count('offers'))
         qs = sort_queryset(qs, self.request,
-                           ['num_basket_additions', 'num_orders',
+                           ['num_basket_additions', 'num_orders', 'num_offers',
                             'date_created'],
                            '-date_created')
 

--- a/src/oscar/templates/oscar/dashboard/vouchers/voucher_list.html
+++ b/src/oscar/templates/oscar/dashboard/vouchers/voucher_list.html
@@ -90,7 +90,7 @@
                         <th>{% trans "Name" %}</th>
                         <th>{% trans "Code" %}</th>
                         <th>{% trans "Status" %}</th>
-                        <th>{% trans "Num offers" %}</th>
+                        <th>{% anchor 'num_offers' _("Num Offers") %}</th>
                         <th>{% anchor 'num_basket_additions' _("Num baskets") %}</th>
                         <th>{% anchor 'num_orders' _("Num orders") %}</th>
                         <th>{% anchor 'date_created' _("Date created") %}</th>
@@ -114,7 +114,7 @@
                                     <span class="badge badge-secondary">{% trans "Inactive" %}</span>
                                 {% endif %}
                             </td>
-                            <td>{{ voucher.offers.count }}</td>
+                            <td>{{ voucher.num_offers }}</td>
                             <td>{{ voucher.num_basket_additions }}</td>
                             <td>{{ voucher.num_orders }}</td>
                             <td>{{ voucher.date_created }}</td>


### PR DESCRIPTION
Reduce db calls by counting offers in voucher listing. Does the job in 1 query instead of 20 queries (when OSCAR_DASHBOARD_ITEMS_PER_PAGE is 20)