### PR TITLE
fix: typos in model field verbose name

### DIFF
--- a/src/oscar/apps/order/abstract_models.py
+++ b/src/oscar/apps/order/abstract_models.py
@@ -443,7 +443,7 @@ class AbstractOrderStatusChange(models.Model):
         "order.Order",
         on_delete=models.CASCADE,
         related_name="status_changes",
-        verbose_name=_("Order Status Changes"),
+        verbose_name=_("Order"),
     )
     old_status = models.CharField(_("Old Status"), max_length=100, blank=True)
     new_status = models.CharField(_("New Status"), max_length=100, blank=True)
@@ -970,7 +970,7 @@ class AbstractLinePrice(models.Model):
         "order.Order",
         on_delete=models.CASCADE,
         related_name="line_prices",
-        verbose_name=_("Option"),
+        verbose_name=_("Order"),
     )
     line = models.ForeignKey(
         "order.Line",
@@ -1377,10 +1377,10 @@ class AbstractSurcharge(models.Model):
         "order.Order",
         on_delete=models.CASCADE,
         related_name="surcharges",
-        verbose_name=_("Surcharges"),
+        verbose_name=_("Order"),
     )
 
-    name = models.CharField(_("Surcharge"), max_length=128)
+    name = models.CharField(_("Name"), max_length=128)
 
     code = models.CharField(_("Surcharge code"), max_length=128)
 

--- a/src/oscar/apps/order/migrations/0001_initial.py
+++ b/src/oscar/apps/order/migrations/0001_initial.py
@@ -377,7 +377,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='lineprice',
             name='order',
-            field=models.ForeignKey(verbose_name='Option', related_name='line_prices', to='order.Order', on_delete=models.CASCADE),
+            field=models.ForeignKey(verbose_name='Order', related_name='line_prices', to='order.Order', on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(

--- a/src/oscar/apps/order/migrations/0006_orderstatuschange.py
+++ b/src/oscar/apps/order/migrations/0006_orderstatuschange.py
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
                 ('old_status', models.CharField(blank=True, max_length=100, verbose_name='Old Status')),
                 ('new_status', models.CharField(blank=True, max_length=100, verbose_name='New Status')),
                 ('date_created', models.DateTimeField(auto_now_add=True, verbose_name='Date Created')),
-                ('order', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='status_changes', to='order.Order', verbose_name='Order Status Changes')),
+                ('order', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='status_changes', to='order.Order', verbose_name='Order')),
             ],
             options={
                 'verbose_name': 'Order Status Change',

--- a/src/oscar/apps/order/migrations/0009_surcharge.py
+++ b/src/oscar/apps/order/migrations/0009_surcharge.py
@@ -23,11 +23,11 @@ class Migration(migrations.Migration):
             name='Surcharge',
             fields=[
                 ('id', models_AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=128, verbose_name='Surcharge')),
+                ('name', models.CharField(max_length=128, verbose_name='Name')),
                 ('code', models.CharField(max_length=128, verbose_name='Surcharge code')),
                 ('incl_tax', models.DecimalField(decimal_places=2, default=0, max_digits=12, verbose_name='Surcharge (inc. tax)')),
                 ('excl_tax', models.DecimalField(decimal_places=2, default=0, max_digits=12, verbose_name='Surcharge (excl. tax)')),
-                ('order', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='surcharges', to='order.Order', verbose_name='Surcharges')),
+                ('order', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='surcharges', to='order.Order', verbose_name='Order')),
             ],
             options={
                 'abstract': False,


### PR DESCRIPTION
There were some typos in the verbose name of some fields of Order models.
I fixed them and made the appropriate change to migration files (verbose name does not actually make any change in DB, hence it is safe to edit instead of creating a new migration).