### PR TITLE
Fix the collapsed table header

### DIFF
--- a/src/oscar/static_src/oscar/scss/dashboard/tables.scss
+++ b/src/oscar/static_src/oscar/scss/dashboard/tables.scss
@@ -21,6 +21,10 @@
   content: "\f078";
 }
 
+.table-header {
+  display: flow-root;
+}
+
 caption,
 .table-header {
   h2, h3 {


### PR DESCRIPTION
When all content is floated (like in stock alerts), the height of the table header collapses. Changing its display value to `flow-root` prevents this from happening. I haven't checked all the uses of `.table-header` but I can't imagine a scenario where this change would break the layout.

### BEFORE
![Screenshot 2023-11-04 at 10 31 42](https://github.com/django-oscar/django-oscar/assets/6452693/b1495cb1-cfee-4234-96db-17b31c00456d)

### AFTER
![Screenshot 2023-11-04 at 10 31 51](https://github.com/django-oscar/django-oscar/assets/6452693/ac9d0d29-624c-4537-b12d-80478bf8c271)
