### PR TITLE
fix: handle broken link for the missing image file

### DIFF
--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -1516,6 +1516,9 @@ class MissingProductImage(object):
             self.symlink_missing_image(media_file_path)
 
     def symlink_missing_image(self, media_file_path):
+        if os.path.islink(media_file_path):
+            # broken link, remove it to create it anew
+            os.unlink(media_file_path)
         static_file_path = find("oscar/img/%s" % self.name)
         if static_file_path is not None:
             try:


### PR DESCRIPTION
We get an exception when the missing image file has previously been symlinked and for whatever reason the link got broken (it happened to me after upgrading the python version of my project).
When `media_file_path` is a link but does not exists as a file, this is because the symlink got broken. In that case we can destroy the symlink before trying to link it again (which fails if we don't unlink it first).