### PR TITLE
WIP: Replace join query with CTE for the range category lookup.

### DIFF
--- a/src/oscar/apps/catalogue/expressions.py
+++ b/src/oscar/apps/catalogue/expressions.py
@@ -1,36 +1,59 @@
 from django.db.models.expressions import Subquery
 
-EXPAND_UPWARDS_CATEGORY_QUERY = """
-(SELECT "CATALOGUE_CATEGORY_JOIN"."id" FROM "catalogue_category" AS "CATALOGUE_CATEGORY_BASE"
-LEFT JOIN "catalogue_category" AS "CATALOGUE_CATEGORY_JOIN" ON (
-    "CATALOGUE_CATEGORY_BASE"."path" LIKE "CATALOGUE_CATEGORY_JOIN"."path" || '%%%%'
-    AND "CATALOGUE_CATEGORY_BASE"."depth" >= "CATALOGUE_CATEGORY_JOIN"."depth"
-)
-WHERE "CATALOGUE_CATEGORY_BASE"."id" IN (%(subquery)s))
-"""
-
-
-EXPAND_DOWNWARDS_CATEGORY_QUERY = """
-(SELECT "CATALOGUE_CATEGORY_JOIN"."id" FROM "catalogue_category" AS "CATALOGUE_CATEGORY_BASE"
-LEFT JOIN "catalogue_category" AS "CATALOGUE_CATEGORY_JOIN" ON (
-    "CATALOGUE_CATEGORY_JOIN"."path" LIKE "CATALOGUE_CATEGORY_BASE"."path" || '%%%%'
-    AND "CATALOGUE_CATEGORY_BASE"."depth" <= "CATALOGUE_CATEGORY_JOIN"."depth"
-)
-WHERE "CATALOGUE_CATEGORY_BASE"."id" IN (%(subquery)s))
-"""
-
 
 # pylint: disable=abstract-method
 class ExpandUpwardsCategoryQueryset(Subquery):
-    template = EXPAND_UPWARDS_CATEGORY_QUERY
+    def __init__(self, queryset, **kwargs):
+        self.queryset = queryset
+        super().__init__(queryset, **kwargs)
+
+    def as_sql(self, compiler, connection, template=None, **extra_context):
+        inner_sql, inner_params = compiler.compile(self.queryset.query)
+
+        sql = f"""
+        (WITH RECURSIVE category_hierarchy AS (
+            SELECT "id", "path", "depth" FROM "catalogue_category" WHERE "id" IN ({inner_sql})
+            UNION ALL
+            SELECT "parent"."id", "parent"."path", "parent"."depth"
+            FROM "catalogue_category" AS "parent"
+            JOIN category_hierarchy AS "child" ON (
+                "child"."path" LIKE "parent"."path" || '%%'
+                AND "parent"."depth" < "child"."depth"
+            )
+        )
+        SELECT DISTINCT "id" FROM category_hierarchy)
+        """
+        return sql, inner_params
 
     def as_sqlite(self, compiler, connection):
-        return super().as_sql(compiler, connection, self.template[1:-1])
+        sql, params = self.as_sql(compiler, connection)
+        return sql[1:-1], params
 
 
 # pylint: disable=abstract-method
 class ExpandDownwardsCategoryQueryset(Subquery):
-    template = EXPAND_DOWNWARDS_CATEGORY_QUERY
+    def __init__(self, queryset, **kwargs):
+        self.queryset = queryset
+        super().__init__(queryset, **kwargs)
+
+    def as_sql(self, compiler, connection, template=None, **extra_context):
+        inner_sql, inner_params = compiler.compile(self.queryset.query)
+
+        sql = f"""
+        (WITH RECURSIVE category_hierarchy AS (
+            SELECT "id", "path", "depth" FROM "catalogue_category" WHERE "id" IN ({inner_sql})
+            UNION ALL
+            SELECT "child"."id", "child"."path", "child"."depth"
+            FROM "catalogue_category" AS "child"
+            JOIN category_hierarchy AS "parent" ON (
+                "child"."path" LIKE "parent"."path" || '%%'
+                AND "child"."depth" > "parent"."depth"
+            )
+        )
+        SELECT DISTINCT "id" FROM category_hierarchy)
+        """
+        return sql, inner_params
 
     def as_sqlite(self, compiler, connection):
-        return super().as_sql(compiler, connection, self.template[1:-1])
+        sql, params = self.as_sql(compiler, connection)
+        return sql[1:-1], params


### PR DESCRIPTION
**WIP** because I want to test this on a shop with lots of categories first.

This PR replaces the range query for the category lookup with a CTE query.

CTE's are known to be powerful for querying hierarchical data (and recommended so).

This should improve the performance a lot for shops with large categorie trees, since the CTE processes the hierarchy level-by-level instead of comparing all possible category combinations in a single massive join when dealing with large category trees.

It's similar to [FEAT: Add postgres materialised view to the ProductCategory model to increase performance on the range queries](https://github.com/django-oscar/django-oscar/pull/4436) and this would probably still be best to implement if you can as it's precomputed (but needs refreshes) but this PR provides a better and more performant fallback.