### PR TITLE
Fix result of prefetch attribute values for children

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ install_requires = [
 ]
 
 sorl_thumbnail_version = "sorl-thumbnail>=12.10.0,<13.0.0"
-easy_thumbnails_version = "easy-thumbnails>=2.9,<3.0"
+easy_thumbnails_version = "easy-thumbnails>=2.9,<2.10"
 
 docs_requires = [
     "Sphinx>=5.0",

--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -772,9 +772,19 @@ class AbstractProduct(models.Model):
         # This means the prefetch_attribute_values method was called. and thus no database queries are needed.
         if hasattr(self, "_prefetched_attribute_values"):
             if self.is_child:
-                return list(self._prefetched_attribute_values) + list(
-                    self.parent._prefetched_parent_attribute_values
-                )
+                # Combine parent and child attribute values where the child values override parent values.
+                # This can not be done in the prefetch itself, because prefetches are separate queries and have no
+                # knowledge of the base query where the prefetch happens on.
+                attribute_values = {
+                    item.attribute.code: item
+                    for item in self.parent._prefetched_parent_attribute_values
+                }
+
+                # Update (override) the dictionary with child attribute values
+                for item in self._prefetched_attribute_values:
+                    attribute_values[item.attribute.code] = item
+
+                return list(attribute_values.values())
             return self._prefetched_attribute_values
 
         if not self.pk:


### PR DESCRIPTION
Despite my efforts to do this in a query, it isn't really possible. The solution I had, was excluding attributes from the parent queryset if ANY child had this attribute, this resulted in the other childs not inheriting the parents value, which actually makes sense if you think about it.

Getting the parent attribute values is simply not possible with a Prefetch, as Prefetch will always have `WHERE product.id in [your list of product ids the query is being done on] `at the end, because this way Django knows which result belongs to which product.

You can't reference the actual child in a Queryset either, as the Prefetch is a seperate query and knows nothing about the base QuerySet.

So the solution is, when prefetched, combine them in python.

I tested the timing of this with 10.000 attributes on the parent and 5000 attributes on the child (so it would inherit some) and it only took an average of `0.004292999976314604` seconds, so this is still much faster than doing a DB query.