### PR TITLE
Supress mention of django-secure from 'Deploying Oscar' docs page

### DIFF
--- a/docs/source/topics/deploying.rst
+++ b/docs/source/topics/deploying.rst
@@ -43,9 +43,6 @@ Oscar relies on the Django framework for security measures and therefore no
 Oscar specific configurations with regard to security are in place. See
 `Django's guidelines for security`_ for more information.
 
-`django-secure`_ is a nice app that comes with a few sanity checks for
-deployments behind SSL.
-
 Search Engine Optimisation
 --------------------------
 


### PR DESCRIPTION
Django-secure has been merged into Django 1.8 and consequently been made redundant. The project is now unsupported and un-maintained as mentioned in its [Pypi page](https://pypi.org/project/django-secure/).