### PR TITLE
Speedup Range.product_queryset() even more

### DIFF
--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -1124,11 +1124,9 @@ class AbstractRange(models.Model):
             _filter |= Q(categories__in=expanded_range_categories)
             # extend filter for parent categories, exclude parent = None
             if (
-                Product.objects.exclude(
-                    parent=None
-                ).filter(
-                    parent__categories__in=expanded_range_categories
-                ).exists()
+                Product.objects.exclude(parent=None)
+                .filter(parent__categories__in=expanded_range_categories)
+                .exists()
             ):
                 _filter |= Q(parent__categories__in=expanded_range_categories)
 

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -1119,8 +1119,8 @@ class AbstractRange(models.Model):
                 self.included_categories.values("id")
             )
             _filter |= Q(categories__in=expanded_range_categories)
-            # extend filter for parent categories
-            if Product.objects.filter(
+            # extend filter for parent categories, exclude nulls
+            if Product.objects.exclude(parent__categories=None).filter(
                 parent__categories__in=expanded_range_categories
             ).exists():
                 _filter |= Q(parent__categories__in=expanded_range_categories)

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -1122,11 +1122,13 @@ class AbstractRange(models.Model):
                 self.included_categories.values("id")
             )
             _filter |= Q(categories__in=expanded_range_categories)
-            # extend filter for parent categories, exclude nulls
+            # extend filter for parent categories, exclude parent = None
             if (
-                Product.objects.exclude(parent__categories=None)
-                .filter(parent__categories__in=expanded_range_categories)
-                .exists()
+                Product.objects.exclude(
+                    parent=None
+                ).filter(
+                    parent__categories__in=expanded_range_categories
+                ).exists()
             ):
                 _filter |= Q(parent__categories__in=expanded_range_categories)
 

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -1120,9 +1120,11 @@ class AbstractRange(models.Model):
             )
             _filter |= Q(categories__in=expanded_range_categories)
             # extend filter for parent categories, exclude nulls
-            if Product.objects.exclude(parent__categories=None).filter(
-                parent__categories__in=expanded_range_categories
-            ).exists():
+            if (
+                Product.objects.exclude(parent__categories=None)
+                .filter(parent__categories__in=expanded_range_categories)
+                .exists()
+            ):
                 _filter |= Q(parent__categories__in=expanded_range_categories)
 
         qs = Product.objects.filter(_filter, ~Q(excludes=self))


### PR DESCRIPTION
Do not join over parent__categories if they are None

Remember, we have a huge Database with > 3,000.000 products, see our demo shop: https://shop.acat.cc/

I have a Range with all level - 2 Cateories except 1 for an offer reserved for special users, giving a discount of 10 percent for all included products.

Due all catalogue pages calculate the basket total, we had again a total execution time of ~ 12 seconds.

The check for `parent__categories__in=expanded_range_categories` took 7 seconds and returned 'False', including all parent__categories with value = null in the check. By excluding `parent__categories=None` we have now an acceptable execution time again.

Speedup: from 12 Seconds down to 513 ms