### PR TITLE
Keep GitHub Actions up to date with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,20 @@
 version: 2
 updates:
-- package-ecosystem: pip
+- package-ecosystem: "github-actions"
+  directory: "/"
+  groups:
+    GitHub_Actions:
+      patterns:
+        - "*"  # Group all Actions updates into a single larger pull request
+  schedule:
+    interval: weekly
+- package-ecosystem: npm
   directory: "/"
   schedule:
     interval: monthly
     time: "11:00"
   open-pull-requests-limit: 10
-- package-ecosystem: npm
+- package-ecosystem: pip
   directory: "/"
   schedule:
     interval: monthly


### PR DESCRIPTION
Resolves warnings on GitHub Actions runs like at the bottom of:
https://github.com/django-oscar/django-oscar/actions/runs/7585638224

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem