### PR TITLE
Fixes exception thrown when pickling/unpickling ProductAttributesContainer

### DIFF
--- a/src/oscar/apps/catalogue/product_attributes.py
+++ b/src/oscar/apps/catalogue/product_attributes.py
@@ -99,6 +99,19 @@ class ProductAttributesContainer:
 
         return cpy
 
+    def __getstate__(self):
+        # Allow everything to go into the pickle except for _cache (which can't
+        # be pickled since it contains a generator)
+        d = {}
+        d.update(self.__dict__)
+        d["_cache"] = None
+        return d
+
+    def __setstate__(self, d):
+        # Update __dict__ instead of setting it to avoid triggering __setattr__,
+        # which causes a recursion error.
+        self.__dict__.update(d)
+
     @property
     def product(self):
         return self._product

--- a/tests/unit/catalogue/test_product_attributes.py
+++ b/tests/unit/catalogue/test_product_attributes.py
@@ -1,3 +1,4 @@
+import pickle
 import unittest
 from copy import deepcopy
 
@@ -331,6 +332,31 @@ class ProductAttributeTest(TestCase):
         with self.assertRaises(AttributeError):
             # pylint: disable=pointless-statement
             product.attr.entity
+
+    def test_can_be_pickled_when_initialized(self):
+        """Should be able to pickle and unpickle an initialized ProductAttributesContainer"""
+        product = Product.objects.get(pk=self.product.pk)
+
+        self.assertEqual(product.attr.weight, 3)
+        self.assertTrue(product.attr.initialized)
+
+        pickled_attrs = pickle.dumps(product.attr)
+        attrs = pickle.loads(pickled_attrs)
+
+        self.assertTrue(attrs.initialized)
+        self.assertEqual(attrs.weight, 3)
+
+    def test_can_be_pickled_when_not_initialized(self):
+        """Should be able to pickle and unpickle an uninitialized ProductAttributesContainer"""
+        product = Product.objects.get(pk=self.product.pk)
+
+        self.assertFalse(product.attr.initialized)
+
+        pickled_attrs = pickle.dumps(product.attr)
+        attrs = pickle.loads(pickled_attrs)
+
+        self.assertFalse(attrs.initialized)
+        self.assertEqual(attrs.weight, 3)
 
 
 class MultiOptionTest(TestCase):


### PR DESCRIPTION
After #4167 and prior to this patch, trying to use pickle with a Product or ProductAttributesContainer results in a recursion error.
