### PR TITLE
Fixes #3844 suspend offer doesn't display with is_active 'NO'

### DIFF
--- a/src/oscar/apps/dashboard/offers/views.py
+++ b/src/oscar/apps/dashboard/offers/views.py
@@ -96,9 +96,9 @@ class OfferListView(ListView):
                 self.search_filters.append(_("Is active"))
             else:
                 qs = qs.filter(
-                    (Q(start_datetime__lte=now) | Q(start_datetime__isnull=True))
-                    & (Q(end_datetime__gte=now) | Q(end_datetime__isnull=True)),
-                    status=ConditionalOffer.SUSPENDED,
+                    Q(start_datetime__gt=now)
+                    | Q(end_datetime__lt=now)
+                    | Q(status=ConditionalOffer.SUSPENDED)
                 )
                 self.search_filters.append(_("Is inactive"))
         if offer_type:

--- a/src/oscar/apps/dashboard/offers/views.py
+++ b/src/oscar/apps/dashboard/offers/views.py
@@ -95,7 +95,11 @@ class OfferListView(ListView):
                 )
                 self.search_filters.append(_("Is active"))
             else:
-                qs = qs.filter(Q(end_datetime__lt=now) | Q(start_datetime__gt=now))
+                qs = qs.filter(
+                    (Q(start_datetime__lte=now) | Q(start_datetime__isnull=True))
+                    & (Q(end_datetime__gte=now) | Q(end_datetime__isnull=True)),
+                    status=ConditionalOffer.SUSPENDED,
+                )
                 self.search_filters.append(_("Is inactive"))
         if offer_type:
             qs = qs.filter(offer_type=offer_type)


### PR DESCRIPTION
Now offers with is_active filter 'NO' are visible, resolves #3844 
![image](https://github.com/django-oscar/django-oscar/assets/87356031/056044cd-b770-4ccc-b65c-84d0dee615df)
