### PR TITLE
Fix error when there is no "basket" defined

### DIFF
--- a/src/oscar/templates/oscar/basket/partials/basket_quick.html
+++ b/src/oscar/templates/oscar/basket/partials/basket_quick.html
@@ -5,7 +5,7 @@
 {% load i18n %}
 
 <ul class="basket-mini-item list-unstyled">
-    {% if request.basket.num_lines %}
+    {% if request.basket.pk and request.basket.num_lines %}
         {% for line in request.basket.all_lines %}
             <li>
                 <div class="row">


### PR DESCRIPTION
This is a simple change that removes an error if someone starts a django-oscar project and goes to the front page without adding any data.
