### PR TITLE
Turn off converting urls in tinymce

### DIFF
--- a/src/oscar/static_src/oscar/js/oscar/dashboard.js
+++ b/src/oscar/static_src/oscar/js/oscar/dashboard.js
@@ -95,6 +95,7 @@ var oscar = (function(o, $) {
                     entity_encoding: 'raw',
                     statusbar: false,
                     menubar: false,
+                    convert_urls: false,
                     plugins: "link lists",
                     style_formats: [
                         {title: 'Text', block: 'p'},


### PR DESCRIPTION
old urls won't break but new urls will not be changed to ../../../ but keep the format they were given by the user.

you can now enter absolute urls (/testing/help/ as well as relative urls (help/) as well als full urls (https://example.com/testing/help/)