### PR TITLE
fix: prevent insert error when creating deferred transaction

### DIFF
--- a/src/oscar/apps/payment/abstract_models.py
+++ b/src/oscar/apps/payment/abstract_models.py
@@ -136,9 +136,7 @@ class AbstractSource(models.Model):
             for txn in self.deferred_txns:
                 self._create_transaction(*txn)
 
-    def create_deferred_transaction(
-        self, txn_type, amount, reference=None, status=None
-    ):
+    def create_deferred_transaction(self, txn_type, amount, reference="", status=""):
         """
         Register the data for a transaction that can't be created yet due to FK
         constraints.  This happens at checkout where create an payment source


### PR DESCRIPTION
`create_deferred_transaction` is using `None` as default for reference and status. Those are both fields that can be blank but not null in DB.
I replaced the defaults of the function to `''` so that the object can actually be saved to the DB when not specifying them.