### PR TITLE
django.utils.timezone.utc was removed in Django 5.0

### DIFF
--- a/tests/functional/dashboard/test_review.py
+++ b/tests/functional/dashboard/test_review.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import timedelta, timezone as datetime_timezone
 
 from django.urls import reverse
 from django.utils import timezone
@@ -84,7 +84,7 @@ class ReviewsDashboardTests(WebTestCase):
             ProductReviewSearchForm doesn't recognize the timezone notation.
             """
             return timezone.make_naive(
-                now - timedelta(days=days), timezone=timezone.utc
+                now - timedelta(days=days), timezone=datetime_timezone.utc
             )
 
         now = timezone.now()


### PR DESCRIPTION
https://docs.djangoproject.com/en/stable/releases/5.0/#features-removed-in-5-0
> The django.utils.timezone.utc alias to datetime.timezone.utc is removed.

https://docs.djangoproject.com/en/stable/releases/4.1/#id2
> The django.utils.timezone.utc alias to datetime.timezone.utc is deprecated. Use datetime.timezone.utc directly.