### PR TITLE
Correct typo in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ The currently supported versions of Oscar are:
 +---------+----------------+
 | Version | End of support |
 +=========+================+
-| 3.2 LTS | Januari 2026   |
+| 3.2 LTS | January 2026   |
 +---------+----------------+
 | 3.1     | April 2022     |
 +---------+----------------+


### PR DESCRIPTION
Correct **January** spelling in README.rst, [Supported versions](https://github.com/django-oscar/django-oscar#id1) section