### PR TITLE
Fix get rules from order with option value instead of option code

### DIFF
--- a/src/oscar/apps/order/abstract_models.py
+++ b/src/oscar/apps/order/abstract_models.py
@@ -698,10 +698,10 @@ class AbstractLine(models.Model):
             value = attribute.value
             if isinstance(value, list):
                 ops.append(
-                    "%s = '%s'" % (attribute.type, (", ".join([str(v) for v in value])))
+                    "%s = '%s'" % (attribute.option.name, (", ".join([str(v) for v in value])))
                 )
             else:
-                ops.append("%s = '%s'" % (attribute.type, value))
+                ops.append("%s = '%s'" % (attribute.option.name, value))
         if ops:
             desc = "%s (%s)" % (desc, ", ".join(ops))
         return desc

--- a/src/oscar/apps/order/abstract_models.py
+++ b/src/oscar/apps/order/abstract_models.py
@@ -698,7 +698,8 @@ class AbstractLine(models.Model):
             value = attribute.value
             if isinstance(value, list):
                 ops.append(
-                    "%s = '%s'" % (attribute.option.name, (", ".join([str(v) for v in value])))
+                    "%s = '%s'"
+                    % (attribute.option.name, (", ".join([str(v) for v in value])))
                 )
             else:
                 ops.append("%s = '%s'" % (attribute.option.name, value))

--- a/tests/unit/catalogue/test_product_attributes.py
+++ b/tests/unit/catalogue/test_product_attributes.py
@@ -55,7 +55,7 @@ class ProductAttributeTest(TestCase):
             upc="1234",
         )
         product.attr.weight = 3
-        product.full_clean()
+        # product.full_clean()
         product.save()
 
         # create the child product

--- a/tests/unit/catalogue/test_product_attributes.py
+++ b/tests/unit/catalogue/test_product_attributes.py
@@ -55,7 +55,7 @@ class ProductAttributeTest(TestCase):
             upc="1234",
         )
         product.attr.weight = 3
-        # product.full_clean()
+        product.full_clean()
         product.save()
 
         # create the child product


### PR DESCRIPTION
This fixes showing order lines with the option value instead of the code.

#4263 