### PR TITLE
Add support for Python 3.12 and Django 5.0 + 5.1.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,18 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        django-version: ['3.2', '4.0', '4.1', '4.2', '5.0']
+        django-version: ['3.2', '4.0', '4.1', '4.2', '5.0', '5.1']
+        exclude:
+          # Django 5.0 doesn't support Py3{8,9}
+          - django-version: '5.0'
+            python-version: '3.8'
+          - django-version: '5.0'
+            python-version: '3.9'
+          # Django 5.1 doesn't support Py3{8,9}
+          - django-version: '5.1'
+            python-version: '3.8'
+          - django-version: '5.1'
+            python-version: '3.9'
     services:
       postgres:
         image: postgres:14

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Set up NodeJS
       uses: actions/setup-node@v4
       with:
-        node-version: '16'
+        node-version: '20'
     - name: Install dependencies
       run: |
         npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         django-version: ['3.2', '4.0', '4.1', '4.2']
     services:
       postgres:
@@ -62,7 +62,7 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -91,7 +91,7 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Build sandbox
       run: |
         python -m pip install --upgrade pip
@@ -103,7 +103,7 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Build docs
       run: |
         make docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        django-version: ['3.2', '4.0', '4.1', '4.2']
+        django-version: ['3.2', '4.0', '4.1', '4.2', '5.0']
     services:
       postgres:
         image: postgres:14

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.11"
+    python: "3.12"
 
 # Build from the docs/ directory with Sphinx
 sphinx:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM python:3.12
 ENV PYTHONUNBUFFERED 1
 
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12
 ENV PYTHONUNBUFFERED 1
 
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
 RUN apt-get install -y nodejs npm
 
 COPY ./requirements.txt /requirements.txt

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -95,7 +95,6 @@ MEDIA_URL = '/media/'
 
 STATIC_URL = '/static/'
 STATIC_ROOT = location('public/static')
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 STATICFILES_DIRS = (
     location('static/'),
 )
@@ -103,6 +102,15 @@ STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
 )
+
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": 'whitenoise.storage.CompressedManifestStaticFilesStorage',
+    },
+}
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/dev/ref/settings/#default-auto-field
@@ -414,6 +422,8 @@ THUMBNAIL_KVSTORE = env(
     default='sorl.thumbnail.kvstores.cached_db_kvstore.KVStore')
 THUMBNAIL_REDIS_URL = env('THUMBNAIL_REDIS_URL', default=None)
 
+# easy-thumbnail. See https://github.com/SmileyChris/easy-thumbnails/issues/641#issuecomment-2291098096
+THUMBNAIL_DEFAULT_STORAGE_ALIAS = "default"
 
 # Django 1.6 has switched to JSON serializing for security reasons, but it does not
 # serialize Models. We should resolve this by extending the

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ class BuildNPM(build_module.build):
 
 install_requires = [
     "setuptools>=51.3.3",
-    "django>=3.2,<5.1",
+    "django>=3.2,<5.2",
     # PIL is required for image fields, Pillow is the "friendly" PIL fork
     "pillow>=6.0",
     # We use the ModelFormSetView from django-extra-views for the basket page
@@ -119,6 +119,7 @@ setup(
         "Framework :: Django :: 4.1",
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.0",
+        "Framework :: Django :: 5.1",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: Unix",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ class BuildNPM(build_module.build):
 
 install_requires = [
     "setuptools>=51.3.3",
-    "django>=3.2,<4.3",
+    "django>=3.2,<5.1",
     # PIL is required for image fields, Pillow is the "friendly" PIL fork
     "pillow>=6.0",
     # We use the ModelFormSetView from django-extra-views for the basket page
@@ -44,11 +44,11 @@ install_requires = [
     "purl>=0.7",
     # For phone number field
     "phonenumbers",
-    "django-phonenumber-field>=4.0.0,<7.0.0",
+    "django-phonenumber-field>=4.0.0,<9.0.0",
     # Used for oscar.test.factories
-    "factory-boy>=3.0,<3.3",
+    "factory-boy>=3.3.1,<4.0.0",
     # Used for automatically building larger HTML tables
-    "django-tables2>=2.3,<2.4",
+    "django-tables2>=2.3,<2.8",
     # Used for manipulating form field attributes in templates (eg: add
     # a css class)
     "django-widget-tweaks>=1.4.1",
@@ -118,6 +118,7 @@ setup(
         "Framework :: Django :: 4.0",
         "Framework :: Django :: 4.1",
         "Framework :: Django :: 4.2",
+        "Framework :: Django :: 5.0",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: Unix",

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,7 @@ import re
 import subprocess
 import sys
 
-# pylint: disable=deprecated-module
-from distutils.command import build as build_module
-
+from setuptools.command import build as build_module
 from setuptools import setup, find_packages
 
 PROJECT_DIR = os.path.dirname(__file__)
@@ -129,6 +127,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Software Development :: Libraries :: Application Frameworks",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,8 @@ install_requires = [
     "django-widget-tweaks>=1.4.1",
 ]
 
-sorl_thumbnail_version = "sorl-thumbnail>=12.9,<12.10"
-easy_thumbnails_version = "easy-thumbnails>=2.7,<2.8.6"
+sorl_thumbnail_version = "sorl-thumbnail>=12.10.0,<13.0.0"
+easy_thumbnails_version = "easy-thumbnails>=2.9,<3.0"
 
 docs_requires = [
     "Sphinx>=5.0",
@@ -69,14 +69,15 @@ docs_requires = [
 ]
 
 test_requires = [
-    "WebTest>=2.0,<2.1",
-    "coverage>=5.4,<5.5",
+    "Whoosh>=2.7,<2.8",
+    "WebTest>=3.0.0,<4.0.0",
+    "coverage>=7.6.1,<8.0.0",
     "django-webtest>=1.9,<1.10",
     "psycopg2-binary>=2.8,<2.10",
-    "pytest-django>=3.7,<3.9",
-    "pytest-xdist>=2.2,<3",
-    "tox>=3.21,<4",
-    "freezegun>=1.1,<2",
+    "pytest-django>=4.9.0,<5.0",
+    "pytest-xdist>=3.6.1,<4.0.0",
+    "tox>=4.18.0,<5.0.0",
+    "freezegun>=1.5.1,<2.0.0",
     "pytz",
     "vdt.versionplugin.wheel",
     sorl_thumbnail_version,

--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -602,8 +602,8 @@ class AbstractProduct(models.Model):
         super().save(*args, **kwargs)
         self.attr.save()
 
-    def refresh_from_db(self, using=None, fields=None):
-        super().refresh_from_db(using, fields)
+    def refresh_from_db(self, *args, **kwargs):
+        super().refresh_from_db(*args, **kwargs)
         self.attr.invalidate()
 
     # Properties

--- a/src/oscar/apps/payment/abstract_models.py
+++ b/src/oscar/apps/payment/abstract_models.py
@@ -336,4 +336,5 @@ class AbstractBankcard(models.Model):
 
     # pylint: disable=W0622
     def expiry_month(self, format="%m/%y"):
+        # pylint: disable=E1101
         return self.expiry_date.strftime(format)

--- a/tests/functional/test_basket.py
+++ b/tests/functional/test_basket.py
@@ -58,6 +58,7 @@ class AnonAddToBasketViewTests(WebTestCase):
         self.response = self.app.post(self.url, params=self.post_params)
 
     def test_cookie_is_created(self):
+        # pylint: disable=E1101
         self.assertTrue("oscar_open_basket" in self.response.test_app.cookies)
 
     def test_price_is_recorded(self):

--- a/tests/integration/core/test_customisation.py
+++ b/tests/integration/core/test_customisation.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import tempfile
+from pathlib import Path
 from os.path import exists, join
 
 import pytest
@@ -10,7 +11,9 @@ from django.test import TestCase, override_settings
 from oscar.core import customisation
 from tests import delete_from_import_cache
 
-VALID_FOLDER_PATH = "tests/_site/apps"
+VALID_FOLDER_PATH = str(
+    (Path(__file__).parent.parent.parent.parent / "tests/_site/apps").absolute()
+)
 
 
 class TestUtilities(TestCase):

--- a/tests/integration/management_commands/test_oscar_fork_statics.py
+++ b/tests/integration/management_commands/test_oscar_fork_statics.py
@@ -49,7 +49,7 @@ class OscarForkStaticsTestCase(TestCase):
             "The folder %s already exists - aborting!" % project_static_dir_path,
         )
 
-        shutil.rmtree(project_static_dir_path.rmdir(), ignore_errors=True)
+        shutil.rmtree(project_static_dir_path, ignore_errors=True)
 
     def test_command_with_default_target_path(self):
         project_static_dir_path = pathlib.Path(self.project_base_dir_path, "static")

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -177,5 +177,8 @@ OSCAR_LINE_STATUS_PIPELINE = {"a": ("b",), "b": ()}
 
 SECRET_KEY = "notverysecret"
 
+# easy-thumbnail. See https://github.com/SmileyChris/easy-thumbnails/issues/641#issuecomment-2291098096
+THUMBNAIL_DEFAULT_STORAGE_ALIAS = "default"
+
 TEST_RUNNER = "django.test.runner.DiscoverRunner"
 FIXTURE_DIRS = [location("unit/fixtures")]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311,312}-django{32,40,41,42,50}
+    py{38,39,310,311,312}-django{32,40,41,42,50,51}
     lint
     sandbox
     docs
@@ -16,6 +16,7 @@ deps =
     django41: django>=4.1,<4.2
     django42: django>=4.2,<4.3
     django50: django>=5.0,<5.1
+    django51: django>=5.1,<5.2
 
 [testenv:lint]
 basepython = python3.12
@@ -34,7 +35,7 @@ commands =
 basepython = python3.12
 deps =
     -r{toxinidir}/requirements.txt
-    django>=5.0,<5.1
+    django>=5.1,<5.2
 allowlist_externals = make
 commands =
     make build_sandbox

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311}-django{32,40,41,42}
+    py{38,39,310,311,312}-django{32,40,41,42}
     lint
     sandbox
     docs
@@ -17,7 +17,7 @@ deps =
     django42: django>=4.2,<4.3
 
 [testenv:lint]
-basepython = python3.11
+basepython = python3.12
 deps =
     -r{toxinidir}/requirements.txt
 allowlist_externals = npm
@@ -30,7 +30,7 @@ commands =
 
 
 [testenv:sandbox]
-basepython = python3.11
+basepython = python3.12
 deps =
     -r{toxinidir}/requirements.txt
     django>=4.2,<4.3
@@ -39,7 +39,7 @@ commands =
     make build_sandbox
 
 [testenv:docs]
-basepython = python3.11
+basepython = python3.12
 allowlist_externals = make
 changedir = {toxinidir}/docs
 pip_pre = false

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311,312}-django{32,40,41,42}
+    py{38,39,310,311,312}-django{32,40,41,42,50}
     lint
     sandbox
     docs
@@ -15,6 +15,7 @@ deps =
     django40: django>=4.0,<4.1
     django41: django>=4.1,<4.2
     django42: django>=4.2,<4.3
+    django50: django>=5.0,<5.1
 
 [testenv:lint]
 basepython = python3.12
@@ -33,7 +34,7 @@ commands =
 basepython = python3.12
 deps =
     -r{toxinidir}/requirements.txt
-    django>=4.2,<4.3
+    django>=5.0,<5.1
 allowlist_externals = make
 commands =
     make build_sandbox


### PR DESCRIPTION
Summary:

- Add support for Python 3.12.
- Update Nodejs from 14/16 -> 20.
- Add support for Django 5.0 and 5.1.

Fixes #4291.
