### PR TITLE
Fix typo max_basket_applications

### DIFF
--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -452,7 +452,7 @@ class AbstractConditionalOffer(models.Model):
             restrictions.append({"description": desc, "is_satisfied": True})
 
         if self.max_basket_applications:
-            if self.max_user_applications == 1:
+            if self.max_basket_applications == 1:
                 desc = _("Limited to 1 use per basket")
             else:
                 desc = _("Limited to %(total)d uses per basket") % {


### PR DESCRIPTION
Fix a typo - I think it should be max_basket_applications instead of max_user_applications