### PR TITLE
Make setuptools get dynamic version from setup.py rather than the pyprojectoml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,3 @@ sorl-thumbnail = [
 easy-thumbnails = [
     "easy-thumbnails>=2.9,<2.11",
 ]
-
-
-[tool.setuptools.dynamic]
-version = {attr = "oscar.__version__"}

--- a/src/oscar/__init__.py
+++ b/src/oscar/__init__.py
@@ -69,6 +69,3 @@ INSTALLED_APPS = [
 
 
 default_app_config = "oscar.config.Shop"
-
-
-__version__ = get_version()


### PR DESCRIPTION
Documented here;
https://packaging.python.org/en/latest/guides/modernize-setup-py-project/#how-to-handle-dynamic-metadata

And this way, our vdt.versionplugin.wheel patch stays working with patching version while building with it.