### PR TITLE
Return True in is_tax_known() when the basket is empty

### DIFF
--- a/src/oscar/apps/basket/abstract_models.py
+++ b/src/oscar/apps/basket/abstract_models.py
@@ -465,10 +465,13 @@ class AbstractBasket(models.Model):
     @property
     def is_tax_known(self):
         """
-        Test if tax values are known for this basket
+        Test if tax values are known for this basket.
+
+        If the basket is empty, then tax values are unknown.
         """
-        return (not self.is_empty and
-                all([line.is_tax_known for line in self.all_lines()]))
+        return not self.is_empty and all(
+            [line.is_tax_known for line in self.all_lines()]
+        )
 
     @property
     def total_excl_tax(self):

--- a/src/oscar/apps/basket/abstract_models.py
+++ b/src/oscar/apps/basket/abstract_models.py
@@ -467,7 +467,8 @@ class AbstractBasket(models.Model):
         """
         Test if tax values are known for this basket
         """
-        return all([line.is_tax_known for line in self.all_lines()])
+        return (not self.is_empty and
+                all([line.is_tax_known for line in self.all_lines()]))
 
     @property
     def total_excl_tax(self):

--- a/src/oscar/apps/basket/abstract_models.py
+++ b/src/oscar/apps/basket/abstract_models.py
@@ -469,7 +469,7 @@ class AbstractBasket(models.Model):
 
         If the basket is empty, then tax values are unknown.
         """
-        return not self.is_empty and all(
+        return (not self.is_empty) and all(
             [line.is_tax_known for line in self.all_lines()]
         )
 

--- a/tests/integration/basket/test_models.py
+++ b/tests/integration/basket/test_models.py
@@ -147,6 +147,9 @@ class TestAddingAProductToABasket(TestCase):
         with self.assertRaises(ValueError):
             self.basket.add(product)
 
+    def test_is_tax_known(self):
+        self.assertTrue(self.basket.is_tax_known)
+
 
 class TestANonEmptyBasket(TestCase):
     def setUp(self):

--- a/tests/integration/basket/test_models.py
+++ b/tests/integration/basket/test_models.py
@@ -41,6 +41,11 @@ class TestANewBasket(TestCase):
     def test_has_no_applied_offers(self):
         self.assertEqual({}, self.basket.applied_offers())
 
+    def test_is_tax_unknown(self):
+        self.assertTrue(self.basket.is_empty)
+        self.assertFalse(self.basket.is_tax_known)
+
+
 
 class TestBasketLine(TestCase):
     def test_description(self):

--- a/tests/integration/basket/test_models.py
+++ b/tests/integration/basket/test_models.py
@@ -46,7 +46,6 @@ class TestANewBasket(TestCase):
         self.assertFalse(self.basket.is_tax_known)
 
 
-
 class TestBasketLine(TestCase):
     def test_description(self):
         basket = BasketFactory()

--- a/tests/integration/order/test_creator.py
+++ b/tests/integration/order/test_creator.py
@@ -206,6 +206,9 @@ class TestShippingOfferForOrder(TestCase):
     def setUp(self):
         self.creator = OrderCreator()
         self.basket = factories.create_basket(empty=True)
+
+        # add the product now so we can calculate the correct surcharges
+        add_product(self.basket, D("12.00"))
         self.surcharges = SurchargeApplicator().get_applicable_surcharges(self.basket)
 
     def apply_20percent_shipping_offer(self):
@@ -221,7 +224,6 @@ class TestShippingOfferForOrder(TestCase):
         return offer
 
     def test_shipping_offer_is_applied(self):
-        add_product(self.basket, D("12.00"))
         offer = self.apply_20percent_shipping_offer()
 
         shipping = FixedPrice(D("5.00"), D("5.00"))
@@ -241,7 +243,6 @@ class TestShippingOfferForOrder(TestCase):
         self.assertEqual(D("38.00"), order.total_incl_tax)
 
     def test_zero_shipping_discount_is_not_created(self):
-        add_product(self.basket, D("12.00"))
         offer = self.apply_20percent_shipping_offer()
 
         shipping = Free()


### PR DESCRIPTION
Added fix to is_tax_known() in oscar.apps.basket.abstract_models.AbstractBasket and a test to verify it works with an empty basket.

Also, modified the 2 tests in tests.integration.order.TestShippingOfferForOrder which relied on is_tax_known() incorrectly returning True when the basket was empty. 

Replaces PR 4140