### PR TITLE
setup: make npm build optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,13 @@ from oscar import get_version  # noqa isort:skip
 
 class BuildNPM(build_module.build):
     def run(self):
-        subprocess.check_call(["npm", "install"])
-        subprocess.check_call(["npm", "run", "build"])
+        try:
+            os.stat(os.path.join(PROJECT_DIR, "package.json"))
+        except FileNotFoundError:
+            pass
+        else:
+            subprocess.check_call(["npm", "install"])
+            subprocess.check_call(["npm", "run", "build"])
         super().run()
 
 


### PR DESCRIPTION
The distribution package does not contain `package.json` nor `gulpfile.js`. Ideally, building from the distribution package would not depend on access to the npm registry.