### PR TITLE
[Fix] Check if attribute has a value

### DIFF
--- a/src/oscar/apps/catalogue/product_attributes.py
+++ b/src/oscar/apps/catalogue/product_attributes.py
@@ -187,7 +187,10 @@ class ProductAttributesContainer:
 
     def validate_attributes(self):
         for attribute in self.get_all_attributes():
-            value = getattr(self, attribute.code, None)
+            if attribute.code in self.__dict__:
+                value = getattr(self, attribute.code, None)
+            else:
+                value = None
             if value is None:
                 if attribute.required:
                     raise ValidationError(


### PR DESCRIPTION
Only validate attributes for which a value is provided. Still throw an error if the attribute is required and value is not given.