### PR TITLE
fix: wrap selector attr value in double quotes

### DIFF
--- a/src/oscar/static_src/oscar/js/oscar/dashboard.js
+++ b/src/oscar/static_src/oscar/js/oscar/dashboard.js
@@ -356,7 +356,7 @@ var oscar = (function(o, $) {
         orders: {
             initTabs: function() {
                 if (location.hash) {
-                    $('.nav-tabs a[href=' + location.hash + ']').tab('show');
+                    $('.nav-tabs a[href="' + location.hash + '"]').tab('show');
                 }
             },
             initTable: function() {


### PR DESCRIPTION
At [src/oscar/static_src/oscar/js/oscar/dashboard.js#L359](https://github.com/django-oscar/django-oscar/blob/83d18427993584fd2983e4d1339ca9d268607992/src/oscar/static_src/oscar/js/oscar/dashboard.js#L359):

`$('.nav-tabs a[href=' + location.hash + ']').tab('show');`

Wrapped location.hash in double quotes here, since it throws an invalid selector error if its value contains a hash (#).

