### PR TITLE
Fix duplicate search box in Dashboard -> Offers -> Voucher (voucher_l…

### DIFF
--- a/src/oscar/templates/oscar/dashboard/vouchers/voucher_list.html
+++ b/src/oscar/templates/oscar/dashboard/vouchers/voucher_list.html
@@ -29,7 +29,7 @@
 
 
 {% block dashboard_content %}
-    {% block page_head %}
+    {% block search_form %}
         <div class="table-header">
             <h3><i class="fas fa-search"></i> {% trans "Search" %}</h3>
         </div>
@@ -72,7 +72,7 @@
             </div>
             {% endif %}
         </div>
-    {% endblock page_head %}
+    {% endblock search_form %}
 
     {% block voucher_table %}
         <table class="table table-striped table-bordered table-hover">


### PR DESCRIPTION
…ist.html)

The block containing the search form for Dashboard -> Offers -> Voucher was named "page_head" causing the search form to render above the top toolbar in addition to the correct place.

I renamed the block to "search_form".