### PR TITLE
Round prices to two decimal places in price comparison check in basket

### DIFF
--- a/src/oscar/apps/basket/abstract_models.py
+++ b/src/oscar/apps/basket/abstract_models.py
@@ -1054,7 +1054,7 @@ class AbstractLine(models.Model):
 
         # Compare current price to price when added to basket
         current_price_incl_tax = self.purchase_info.price.incl_tax
-        if current_price_incl_tax != self.price_incl_tax:
+        if round(current_price_incl_tax, 2) != round(self.price_incl_tax, 2):
             product_prices = {
                 "product": self.product.get_title(),
                 "old_price": currency(self.price_incl_tax, self.price_currency),


### PR DESCRIPTION
Fixed price comparison by rounding to two decimal places, preventing misleading cart notifications when prices are effectively the same. Previously, the comparison between these two prices was done directly, which caused issues when the number of decimal places differed.