### PR TITLE
Add a .git-blame-ignore-revs file to ignore the black & pylint commit in blame view.

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Black & pylint the entire code base
+c9af48338d37f4536c1bdcc6d3a6395bf6aacedc


### PR DESCRIPTION
Hides the recent black & pylint commit from the blame view:
https://github.com/django-oscar/django-oscar/commit/c9af48338d37f4536c1bdcc6d3a6395bf6aacedc