### PR TITLE
Feature (#360 issue on api repo) - Empty basket should return shipping list no NoShippingRequired() case

### DIFF
--- a/src/oscar/apps/basket/abstract_models.py
+++ b/src/oscar/apps/basket/abstract_models.py
@@ -411,6 +411,8 @@ class AbstractBasket(models.Model):
         Test whether the basket contains physical products that require
         shipping.
         """
+        if not self.all_lines():
+            return True  
         for line in self.all_lines():
             if line.product.is_shipping_required:
                 return True


### PR DESCRIPTION
NoShippingRequired()  is used for items who don't need to be shipped (digital for most of them). The API return that in case of empty basket. It should more usefull to have the list of shipping methods available instead of NoShippingRequired() directly.

This if can return True to make the difference