### PR TITLE
[FEAT] Auto select existing user when an account already exists

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ uWSGI>=2.0.19
 whitenoise>=6.7.0,<6.8
 
 # Linting
-pylint>=3.1.0
+pylint>=3.2.4
 pylint-django>=2.5.5
 black>=24.4.2
 

--- a/src/oscar/apps/catalogue/managers.py
+++ b/src/oscar/apps/catalogue/managers.py
@@ -100,7 +100,7 @@ class ProductQuerySet(models.query.QuerySet):
         )
         product_options = Option.objects.filter(product=OuterRef("pk"))
         return (
-            self.select_related("product_class")
+            self.select_related("product_class")  # pylint:disable=E1102
             .annotate(
                 has_product_class_options=Exists(product_class_options),
                 has_product_options=Exists(product_options),

--- a/src/oscar/apps/checkout/forms.py
+++ b/src/oscar/apps/checkout/forms.py
@@ -84,6 +84,11 @@ class GatewayForm(AuthenticationForm):
                 if User._default_manager.filter(email__iexact=email).exists():
                     msg = _("A user with that email address already exists")
                     self._errors["username"] = self.error_class([msg])
+                    self.data = self.data.copy()
+                    options_field = "options"
+                    if self.prefix:
+                        options_field = f"{self.prefix}-{options_field}"
+                    self.data[options_field] = self.EXISTING
             return self.cleaned_data
         return super().clean()
 

--- a/src/oscar/apps/checkout/forms.py
+++ b/src/oscar/apps/checkout/forms.py
@@ -84,11 +84,13 @@ class GatewayForm(AuthenticationForm):
                 if User._default_manager.filter(email__iexact=email).exists():
                     msg = _("A user with that email address already exists")
                     self._errors["username"] = self.error_class([msg])
+
+                    # change the value of the 'options' in the submitted data,
+                    # which will be used to render the form
+                    options_field = self.add_prefix("options")
                     self.data = self.data.copy()
-                    options_field = "options"
-                    if self.prefix:
-                        options_field = f"{self.prefix}-{options_field}"
                     self.data[options_field] = self.EXISTING
+
             return self.cleaned_data
         return super().clean()
 

--- a/tests/functional/checkout/test_guest_checkout.py
+++ b/tests/functional/checkout/test_guest_checkout.py
@@ -107,6 +107,29 @@ class TestIndexView(
         page = self.get(reverse("checkout:index"))
         self.assertEqual(email, page.form["username"].value)
 
+    def test_auto_select_existing_user(self):
+        email = "forgetfulguest@test.com"
+        self.create_user(email, email, self.password)
+
+        self.add_product_to_basket()
+
+        # select guest checkout
+        page = self.get(reverse("checkout:index"))
+        form = page.form
+        form["options"].select(GatewayForm.GUEST)
+        form["username"].value = email
+
+        response = form.submit()
+
+        # since this user allready exists
+        self.assertEqual(email, response.form["username"].value)
+        self.assertEqual(
+            GatewayForm.EXISTING,
+            response.form["options"].value,
+            "Since this user has an account, the GatewayForm should "
+            "be changed to existing, so the user can enter his password",
+        )
+
 
 @override_settings(OSCAR_ALLOW_ANON_CHECKOUT=True)
 class TestShippingAddressView(


### PR DESCRIPTION
During checkout, auto select existing user option below the email field when:

- User submits the form as guest user.
- An account already exists with that email.
