### PR TITLE
[FEAT] Optimize Offer Listing page

### DIFF
--- a/src/oscar/apps/dashboard/offers/views.py
+++ b/src/oscar/apps/dashboard/offers/views.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.core import serializers
 from django.core.serializers.json import DjangoJSONEncoder
-from django.db.models import Q, Count
+from django.db.models import Count, Q
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse

--- a/src/oscar/apps/dashboard/offers/views.py
+++ b/src/oscar/apps/dashboard/offers/views.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.core import serializers
 from django.core.serializers.json import DjangoJSONEncoder
-from django.db.models import Q
+from django.db.models import Q, Count
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
@@ -38,7 +38,9 @@ class OfferListView(ListView):
 
     def get_queryset(self):
         self.search_filters = []
-        qs = self.model._default_manager.all()
+        qs = self.model._default_manager.annotate(
+            voucher_count=Count('vouchers')
+        ).select_related('benefit', 'condition')
         qs = sort_queryset(qs, self.request, ['name', 'offer_type', 'start_datetime', 'end_datetime',
                                               'num_applications', 'total_discount'])
 

--- a/src/oscar/templates/oscar/dashboard/offers/offer_list.html
+++ b/src/oscar/templates/oscar/dashboard/offers/offer_list.html
@@ -103,7 +103,7 @@
                         <td><a href="{% url 'dashboard:offer-detail' pk=offer.pk %}">{{ offer.name }}</a></td>
                         <td>{{ offer.offer_type }}</td>
                         {% if form.is_bound %}{% if form.is_voucher_offer_type or not form.cleaned_data.offer_type %}
-                        <td>{{ offer.vouchers.count }}</td>
+                        <td>{{ offer.voucher_count }}</td>
                         {% endif %}{% endif %}
                         <td>{{ offer.start_datetime|default:"-" }}</td>
                         <td>{{ offer.end_datetime|default:"-" }}</td>
@@ -145,7 +145,7 @@
                                         <a class="dropdown-item" href="{% url 'dashboard:offer-metadata' pk=offer.pk %}">
                                             {% trans "Edit" %}
                                         </a>
-                                        {% if not offer.vouchers.exists %}
+                                        {% if not offer.voucher_count %}
                                         <a class="dropdown-item" href="{% url 'dashboard:offer-delete' pk=offer.pk %}">
                                             {% trans "Delete" %}
                                         </a>


### PR DESCRIPTION
This PR reduces db calls in offer listing page from 108 to 28, provided we display the default 20 offers per page.