### PR TITLE
Fix a typo which caused a typeerror on string formatting

### DIFF
--- a/src/oscar/apps/customer/forms.py
+++ b/src/oscar/apps/customer/forms.py
@@ -208,7 +208,7 @@ class OrderSearchForm(forms.Form):
                     "%(order_number)s"
                 )
             else:
-                desc = _("Orders placed between %(date_from)s and% (date_to)s")
+                desc = _("Orders placed between %(date_from)s and %(date_to)s")
         elif date_from:
             if order_number:
                 desc = _(

--- a/tests/unit/customer/test_forms.py
+++ b/tests/unit/customer/test_forms.py
@@ -67,3 +67,57 @@ class TestOrderSearchForm(TestCase):
                 "number__contains": "100",
             },
         )
+
+    def test_orders_descriptions(self):
+        form = OrderSearchForm(data={"date_from": "2023-01-01", "date_to": "2023-01-02", "order_number": "100"})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(
+            form.description(),
+            "Orders placed between 2023-01-01 and 2023-01-02 and order number containing 100",
+        )
+
+        form = OrderSearchForm(data={"date_from": "2023-01-01", "date_to": "2023-01-02", "order_number": ""})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(
+            form.description(),
+            "Orders placed between 2023-01-01 and 2023-01-02",
+        )
+
+        form = OrderSearchForm(data={"date_from": "2023-01-01", "date_to": "", "order_number": "100"})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(
+            form.description(),
+            "Orders placed since 2023-01-01 and order number containing 100",
+        )
+
+        form = OrderSearchForm(data={"date_from": "2023-01-01", "date_to": "", "order_number": ""})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(
+            form.description(),
+            "Orders placed since 2023-01-01",
+        )
+
+        form = OrderSearchForm(data={"date_from": "", "date_to": "2023-01-02", "order_number": "100"})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(
+            form.description(),
+            "Orders placed until 2023-01-02 and order number containing 100",
+        )
+
+        form = OrderSearchForm(data={"date_from": "", "date_to": "2023-01-02", "order_number": ""})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(
+            form.description(),
+            "Orders placed since 2023-01-02",
+        )
+
+        form = OrderSearchForm(data={"date_from": "", "date_to": "", "order_number": "100"})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(
+            form.description(),
+            "Orders with order number containing 100",
+        )
+
+        form = OrderSearchForm(data={"date_from": "", "date_to": "", "order_number": ""})
+        self.assertTrue(form.is_valid())
+        self.assertIsNone(form.description())


### PR DESCRIPTION
Fix a typo where the string formatting caused a typeerror when only providing a datefrom and dateto, without an order number. See https://github.com/django-oscar/django-oscar/issues/4219