### PR TITLE
i18n: Add missing space and lower a letter.

### DIFF
--- a/src/oscar/locale/fr/LC_MESSAGES/django.po
+++ b/src/oscar/locale/fr/LC_MESSAGES/django.po
@@ -38,8 +38,8 @@ msgstr ""
 "Project-Id-Version: django-oscar\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-11-30 10:56+0100\n"
-"PO-Revision-Date: 2013-02-18 17:05+0000\n"
-"Last-Translator: Florian Pichon, 2023\n"
+"PO-Revision-Date: 2024-03-08 09:07+0100\n"
+"Last-Translator: Julien Palard, 2024\n"
 "Language-Team: French (http://app.transifex.com/codeinthehole/django-oscar/language/fr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -2523,9 +2523,9 @@ msgstr "Résumé des options"
 #, python-format
 msgid "%s Attribute Option Group"
 msgid_plural "%s Attribute Option Groups"
-msgstr[0] "%sGroupe d'options d'attributs"
-msgstr[1] "%sGroupes d'options d'attributs"
-msgstr[2] "%sGroupes d'options d'attributs"
+msgstr[0] "%s groupe d'options d'attributs"
+msgstr[1] "%s groupes d'options d'attributs"
+msgstr[2] "%s groupes d'options d'attributs"
 
 #: apps/dashboard/catalogue/tables.py:113
 #, python-format


### PR DESCRIPTION
Before it looked like this:

![Screenshot 2024-03-08 at 09-08-27 Groupes d'options d'attributs Tableau de bord Oscar -](https://github.com/django-oscar/django-oscar/assets/239510/32f00318-1841-4668-a317-ed02c27c5a7b)

In french the "G" would not take a captal letter after the number, it's "5 groupes d'options d'attributs" so I also lowercased the G.