### PR TITLE
Don’t allow adding a product to basket with negative quantity

### DIFF
--- a/src/oscar/apps/basket/abstract_models.py
+++ b/src/oscar/apps/basket/abstract_models.py
@@ -279,7 +279,7 @@ class AbstractBasket(models.Model):
         # Determine price to store (if one exists).  It is only stored for
         # audit and sometimes caching.
         defaults = {
-            "quantity": quantity,
+            "quantity": max(0, quantity),
             "price_excl_tax": stock_info.price.excl_tax,
             "price_currency": stock_info.price.currency,
             "tax_code": stock_info.price.tax_code,


### PR DESCRIPTION
When updating the quantity of an existing line, the quantity is set to a minimum of 0: https://github.com/django-oscar/django-oscar/blob/c6583f6079e1e88f8cd2e5ae74a7e92a08ffe7d4/src/oscar/apps/basket/abstract_models.py#L302

When creating a new line, no such check is done: https://github.com/django-oscar/django-oscar/blob/c6583f6079e1e88f8cd2e5ae74a7e92a08ffe7d4/src/oscar/apps/basket/abstract_models.py#L282

This means that updating a line with quantity < 0 will set the quantity to 0, while creating a line with quantity < 0 will raise an `IntegrityError`.

This PR makes the behaviour consistent when creating a new line and updating an existing line.