### PR TITLE
Dashboard: Add a link to the attribute option group list

### DIFF
--- a/src/oscar/defaults.py
+++ b/src/oscar/defaults.py
@@ -133,6 +133,10 @@ OSCAR_DASHBOARD_NAVIGATION = [
                 "label": _("Options"),
                 "url_name": "dashboard:catalogue-option-list",
             },
+            {
+                "label": _("Attribute Option Groups"),
+                "url_name": "dashboard:catalogue-attribute-option-group-list",
+            },
         ],
     },
     {


### PR DESCRIPTION
Closes #4256.

It looks like this:

![Screenshot 2024-03-08 at 09-00-31 Dashboard Oscar -](https://github.com/django-oscar/django-oscar/assets/239510/8c9cd832-66e6-4e93-8b92-0369da9f68a7)

and links to the existing list of attribute option group.

The text was already known by gettext (and it's already translated in french at least).