### PR TITLE
fix: call _fetch_item from _process_image for easier override

### DIFF
--- a/src/oscar/apps/catalogue/utils.py
+++ b/src/oscar/apps/catalogue/utils.py
@@ -39,7 +39,7 @@ class Importer(object):
             for filename in filenames:
                 try:
                     lookup_value = self._get_lookup_value_from_filename(filename)
-                    self._process_image(image_dir, filename, lookup_value)
+                    self._process_image(image_dir, filename)
                     stats["num_processed"] += 1
                 except Product.MultipleObjectsReturned:
                     self.logger.warning(
@@ -121,13 +121,12 @@ class Importer(object):
         # unknown archive - perhaps this should be treated differently
         return ""
 
-    def _process_image(self, dirname, filename, lookup_value):
+    def _process_image(self, dirname, filename):
         file_path = os.path.join(dirname, filename)
         trial_image = Image.open(file_path)
         trial_image.verify()
 
-        kwargs = {self._field: lookup_value}
-        item = Product._default_manager.get(**kwargs)
+        item = self._fetch_item(filename)
 
         new_data = open(file_path, "rb").read()
         next_index = 0


### PR DESCRIPTION
In `catalogue.Importer`, we have the `_fetch_item` function as a practical override entry point.
But instead of using it, `_process_image` is reimplementing the same logic directly in the function.
I fixed it so that `_fetch_item` is used and I removed the now unnecessary lookup argument in `_process_image`.

With those changes, in `handle` L.41, the `lookup_value` is retrieved but is only used to construct some error logs. I think we should change the text of the logs so as not to need to retrieve this value just for them, but I wanted to discuss about it first.

(PS: I have been working using Oscar for more than 2 years now, building a marketplace from scratch. I finally have some times to give back to that awesome project by providing some fixes for issues I found along the way so I'll be pretty active in the following days!)