### PR TITLE
fix blocktrans indentation

### DIFF
--- a/src/oscar/templates/oscar/basket/messages/addition.html
+++ b/src/oscar/templates/oscar/basket/messages/addition.html
@@ -1,16 +1,17 @@
 {% load i18n %}
 
 {% block message_content %}
-    {% if quantity == 1 %}
-        {% blocktrans with title=product.get_title %}
-            <strong>{{ title }}</strong> has been added to your basket.
-        {% endblocktrans %}
+{% if quantity == 1 %}
+    {% blocktrans with title=product.get_title %}
+    <strong>{{ title }}</strong> has been added to your basket.
+    {% endblocktrans %}
     {% else %}
-        {% blocktrans with title=product.get_title quantity=quantity %}
-            <strong>{{ quantity }}</strong> copies of <strong>{{ title }}</strong>
-            have been added to your basket.
-        {% endblocktrans %}
-    {% endif %}
+
+    {% blocktrans with title=product.get_title quantity=quantity %}
+    <strong>{{ quantity }}</strong> copies of <strong>{{ title }}</strong>
+    have been added to your basket.
+    {% endblocktrans %}
+{% endif %}
 {% endblock message_content %}
 
 {% block analytics_scripts %}{% endblock analytics_scripts %}

--- a/src/oscar/templates/oscar/basket/messages/line_restored.html
+++ b/src/oscar/templates/oscar/basket/messages/line_restored.html
@@ -1,9 +1,9 @@
 {% load i18n %}
 
 {% block message_content %}
-    {% blocktrans with title=line.product.get_title %}
-    <strong>{{ title }}</strong> has been moved back to your basket.
-    {% endblocktrans %}
+{% blocktrans with title=line.product.get_title %}
+<strong>{{ title }}</strong> has been moved back to your basket.
+{% endblocktrans %}
 {% endblock message_content %}
 
 {% block analytics_scripts %}{% endblock analytics_scripts %}

--- a/src/oscar/templates/oscar/basket/messages/line_saved.html
+++ b/src/oscar/templates/oscar/basket/messages/line_saved.html
@@ -1,9 +1,9 @@
 {% load i18n %}
 
 {% block message_content %}
-    {% blocktrans with title=line.product.get_title %}
-    <strong>{{ title }}</strong> has been saved for later
-    {% endblocktrans %}
+{% blocktrans with title=line.product.get_title %}
+<strong>{{ title }}</strong> has been saved for later
+{% endblocktrans %}
 {% endblock message_content %}
 
 {% block analytics_scripts %}{% endblock analytics_scripts %}

--- a/src/oscar/templates/oscar/basket/messages/new_total.html
+++ b/src/oscar/templates/oscar/basket/messages/new_total.html
@@ -2,20 +2,19 @@
 {% load currency_filters %}
 
 {% block message_content %}
-    {% if basket.is_empty %}
-        {% trans "Your basket is now empty" %}
+{% if basket.is_empty %}
+    {% trans "Your basket is now empty" %}
+{% else %}
+    {% if basket.is_tax_known %}
+        {% blocktrans with total=basket.total_incl_tax|currency:basket.currency %}
+        Your basket total is now <strong>{{ total }}</strong>
+        {% endblocktrans %}
     {% else %}
-        {% if basket.is_tax_known %}
-            {% blocktrans with total=basket.total_incl_tax|currency:basket.currency %}
-            Your basket total is now <strong>{{ total }}</strong>
-            {% endblocktrans %}
-        {% else %}
-            {% blocktrans with total=basket.total_excl_tax|currency:basket.currency %}
-            Your basket total is now <strong>{{ total }}</strong>
-            {% endblocktrans %}
-        {% endif %}
+        {% blocktrans with total=basket.total_excl_tax|currency:basket.currency %}
+        Your basket total is now <strong>{{ total }}</strong>
+        {% endblocktrans %}
     {% endif %}
-    
+{% endif %}
 {% endblock message_content %}
 
 {% if include_buttons %}

--- a/src/oscar/templates/oscar/basket/messages/offer_gained.html
+++ b/src/oscar/templates/oscar/basket/messages/offer_gained.html
@@ -1,10 +1,10 @@
 {% load i18n %}
 
 {% block message_content %}
-    {% blocktrans with name=offer.name %}
-    Your basket now qualifies for the 
-    <strong>{{ name }}</strong> offer.
-    {% endblocktrans %}
+{% blocktrans with name=offer.name %}
+Your basket now qualifies for the 
+<strong>{{ name }}</strong> offer.
+{% endblocktrans %}
 {% endblock message_content %}
 
 {% block analytics_scripts %}{% endblock analytics_scripts %}

--- a/src/oscar/templates/oscar/basket/messages/offer_lost.html
+++ b/src/oscar/templates/oscar/basket/messages/offer_lost.html
@@ -1,10 +1,10 @@
 {% load i18n %}
 
 {% block message_content %}
-    {% blocktrans with name=offer.name %}
-    Your basket no longer qualifies for the
-    <strong>{{ name }}</strong> offer.
-    {% endblocktrans %}
+{% blocktrans with name=offer.name %}
+Your basket no longer qualifies for the
+<strong>{{ name }}</strong> offer.
+{% endblocktrans %}
 {% endblock message_content %}
 
 {% block analytics_scripts %}{% endblock analytics_scripts %}


### PR DESCRIPTION
revert the blocktrans indentations to how they were before, because changing the indentation breaks the msgid in django.po files. 