### PR TITLE
[Fix] Number of orders sorting fix in dashboard customer listing

### DIFF
--- a/src/oscar/apps/dashboard/users/tables.py
+++ b/src/oscar/apps/dashboard/users/tables.py
@@ -1,3 +1,4 @@
+from django.db.models import F
 from django.utils.translation import gettext_lazy as _
 from django_tables2 import A, Column, LinkColumn, TemplateColumn
 
@@ -28,3 +29,16 @@ class UserTable(DashboardTable):
 
     class Meta(DashboardTable.Meta):
         template_name = "oscar/dashboard/users/table.html"
+
+    def order_num_orders(self, queryset, is_descending):
+        """
+        User record is created only once a user places an order, all such records must
+        be at the end of listing, when sorting in descending order, and at the start
+        when sorting in ascending.
+        """
+        if is_descending:
+            order_by = F("userrecord__num_orders").desc(nulls_last=True)
+        else:
+            order_by = F("userrecord__num_orders").asc(nulls_first=True)
+
+        return (queryset.order_by(order_by), True)

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -1,7 +1,7 @@
 # pylint: disable=unused-argument, W0621
 import csv
 import operator
-from decimal import ROUND_UP
+from decimal import ROUND_DOWN
 from decimal import Decimal as D
 
 from django.conf import settings
@@ -753,7 +753,7 @@ class AbstractBenefit(BaseOfferMixin, models.Model):
         if errors:
             raise exceptions.ValidationError(errors)
 
-    def round(self, amount, currency=None, round_type=ROUND_UP):
+    def round(self, amount, currency=None, round_type=ROUND_DOWN):
         """
         Apply rounding to discount amount
         """

--- a/src/oscar/apps/offer/benefits.py
+++ b/src/oscar/apps/offer/benefits.py
@@ -1,6 +1,6 @@
 # pylint: disable=W0621, unused-argument
 
-from decimal import Decimal as D, ROUND_DOWN
+from decimal import Decimal as D
 
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
@@ -195,9 +195,7 @@ class AbsoluteDiscountBenefit(Benefit):
             else:
                 # Calculate a weighted discount for the line
                 line_discount = self.round(
-                    ((price * qty) / affected_items_total) * discount,
-                    basket.currency,
-                    ROUND_DOWN,
+                    ((price * qty) / affected_items_total) * discount, basket.currency
                 )
             apply_discount(line, line_discount, qty, offer)
             applied_discount += line_discount

--- a/tests/integration/offer/test_benefit.py
+++ b/tests/integration/offer/test_benefit.py
@@ -1,5 +1,5 @@
 # pylint: disable=redefined-outer-name
-from decimal import ROUND_UP, Decimal
+from decimal import ROUND_DOWN, Decimal
 from unittest.mock import patch
 
 import pytest
@@ -51,7 +51,7 @@ class TestBenefit(TestCase):
         decimal = Decimal(10.0570)
 
         self.assertEqual(
-            benefit.round(decimal), decimal.quantize(Decimal("0.01"), ROUND_UP)
+            benefit.round(decimal), decimal.quantize(Decimal("0.01"), ROUND_DOWN)
         )
 
     @override_settings(

--- a/tests/integration/offer/test_percentage_benefit.py
+++ b/tests/integration/offer/test_percentage_benefit.py
@@ -234,16 +234,16 @@ class TestPercentageBenefitDiscountAccuracy(TestCase):
     def test_discount_value(self):
         """
         price = 2.37 * 6 + 3.28 = 17.5
-        discount = 17.5 * 0.03 = 0.525 = round(0.525) = 0.53
+        discount = 17.5 * 0.03 = 0.525 = round(0.525) = 0.52
         """
         result = self.benefit.apply(self.basket, self.condition, self.offer)
-        self.assertEqual(D("0.53"), result.discount)
+        self.assertEqual(D("0.52"), result.discount)
 
     def test_discount_value_round_down(self):
         """
         price = 2.37 * 6 + 3.28 = 17.5
-        discount = 17.5 * 0.05 = 0.875 = round(0.875) = 0.88
+        discount = 17.5 * 0.05 = 0.875 = round(0.875) = 0.87
         """
         self.benefit.value = D("5.00")
         result = self.benefit.apply(self.basket, self.condition, self.offer)
-        self.assertEqual(D("0.88"), result.discount)
+        self.assertEqual(D("0.87"), result.discount)

--- a/tests/unit/dashboard/test_tables.py
+++ b/tests/unit/dashboard/test_tables.py
@@ -1,0 +1,21 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+
+from oscar.core.loading import get_class
+from oscar.test.factories import UserFactory, create_order
+
+User = get_user_model()
+UserTable = get_class("dashboard.users.tables", "UserTable")
+
+
+class UserTableTestCase(TestCase):
+    def test_num_orders_sort(self):
+        user1 = UserFactory()
+        user2 = UserFactory()
+        create_order(user=user2)
+        table = UserTable(data=User.objects.all())
+        table.order_by = "num_orders"
+        self.assertEqual(table.data[0].id, user1.id)
+        table.order_by = "-num_orders"
+        # User2 has with num_orders value of 1
+        self.assertEqual(table.data[0].id, user2.id)


### PR DESCRIPTION
User record is created only once a user places an order, all such records must be at the end of listing, when sorting in descending order, and at the start when sorting in ascending.