### PR TITLE
Fix basket check id and translation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ test_migrations: install-migrations-testing-requirements ## Tests migrations
 # Translations Handling
 #######################
 extract_translations: ## Extract strings and create source .po files
-	cd src/oscar; django-admin.py makemessages -a
+	cd src/oscar; django-admin makemessages -a
 
 compile_translations: ## Compile translation files and create .mo files
 	cd src/oscar; django-admin compilemessages

--- a/src/oscar/apps/basket/abstract_models.py
+++ b/src/oscar/apps/basket/abstract_models.py
@@ -203,6 +203,8 @@ class AbstractBasket(models.Model):
         The basket can contain multiple lines with the same product and
         stockrecord, but different options. Those quantities are summed up.
         """
+        if self.id is None:
+            return 0
         matching_lines = self.lines.filter(stockrecord=line.stockrecord)
         quantity = matching_lines.aggregate(Sum("quantity"))["quantity__sum"]
         return quantity or 0
@@ -590,7 +592,7 @@ class AbstractBasket(models.Model):
 
     @property
     def contains_a_voucher(self):
-        if not self.id:
+        if self.id is None:
             return False
         return self.vouchers.exists()
 
@@ -636,17 +638,18 @@ class AbstractBasket(models.Model):
         The basket can contain multiple lines with the same product, but
         different options and stockrecords. Those quantities are summed up.
         """
-        if self.id:
-            matching_lines = self.lines.filter(product=product)
-            quantity = matching_lines.aggregate(Sum("quantity"))["quantity__sum"]
-            return quantity or 0
-
-        return 0
+        if self.id is None:
+            return 0
+        matching_lines = self.lines.filter(product=product)
+        quantity = matching_lines.aggregate(Sum("quantity"))["quantity__sum"]
+        return quantity or 0
 
     def line_quantity(self, product, stockrecord, options=None):
         """
         Return the current quantity of a specific product and options
         """
+        if self.id is None:
+            return 0
         ref = self._create_line_reference(product, stockrecord, options)
         try:
             return self.lines.get(line_reference=ref).quantity

--- a/src/oscar/apps/basket/abstract_models.py
+++ b/src/oscar/apps/basket/abstract_models.py
@@ -1044,8 +1044,9 @@ class AbstractLine(models.Model):
         This could be things like the price has changed
         """
         if isinstance(self.purchase_info.availability, Unavailable):
-            msg = "'%(product)s' is no longer available"
-            return _(msg) % {"product": self.product.get_title()}
+            return _("'%(product)s' is no longer available") % {
+                "product": self.product.get_title()
+            }
 
         if not self.price_incl_tax:
             return

--- a/tests/integration/basket/test_models.py
+++ b/tests/integration/basket/test_models.py
@@ -27,6 +27,8 @@ class TestANewBasket(TestCase):
         self.assertEqual(0, self.basket.num_items)
 
     def test_doesnt_contain_vouchers(self):
+        # assert no exception on unsaved basket
+        self.assertFalse(Basket().contains_a_voucher)
         self.assertFalse(self.basket.contains_a_voucher)
 
     def test_can_be_edited(self):
@@ -165,7 +167,13 @@ class TestANonEmptyBasket(TestCase):
         self.assertEqual(self.basket.num_items, 0)
 
     def test_returns_correct_product_quantity(self):
+        # assert no exception on unsaved basket
+        self.assertEqual(0, Basket().product_quantity(self.product))
         self.assertEqual(10, self.basket.product_quantity(self.product))
+
+    def test_returns_correct_line_quantity_for_unsaved_basket(self):
+        # assert no exception on unsaved basket
+        self.assertEqual(0, Basket().line_quantity(self.product, self.record))
 
     def test_returns_correct_line_quantity_for_existing_product_and_stockrecord(self):
         self.assertEqual(10, self.basket.line_quantity(self.product, self.record))
@@ -259,6 +267,10 @@ class TestANonEmptyBasket(TestCase):
 
     def test_is_quantity_allowed(self):
         with self.settings(OSCAR_MAX_BASKET_QUANTITY_THRESHOLD=20):
+            # assert no exception on unsaved basket
+            allowed, message = Basket().is_quantity_allowed(1)
+            self.assertTrue(allowed)
+            self.assertIsNone(message)
             # 7 or below is possible
             allowed, message = self.basket.is_quantity_allowed(qty=7)
             self.assertTrue(allowed)


### PR DESCRIPTION
Fixed a bug about a basket warning message that couldn't be discovered by makemessage as well as fixed the `makemessages` command in the makefile.
Prevent some access to db properties of the basket when the object is not yet saved and added some test for it