### PR TITLE
Fixes incorrect variable name in code example in the docs 

### DIFF
--- a/docs/source/howto/how_to_customise_oscar_communications.rst
+++ b/docs/source/howto/how_to_customise_oscar_communications.rst
@@ -21,9 +21,9 @@ to send out to a customer, the client code will do something like this::
     try:
         event_type = CommunicationEventType.objects.get(code=commtype_code)
     except CommunicationEventType.DoesNotExist:
-        messages = CommunicationEventType.objects.get_and_render(commtype_code, ctx)
+        messages = CommunicationEventType.objects.get_and_render(commtype_code, context)
     else:
-        messages = event_type.get_messages(ctx)
+        messages = event_type.get_messages(context)
 
 What's happening here is:
 


### PR DESCRIPTION
This fixes an incorrect variable name in a code example in the [Customising Oscar’s communications](https://django-oscar.readthedocs.io/en/latest/howto/how_to_customise_oscar_communications.html) documentation page.