### PR TITLE
fix: use old email to build reset_url on email change

### DIFF
--- a/src/oscar/apps/customer/views.py
+++ b/src/oscar/apps/customer/views.py
@@ -347,7 +347,7 @@ class ProfileUpdateView(PageTitleMixin, generic.FormView):
         user = self.request.user
         extra_context = {
             "user": user,
-            "reset_url": get_password_reset_url(old_user),
+            "reset_url": get_password_reset_url(user),
             "new_email": new_email,
             "request": self.request,
         }


### PR DESCRIPTION
When an user change their email, we execute `ProfileUpdateView.send_email_changed_email` to alert the old email address of the change. In this alert, we include a reset email link to be able to revert the change.
Problem: since the reset url is built with the old user object, the reset url validation is failing when it is compared to the new user. Building the reset url using the new user object instead fix the issue