### PR TITLE
Correction of the if condition in product_list.html

### DIFF
--- a/src/oscar/apps/dashboard/catalogue/views.py
+++ b/src/oscar/apps/dashboard/catalogue/views.py
@@ -92,6 +92,7 @@ class ProductListView(PartnerProductFilterMixin, SingleTableView):
         ctx = super().get_context_data(**kwargs)
         ctx["form"] = self.form
         ctx["productclass_form"] = self.productclass_form_class()
+        ctx["has_products"] = self.get_queryset().exists()
         return ctx
 
     def get_description(self, form):

--- a/src/oscar/templates/oscar/dashboard/catalogue/product_list.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/product_list.html
@@ -64,7 +64,7 @@
         </div>
     {% endblock %}
 
-    {% if products %}
+    {% if has_products %}
         {% block product_list %}
             <form method="post">
                 {% csrf_token %}


### PR DESCRIPTION
Correction of the if condition in product_list.html because would never enter in the else block, due to 'products' will always be truly, because it is getting the ProductTable instance for the table. 
The table instance will always exist, with or without data, depending on the get_queryset()

In this example, of the sandbox, if there aren't products founded, is rendered the table head, when really should be rendered the else statement.

![image](https://github.com/user-attachments/assets/62723b47-3d6d-401d-872d-0d35e9e4b23f)
