### PR TITLE
Admin logout button should use POST as django 5 no longer supports is through GET.

### DIFF
--- a/src/oscar/templates/oscar/dashboard/catalogue/attribute_option_group_delete.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/attribute_option_group_delete.html
@@ -44,7 +44,7 @@
         <div class="table-header">
             <h2>{% trans "Delete Attribute Option Group" %}</h2>
         </div>
-        <form method="post" class="card card-body">
+        <form id="attribute_delete_form" method="post" class="card card-body">
             {% csrf_token %}
             {% if is_popup %}<input type="hidden" name="{{ is_popup_var }}" value="1" />{% endif %}
             {% if not is_popup %}

--- a/src/oscar/templates/oscar/dashboard/catalogue/attribute_option_group_form.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/attribute_option_group_form.html
@@ -36,7 +36,7 @@
 {% block headertext %}{{ title }}{% endblock %}
 
 {% block dashboard_content %}
-    <form class="form-stacked wysiwyg fixed-actions" method="post" data-behaviour="tab-nav-errors">
+    <form id="create_update_attribute_option_group_form" class="form-stacked wysiwyg fixed-actions" method="post" data-behaviour="tab-nav-errors">
         {% csrf_token %}
 
         <div class="row">

--- a/src/oscar/templates/oscar/dashboard/catalogue/attribute_option_group_list.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/attribute_option_group_list.html
@@ -27,7 +27,7 @@
 {% block dashboard_content %}
     {% if attribute_option_groups %}
         {% block product_list %}
-            <form method="post">
+            <form id="search_attribute_group_form" method="post">
                 {% csrf_token %}
                 {% render_table attribute_option_groups %}
             </form>

--- a/src/oscar/templates/oscar/dashboard/catalogue/category_delete.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/category_delete.html
@@ -25,7 +25,7 @@
     <div class="table-header">
         <h2>{% trans "Delete category" %}</h2>
     </div>
-    <form method="post" class="card card-body bg-light">
+    <form id="delete_category_form" method="post" class="card card-body bg-light">
         {% csrf_token %}
         {{ form }}
         {% blocktrans with name=object.name %}

--- a/src/oscar/templates/oscar/dashboard/catalogue/category_form.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/category_form.html
@@ -27,7 +27,7 @@
 {% block headertext %}{{ title }}{% endblock %}
 
 {% block dashboard_content %}
-    <form action="{% if request.GET.urlencode %}?{{ request.GET.urlencode }}{% endif %}" method="post" class="form-stacked wysiwyg fixed-actions" enctype="multipart/form-data" data-behaviour="tab-nav-errors" autocomplete="off">
+    <form id="create_update_category_form" action="{% if request.GET.urlencode %}?{{ request.GET.urlencode }}{% endif %}" method="post" class="form-stacked wysiwyg fixed-actions" enctype="multipart/form-data" data-behaviour="tab-nav-errors" autocomplete="off">
         {% csrf_token %}
         <div class="row">
             {% block tab_nav %}

--- a/src/oscar/templates/oscar/dashboard/catalogue/option_delete.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/option_delete.html
@@ -42,7 +42,7 @@
         <div class="table-header">
             <h2>{% trans "Delete Option" %}</h2>
         </div>
-        <form action="." method="post" class="card card-body bg-light">
+        <form id="delete_option_form" action="." method="post" class="card card-body bg-light">
             {% csrf_token %}
             {% if is_popup %}<input type="hidden" name="{{ is_popup_var }}" value="1" />{% endif %}
             {% if not is_popup %}

--- a/src/oscar/templates/oscar/dashboard/catalogue/option_form.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/option_form.html
@@ -36,7 +36,7 @@
 {% block headertext %}{{ title }}{% endblock %}
 
 {% block dashboard_content %}
-    <form class="form-stacked wysiwyg fixed-actions" method="post" data-behaviour="tab-nav-errors">
+    <form id="create_update_option_form" class="form-stacked wysiwyg fixed-actions" method="post" data-behaviour="tab-nav-errors">
         {% csrf_token %}
 
         <div class="row">

--- a/src/oscar/templates/oscar/dashboard/catalogue/option_list.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/option_list.html
@@ -25,7 +25,7 @@
 {% block dashboard_content %}
     {% if options %}
         {% block product_list %}
-            <form action="." method="post">
+            <form id="search_option_form" action="." method="post">
                 {% csrf_token %}
                 {% render_table options %}
             </form>

--- a/src/oscar/templates/oscar/dashboard/catalogue/product_class_delete.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/product_class_delete.html
@@ -24,7 +24,7 @@
         <div class="table-header">
             <h2>{% trans "Delete product type" %}</h2>
         </div>
-        <form method="post" class="card card-body bg-light">
+        <form id="delete_product_class_form" method="post" class="card card-body bg-light">
             {% csrf_token %}
             {{ form }}
             <p>

--- a/src/oscar/templates/oscar/dashboard/catalogue/product_class_form.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/product_class_form.html
@@ -20,7 +20,7 @@
 {% block headertext %}{{ title }}{% endblock %}
 
 {% block dashboard_content %}
-    <form class="form-stacked wysiwyg fixed-actions" method="post" data-behaviour="tab-nav-errors">
+    <form id="create_update_product_class_form" class="form-stacked wysiwyg fixed-actions" method="post" data-behaviour="tab-nav-errors">
         {% csrf_token %}
 
         <div class="row">

--- a/src/oscar/templates/oscar/dashboard/catalogue/product_delete.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/product_delete.html
@@ -25,7 +25,7 @@
     <div class="table-header">
         <h2>{{ title }}</h2>
     </div>
-    <form method="post" class="card card-body bg-light">
+    <form id="delete_product_form" method="post" class="card card-body bg-light">
         {% csrf_token %}
 
         <p>

--- a/src/oscar/templates/oscar/dashboard/catalogue/product_list.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/product_list.html
@@ -33,7 +33,7 @@
             <h3><i class="fas fa-sitemap"></i> {% trans "Create new product" %}</h3>
         </div>
         <div class="card card-body">
-            <form action="{% url 'dashboard:catalogue-product-create' %}" method="get" class="form-inline">
+            <form id="create_product_with_class_form" action="{% url 'dashboard:catalogue-product-create' %}" method="get" class="form-inline">
                 {% include "oscar/dashboard/partials/form_fields_inline.html" with form=productclass_form %}
                 <button class="btn btn-primary" type="submit" data-loading-text="{% trans 'Submitting...' %}">
                     <i class="fas fa-plus-circle"></i> {% trans "New Product" %}
@@ -47,7 +47,7 @@
             <h3><i class="fas fa-search"></i> {% trans "Search Products" %}</h3>
         </div>
         <div class="card card-body">
-            <form method="get" class="form-inline">
+            <form id="search_product_form" method="get" class="form-inline">
                 {% comment %}
                     Add the current query string to the search form so that the
                     sort order is not reset when searching.

--- a/src/oscar/templates/oscar/dashboard/catalogue/product_update.html
+++ b/src/oscar/templates/oscar/dashboard/catalogue/product_update.html
@@ -31,7 +31,7 @@
 {% block headertext %}{{ title }}{% endblock %}
 
 {% block dashboard_content %}
-    <form action="{% if request.GET.urlencode %}?{{ request.GET.urlencode }}{% endif %}" method="post" class="form-stacked wysiwyg fixed-actions" enctype="multipart/form-data" data-behaviour="tab-nav-errors" autocomplete="off">
+    <form id="create_update_product_form" action="{% if request.GET.urlencode %}?{{ request.GET.urlencode }}{% endif %}" method="post" class="form-stacked wysiwyg fixed-actions" enctype="multipart/form-data" data-behaviour="tab-nav-errors" autocomplete="off">
         {% csrf_token %}
 
         {% if parent %}

--- a/src/oscar/templates/oscar/dashboard/comms/detail.html
+++ b/src/oscar/templates/oscar/dashboard/comms/detail.html
@@ -26,7 +26,7 @@
 
 
 {% block dashboard_content %}
-    <form method="post" class="form-stacked">
+    <form id="update_communication_event_form" method="post" class="form-stacked">
         <div class="tabbable dashboard">
             {% if preview %}
                 <ul class="nav nav-tabs mb-0">

--- a/src/oscar/templates/oscar/dashboard/layout.html
+++ b/src/oscar/templates/oscar/dashboard/layout.html
@@ -42,9 +42,12 @@
                   <li class="nav-item">
                     <a class="nav-link" href="{% url 'customer:summary' %}"><i class="fas fa-user"></i> {% trans "Account" %}</a>
                   </li>
-                  <li class="nav-item">
-                    <a class="nav-link" href="{% url 'dashboard:logout' %}"><i class="fas fa-sign-out-alt"></i> {% trans "Log out" %}</a>
-                  </li>
+                  <form method="post" action="{% url 'dashboard:logout' %}">
+                    {% csrf_token %}
+                    <button class="btn btn-link nav-link" type="submit">
+                        <i class="fas fa-sign-out-alt"></i> {% trans "Log out" %}
+                    </button>
+                  </form>
                 </ul>
           </div>
         </nav>

--- a/src/oscar/templates/oscar/dashboard/layout.html
+++ b/src/oscar/templates/oscar/dashboard/layout.html
@@ -42,7 +42,7 @@
                   <li class="nav-item">
                     <a class="nav-link" href="{% url 'customer:summary' %}"><i class="fas fa-user"></i> {% trans "Account" %}</a>
                   </li>
-                  <form method="post" action="{% url 'dashboard:logout' %}">
+                  <form id="logout_form" method="post" action="{% url 'dashboard:logout' %}">
                     {% csrf_token %}
                     <button class="btn btn-link nav-link" type="submit">
                         <i class="fas fa-sign-out-alt"></i> {% trans "Log out" %}

--- a/src/oscar/templates/oscar/dashboard/offers/offer_delete.html
+++ b/src/oscar/templates/oscar/dashboard/offers/offer_delete.html
@@ -23,7 +23,7 @@
 {% endblock %}
 
 {% block dashboard_content %}
-    <form method="post">
+    <form id="delete_offer_form" method="post">
         {% csrf_token %}
         <p>{% trans "Are you sure you want to delete this offer?" %}</p>
         <div class="form-actions">

--- a/src/oscar/templates/oscar/dashboard/offers/offer_list.html
+++ b/src/oscar/templates/oscar/dashboard/offers/offer_list.html
@@ -30,7 +30,7 @@
         <h3><i class="fas fa-search"></i> {% trans "Search" %}</h3>
     </div>
     <div class="card card-body bg-light">
-        <form method="get" class="form-inline">
+        <form id="search_offers_form" method="get" class="form-inline">
             {% for field in form %}
                 {% if field.name in form.basic_fields %}
                     {% if field.is_hidden %}
@@ -69,7 +69,7 @@
         {% endif %}
     </div>
 
-    <form method="post" class="order_table">
+    <form id="filter_offers_form" method="post" class="order_table">
         {% csrf_token %}
         <table class="table table-striped table-bordered table-hover">
             <caption>

--- a/src/oscar/templates/oscar/dashboard/offers/step_form.html
+++ b/src/oscar/templates/oscar/dashboard/offers/step_form.html
@@ -48,7 +48,7 @@
             {% endblock %}
         </div>
         <div class="{% if session_offer %}col-md-6{% else %}col-md-9{% endif %}">
-            <form method="post" class="form-stacked wysiwyg fixed-actions">
+            <form id="create_update_offer_step_form" method="post" class="form-stacked wysiwyg fixed-actions">
                 <div class="table-header">
                     <h3>{{ title }}</h3>
                 </div>

--- a/src/oscar/templates/oscar/dashboard/orders/order_detail.html
+++ b/src/oscar/templates/oscar/dashboard/orders/order_detail.html
@@ -697,7 +697,7 @@
                                         <td>
                                             {% if note.is_editable %}
                                                 <a href="{% url 'dashboard:order-detail-note' number=order.number note_id=note.id %}#notes" class="btn btn-info">{% trans "Edit" %}</a>
-                                                <form method="post" class="float-left m-0">
+                                                <form id="delete_order_note_form" method="post" class="float-left m-0">
                                                     {% csrf_token %}
                                                     <input type="hidden" name="order_action" value="delete_note" />
                                                     <input type="hidden" name="note_id" value="{{ note.id }}" />

--- a/src/oscar/templates/oscar/dashboard/orders/shippingaddress_form.html
+++ b/src/oscar/templates/oscar/dashboard/orders/shippingaddress_form.html
@@ -24,7 +24,7 @@
 
 {% block content %}
 
-    <form method="post" class="card card-body">
+    <form id="order_shipping_address_form" method="post" class="card card-body">
         {% csrf_token %}
         {% include "oscar/dashboard/partials/form_fields.html" with form=form style='horizontal' %}
         <div class="form-actions">

--- a/src/oscar/templates/oscar/dashboard/orders/statistics.html
+++ b/src/oscar/templates/oscar/dashboard/orders/statistics.html
@@ -26,7 +26,7 @@
         <h3><i class="fas fa-filter"></i> {% trans "Filter" %}</h3>
     </div>
     <div class="card card-body bg-light">
-        <form method="get" action="{% url 'dashboard:order-stats' %}" class="form-inline">
+        <form id="order_statistics_form" method="get" action="{% url 'dashboard:order-stats' %}" class="form-inline">
             {% include "oscar/dashboard/partials/form_fields_inline.html" with form=form %}
             <button type="submit" class="btn btn-primary mr-2" data-loading-text="{% trans 'Filtering...' %}">{% trans "Filter result" %}</button>
             <a href="{% url 'dashboard:order-stats' %}" class="btn btn-secondary">{% trans "Reset" %}</a>

--- a/src/oscar/templates/oscar/dashboard/pages/delete.html
+++ b/src/oscar/templates/oscar/dashboard/pages/delete.html
@@ -28,7 +28,7 @@
     <div class="table-header">
         <h2>{% trans "Delete page" %}</h2>
     </div>
-    <form method="post" class="card card-body">
+    <form id="delete_page_form" method="post" class="card card-body">
         {% csrf_token %}
         {{ form }}
         <p>{% blocktrans with title=object.title %}Delete page <strong>{{ title }}</strong> - are you sure?{% endblocktrans %}</p>

--- a/src/oscar/templates/oscar/dashboard/pages/index.html
+++ b/src/oscar/templates/oscar/dashboard/pages/index.html
@@ -31,7 +31,7 @@
         <h3><i class="fas fa-search"></i> {% trans "Search" %}</h3>
     </div>
     <div class="card card-body">
-        <form method="get" class="form-inline">
+        <form id="search_page_form" method="get" class="form-inline">
             {% include "oscar/dashboard/partials/form_fields_inline.html" with form=form %}
             <button type="submit" class="btn btn-primary mr-2" data-loading-text="{% trans 'Searching...' %}">
                 {% trans "Search" %}
@@ -46,7 +46,7 @@
 
 
     {% if flatpage_list %}
-        <form method="post">
+        <form id="filter_page_form" method="post">
             {% csrf_token %}
             <table class="table table-striped table-bordered table-hover">
                 <thead>

--- a/src/oscar/templates/oscar/dashboard/pages/update.html
+++ b/src/oscar/templates/oscar/dashboard/pages/update.html
@@ -26,7 +26,7 @@
     <h2>{{ title }}</h2>
 </div>
 
-<form method="post" class="card card-body form-stacked wysiwyg" enctype="multipart/form-data">
+<form id="create_update_page_form" method="post" class="card card-body form-stacked wysiwyg" enctype="multipart/form-data">
     {% csrf_token %}
     {% include 'oscar/dashboard/partials/form_fields.html' with form=form %}
     <div class="form-actions">

--- a/src/oscar/templates/oscar/dashboard/partners/partner_delete.html
+++ b/src/oscar/templates/oscar/dashboard/partners/partner_delete.html
@@ -23,7 +23,7 @@
 {% endblock %}
 
 {% block dashboard_content %}
-    <form method="post">
+    <form id="delete_partner_form" method="post">
         {% csrf_token %}
         <p>{% trans "Are you sure you want to delete this partner?" %}</p>
         <div class="form-actions">

--- a/src/oscar/templates/oscar/dashboard/partners/partner_list.html
+++ b/src/oscar/templates/oscar/dashboard/partners/partner_list.html
@@ -24,7 +24,7 @@
 
 {% block dashboard_content %}
     <div class="card card-body bg-light">
-        <form method="get" class="form-inline">
+        <form id="search_partner_form" method="get" class="form-inline">
             {% include 'oscar/dashboard/partials/form_fields_inline.html' with form=form %}
             <button type="submit" class="btn btn-primary" data-loading-text="{% trans 'Searching...' %}">{% trans "Search" %}</button>
             {% if is_filtered %}
@@ -33,7 +33,7 @@
         </form>
     </div>
 
-    <form method="post" class="order_table">
+    <form id="filter_partner_form" method="post" class="order_table">
         {% csrf_token %}
         <table class="table table-striped table-bordered">
             <caption>

--- a/src/oscar/templates/oscar/dashboard/partners/partner_manage.html
+++ b/src/oscar/templates/oscar/dashboard/partners/partner_manage.html
@@ -48,7 +48,7 @@
                             <td>{{ user.first_name|default:"-" }}</td>
                             <td>{{ user.last_name|default:"-" }}</td>
                             <td>
-                                <form action="{% url 'dashboard:partner-user-unlink' partner_pk=partner.id user_pk=user.id %}" method="post">
+                                <form id="unlink_user_from_partner_form" action="{% url 'dashboard:partner-user-unlink' partner_pk=partner.id user_pk=user.id %}" method="post">
                                     {% csrf_token %}
                                     <button type="submit" class="btn btn-danger" data-loading-text="{% trans 'Unlinking...' %}">{% trans 'Unlink user' %}</button>
                                 </form>

--- a/src/oscar/templates/oscar/dashboard/partners/partner_user_form.html
+++ b/src/oscar/templates/oscar/dashboard/partners/partner_user_form.html
@@ -26,7 +26,7 @@
 {% block headertext %}{{ title }}{% endblock %}
 
 {% block dashboard_content %}
-    <form method="post" class="card card-body form-stacked wysiwyg" enctype="multipart/form-data">
+    <form id="user_partner_form" method="post" class="card card-body form-stacked wysiwyg" enctype="multipart/form-data">
         {% csrf_token %}
         {% include 'oscar/dashboard/partials/form_fields.html' with form=form %}
         <div class="form-actions">

--- a/src/oscar/templates/oscar/dashboard/partners/partner_user_list.html
+++ b/src/oscar/templates/oscar/dashboard/partners/partner_user_list.html
@@ -48,7 +48,7 @@
                         <td>{{ user.first_name|default:"-" }}</td>
                         <td>{{ user.last_name|default:"-" }}</td>
                         <td>
-                            <form action="{% url 'dashboard:partner-user-unlink' partner_pk=partner.id user_pkuser.id %}" method="post">
+                            <form id="unlink_user_from_partner_form" action="{% url 'dashboard:partner-user-unlink' partner_pk=partner.id user_pkuser.id %}" method="post">
                                 {% csrf_token %}
                                 <button type="submit" class="btn btn-danger" data-loading-text="{% trans 'Unlinking...' %}">{% trans 'Unlink user' %}</button>
                             </form>

--- a/src/oscar/templates/oscar/dashboard/partners/partner_user_select.html
+++ b/src/oscar/templates/oscar/dashboard/partners/partner_user_select.html
@@ -23,7 +23,7 @@
 {% block dashboard_content %}
     {% block users_form %}
         <div class="card card-body">
-            <form method="get" class="form-inline">
+            <form id="search_partner_user_form" method="get" class="form-inline">
                 {% include 'oscar/dashboard/partials/form_fields_inline.html' with form=form %}
                 <button type="submit" class="btn btn-primary" data-loading-text="{% trans 'Searching...' %}">{% trans "Search" %}</button>
                 {% if form.is_bound %}
@@ -61,7 +61,7 @@
                                                 User is already linked to {{ name }}.
                                             {% endblocktrans %}
                                         {% else %}
-                                            <form action="{% url 'dashboard:partner-user-link' partner_pk=partner.id user_pk=user.id %}" method="post">
+                                            <form id="unlink_user_from_partner_form" action="{% url 'dashboard:partner-user-link' partner_pk=partner.id user_pk=user.id %}" method="post">
                                                 {% csrf_token %}
                                                 <button type="submit" class="btn btn-primary" data-loading-text="{% trans 'Linking...' %}">{% trans 'Link user' %}</button>
                                             </form>

--- a/src/oscar/templates/oscar/dashboard/ranges/range_delete.html
+++ b/src/oscar/templates/oscar/dashboard/ranges/range_delete.html
@@ -23,7 +23,7 @@
 {% endblock %}
 
 {% block dashboard_content %}
-    <form method="post" class="card card-body bg-light">
+    <form id="delete_range_form" method="post" class="card card-body bg-light">
         <p>{% trans "Are you sure you want to delete this range?" %}</p>
         {% csrf_token %}
         <div class="form-actions">

--- a/src/oscar/templates/oscar/dashboard/ranges/range_form.html
+++ b/src/oscar/templates/oscar/dashboard/ranges/range_form.html
@@ -28,7 +28,7 @@
 {% endblock %}
 
 {% block dashboard_content %}
-    <form method="post" class="form-stacked card card-body bg-light wysiwyg">
+    <form id="create_update_range_form" method="post" class="form-stacked card card-body bg-light wysiwyg">
         {% csrf_token %}
         {% include "oscar/dashboard/partials/form_fields.html" with form=form %}
         {% block form_actions %}

--- a/src/oscar/templates/oscar/dashboard/ranges/range_product_list.html
+++ b/src/oscar/templates/oscar/dashboard/ranges/range_product_list.html
@@ -61,7 +61,7 @@
 
         <div class="card card-body bg-light">
 
-          <form method="post" class="form-stacked" enctype="multipart/form-data">
+          <form id="add_products_range_form"  method="post" class="form-stacked" enctype="multipart/form-data">
             {% csrf_token %}
             <input type="hidden" name="action" value="add_products"/>
             {% include 'oscar/dashboard/partials/form_fields.html' with form=form %}
@@ -103,7 +103,7 @@
           {% endwith %}
 
           {% if products %}
-          <form method="post">
+          <form id="update_products_range_form" method="post">
             {% csrf_token %}
             <table class="table table-striped table-bordered table-hover">
              <caption>
@@ -171,7 +171,7 @@
 
         <div class="card card-body bg-light">
 
-          <form method="post" class="form-stacked" enctype="multipart/form-data">
+          <form id="add_excluded_products_range_form" method="post" class="form-stacked" enctype="multipart/form-data">
             {% csrf_token %}
             <input type="hidden" name="action" value="add_excluded_products"/>
             {% include 'oscar/dashboard/partials/form_fields.html' with form=form_excluded %}
@@ -213,7 +213,7 @@
           {% endwith %}
 
           {% if range.excluded_products.count %}
-            <form method="post">
+            <form id="remove_excluded_products_range_form" method="post">
               {% csrf_token %}
               <table class="table table-striped table-bordered table-hover">
                <caption>

--- a/src/oscar/templates/oscar/dashboard/reports/index.html
+++ b/src/oscar/templates/oscar/dashboard/reports/index.html
@@ -24,7 +24,7 @@
         <h3><i class="fas fa-chart-bar"></i> {% trans "Reporting dashboard" %}</h3>
     </div>
     <div class="card card-body">
-        <form method="get" class="form-inline">
+        <form id="generate_report_form" method="get" class="form-inline">
             {% include "oscar/dashboard/partials/form_fields_inline.html" with form=form %}
             <span class="form-group">
                 {# data-loading-text is deliberately not used here so that the button doesn't stay disabled after a CSV download has started #}

--- a/src/oscar/templates/oscar/dashboard/reviews/review_delete.html
+++ b/src/oscar/templates/oscar/dashboard/reviews/review_delete.html
@@ -28,7 +28,7 @@
     <div class="table-header">
         <h2>{% trans "Review" %}</h2>
     </div>
-    <form method="post" class="card card-body bg-light">
+    <form id="delete_review_form" method="post" class="card card-body bg-light">
         {% csrf_token %}
 
         <table class="table table-striped table-bordered table-hover">

--- a/src/oscar/templates/oscar/dashboard/reviews/review_list.html
+++ b/src/oscar/templates/oscar/dashboard/reviews/review_list.html
@@ -29,7 +29,7 @@
         <h3><i class="fas fa-search"></i> {% trans "Review Search" %}</h3>
     </div>
     <div class="card card-body">
-        <form method="get" class="form-inline">
+        <form id="search_review_form" method="get" class="form-inline">
             {% include 'oscar/dashboard/partials/form_fields_inline.html' with form=form %}
             <button type="submit" class="btn btn-primary" data-loading-text="{% trans 'Searching...' %}">{% trans "Search" %}</button>
         </form>
@@ -37,7 +37,7 @@
 
     {% if review_list %}
 
-        <form method="post">
+        <form id="update_reviews_form" method="post">
             {% csrf_token %}
             <table class="table table-striped table-bordered table-hover">
                 <caption>

--- a/src/oscar/templates/oscar/dashboard/reviews/review_update.html
+++ b/src/oscar/templates/oscar/dashboard/reviews/review_update.html
@@ -23,7 +23,7 @@
 {% endblock %}
 
 {% block dashboard_content %}
-    <form method="post" class="form-stacked" enctype="multipart/form-data">
+    <form id="create_update_review_form" method="post" class="form-stacked" enctype="multipart/form-data">
         {% csrf_token %}
         <div class="table-header">
             <h3>{% trans "Review information" %}</h3>

--- a/src/oscar/templates/oscar/dashboard/shipping/weight_band_delete.html
+++ b/src/oscar/templates/oscar/dashboard/shipping/weight_band_delete.html
@@ -38,7 +38,7 @@
             </tr>
         </tbody>
     </table>
-    <form method="post" class="card card-body bg-light">
+    <form id="delete_weight_band_form" method="post" class="card card-body bg-light">
         <p>{% trans "Are you sure you want to delete this weight band method?" %}</p>
         {% csrf_token %}
         <div class="form-actions">

--- a/src/oscar/templates/oscar/dashboard/shipping/weight_band_form.html
+++ b/src/oscar/templates/oscar/dashboard/shipping/weight_band_form.html
@@ -25,7 +25,7 @@
 
 {% block dashboard_content %}
     <div class="card card-body bg-light">
-        <form method="post" class="form-stacked">
+        <form id="create_update_weight_band_form" method="post" class="form-stacked">
             {% csrf_token %}
             {% include "oscar/dashboard/partials/form_fields.html" with form=form %}
             {% block form_actions %}

--- a/src/oscar/templates/oscar/dashboard/shipping/weight_based_delete.html
+++ b/src/oscar/templates/oscar/dashboard/shipping/weight_based_delete.html
@@ -21,7 +21,7 @@
 {% endblock %}
 
 {% block dashboard_content %}
-    <form method="post" class="card card-body bg-light">
+    <form id="delete_weight_based_form" method="post" class="card card-body bg-light">
         <p>{% trans "Are you sure you want to delete this shipping method?" %}</p>
         {% csrf_token %}
         <div class="form-actions">

--- a/src/oscar/templates/oscar/dashboard/shipping/weight_based_detail.html
+++ b/src/oscar/templates/oscar/dashboard/shipping/weight_based_detail.html
@@ -85,7 +85,7 @@
         {% endif %}
 
         <h2>{% trans "Add a new weight band" %}</h2>
-        <form method="post">
+        <form id="add_new_weight_band_form" method="post">
             {% csrf_token %}
             {% include "oscar/dashboard/partials/form_fields.html" with form=form %}
             <button type="submit" class="btn btn-primary" data-loading-text="{% trans 'Adding...' %}">{% trans 'Add weight band' %}</button>

--- a/src/oscar/templates/oscar/dashboard/shipping/weight_based_form.html
+++ b/src/oscar/templates/oscar/dashboard/shipping/weight_based_form.html
@@ -35,7 +35,7 @@
 {% endblock %}
 
 {% block dashboard_content %}
-    <form method="post" class="form-stacked card card-body bg-light wysiwyg">
+    <form id="create_update_weight_based_form" method="post" class="form-stacked card card-body bg-light wysiwyg">
         {% csrf_token %}
         {% include "oscar/dashboard/partials/form_fields.html" with form=form %}
         {% block form_actions %}

--- a/src/oscar/templates/oscar/dashboard/users/alerts/delete.html
+++ b/src/oscar/templates/oscar/dashboard/users/alerts/delete.html
@@ -28,7 +28,7 @@
     </div>
     <div class="card card-body bg-light">
         {% include 'oscar/dashboard/users/alerts/partials/alert.html' %}
-        <form method="post">
+        <form id="delete_alert_form" method="post">
             {% csrf_token %}
             <div class="form-actions">
                 <p>{% trans "Are you sure that you want to delete this alert?" %}</p>

--- a/src/oscar/templates/oscar/dashboard/users/alerts/list.html
+++ b/src/oscar/templates/oscar/dashboard/users/alerts/list.html
@@ -26,7 +26,7 @@
         <h3><i class="fas fa-search"></i> {% trans "Search product alerts" %}</h3>
     </div>
     <div class="card card-body">
-        <form method="get" class="form-inline">
+        <form id="search_alert_form" method="get" class="form-inline">
             {% include "oscar/dashboard/partials/form_fields_inline.html" with form=form %}
             <button type="submit" class="btn btn-primary mr-2" data-loading-text="{% trans 'Searching...' %}">{% trans "Search" %}</button>
             {% trans "or" %}

--- a/src/oscar/templates/oscar/dashboard/users/alerts/update.html
+++ b/src/oscar/templates/oscar/dashboard/users/alerts/update.html
@@ -25,7 +25,7 @@
     <div class="table-header">
         <h2 class="float-left">{% blocktrans with id=alert.id %}Product alert #{{ id }}{% endblocktrans %}</h2>
         <div class="float-right">
-            <form method="post" class="form-inline">
+            <form id="update_alert_form" method="post" class="form-inline">
                 {% csrf_token %}
                 {% include 'oscar/dashboard/partials/form_fields_inline.html' %}
                 <button type='submit' class="btn btn-primary" data-loading-text="{% trans 'Saving...' %}">{% trans "Save" %}</button>

--- a/src/oscar/templates/oscar/dashboard/users/index.html
+++ b/src/oscar/templates/oscar/dashboard/users/index.html
@@ -29,7 +29,7 @@
         <h3><i class="fas fa-search"></i> {% trans "Search" %}</h3>
     </div>
     <div class="card card-body">
-        <form method="get" class="form-inline">
+        <form id="search_users_form" method="get" class="form-inline">
             {% include "oscar/dashboard/partials/form_fields_inline.html" with form=form %}
             <button type="submit" name="search" class="btn btn-primary mr-2" data-loading-text="{% trans 'Searching...' %}">{% trans "Search" %}</button>
             <a href="{% url 'dashboard:users-index' %}" class="btn btn-secondary">{% trans "Reset" %}</a>

--- a/src/oscar/templates/oscar/dashboard/vouchers/voucher_delete.html
+++ b/src/oscar/templates/oscar/dashboard/vouchers/voucher_delete.html
@@ -37,7 +37,7 @@
     </div>
     <div class="card card-body bg-light">
         {% include "oscar/dashboard/vouchers/partials/voucher_details_table.html" %}
-        <form method="post">
+        <form id="delete_voucher_form" method="post">
             {% csrf_token %}
             <div class="form-actions">
                 <button class="btn btn-danger" type="submit" data-loading-text="{% trans 'Deleting...' %}">{% trans "Delete" %}</button> {% trans "or" %}

--- a/src/oscar/templates/oscar/dashboard/vouchers/voucher_form.html
+++ b/src/oscar/templates/oscar/dashboard/vouchers/voucher_form.html
@@ -33,7 +33,7 @@
             {% endif %}
         </h2>
     </div>
-    <form method="post" class="card card-body form-stacked">
+    <form id="create_update_voucher_form" method="post" class="card card-body form-stacked">
         {% csrf_token %}
         {% include "oscar/dashboard/partials/form_fields.html" with form=form %}
         {% block form_actions %}

--- a/src/oscar/templates/oscar/dashboard/vouchers/voucher_list.html
+++ b/src/oscar/templates/oscar/dashboard/vouchers/voucher_list.html
@@ -34,7 +34,7 @@
             <h3><i class="fas fa-search"></i> {% trans "Search" %}</h3>
         </div>
         <div class="card card-body bg-light">
-            <form method="get" class="form-inline">
+            <form id="search_voucher_form" method="get" class="form-inline">
                 {% for field in form %}
                     {% if field.name in form.basic_fields %}
                         {% if field.is_hidden %}

--- a/src/oscar/templates/oscar/dashboard/vouchers/voucher_set_delete.html
+++ b/src/oscar/templates/oscar/dashboard/vouchers/voucher_set_delete.html
@@ -29,7 +29,7 @@
     </div>
     <div class="card card-body bg-light">
         {% include "oscar/dashboard/vouchers/partials/voucher_set_details_table.html" %}
-        <form method="post">
+        <form id="delete_voucher_set_form" method="post">
             {% csrf_token %}
             <div class="form-actions">
                 <button class="btn btn-danger" type="submit" data-loading-text="{% trans 'Deleting...' %}">{% trans "Delete" %}</button> {% trans "or" %}

--- a/src/oscar/templates/oscar/dashboard/vouchers/voucher_set_detail.html
+++ b/src/oscar/templates/oscar/dashboard/vouchers/voucher_set_detail.html
@@ -36,7 +36,7 @@
     <h3><i class="fas fa-search"></i> {% trans "Search vouchers" %}</h3>
 </div>
 <div class="card card-body bg-light">
-    <form method="get" class="form-inline">
+    <form id="search_voucher_in_voucherset_form" method="get" class="form-inline">
 		{% include 'oscar/partials/form_fields_inline.html' with form=form %}
 		<button type="submit" class="btn btn-primary">{% trans "Search" %}</button>
 		<a href="{% url 'dashboard:voucher-set-detail' pk=voucher_set.pk %}" class="btn">{% trans "Reset" %}</a>

--- a/src/oscar/templates/oscar/dashboard/vouchers/voucher_set_form.html
+++ b/src/oscar/templates/oscar/dashboard/vouchers/voucher_set_form.html
@@ -33,7 +33,7 @@
             {% endif %}
         </h2>
     </div>
-    <form method="post" class="card card-body form-stacked">
+    <form id="create_update_voucherset_form" method="post" class="card card-body form-stacked">
         {% csrf_token %}
         {% include "oscar/dashboard/partials/form_fields.html" with form=form %}
         {% block form_actions %}

--- a/tests/functional/dashboard/test_catalogue.py
+++ b/tests/functional/dashboard/test_catalogue.py
@@ -123,7 +123,7 @@ class TestAStaffUser(WebTestCase):
         page = self.get(
             reverse("dashboard:catalogue-product-create", args=(product_class.slug,))
         )
-        form = page.form
+        form = page.forms["create_update_product_form"]
         form["upc"] = "123456"
         form["title"] = "new product"
         form["productcategory_set-0-category"] = category.id
@@ -137,7 +137,7 @@ class TestAStaffUser(WebTestCase):
         page = self.get(
             reverse("dashboard:catalogue-product-create", args=(product_class.slug,))
         )
-        form = page.form
+        form = page.forms["create_update_product_form"]
         form["upc"] = "123456"
         form["title"] = "new product"
         form["productcategory_set-0-category"] = category.id
@@ -162,7 +162,7 @@ class TestAStaffUser(WebTestCase):
         page = self.get(
             reverse("dashboard:catalogue-product", kwargs={"pk": product.id})
         )
-        form = page.forms[0]
+        form = page.forms["create_update_product_form"]
         form["productcategory_set-0-category"] = category.id
         self.assertNotEqual(form["title"].value, new_title)
         form["title"] = new_title
@@ -184,7 +184,7 @@ class TestAStaffUser(WebTestCase):
         page = self.get(
             reverse("dashboard:catalogue-product-create", args=(product_class.slug,))
         )
-        form = page.form
+        form = page.forms["create_update_product_form"]
         form["upc"] = "123456"
         form["title"] = "new product"
         form["attr_weight"] = "5"
@@ -198,9 +198,11 @@ class TestAStaffUser(WebTestCase):
         category = Category.add_root(name="Test Category")
         ProductCategory.objects.create(category=category, product=product)
 
-        page = self.get(
-            reverse("dashboard:catalogue-product-delete", args=(product.id,))
-        ).form.submit()
+        page = (
+            self.get(reverse("dashboard:catalogue-product-delete", args=(product.id,)))
+            .forms["delete_product_form"]
+            .submit()
+        )
 
         self.assertRedirects(page, reverse("dashboard:catalogue-product-list"))
         self.assertEqual(Product.objects.count(), 0)
@@ -213,7 +215,7 @@ class TestAStaffUser(WebTestCase):
         create_product(parent=parent_product)
 
         url = reverse("dashboard:catalogue-product-delete", args=(parent_product.id,))
-        page = self.get(url).form.submit()
+        page = self.get(url).forms["delete_product_form"].submit()
 
         self.assertRedirects(page, reverse("dashboard:catalogue-product-list"))
         self.assertEqual(Product.objects.count(), 0)
@@ -223,7 +225,7 @@ class TestAStaffUser(WebTestCase):
         child_product = create_product(parent=parent_product)
 
         url = reverse("dashboard:catalogue-product-delete", args=(child_product.id,))
-        page = self.get(url).form.submit()
+        page = self.get(url).forms["delete_product_form"].submit()
 
         expected_url = reverse(
             "dashboard:catalogue-product", kwargs={"pk": parent_product.pk}
@@ -255,7 +257,7 @@ class TestAStaffUser(WebTestCase):
             "dashboard:catalogue-product-create-child",
             kwargs={"parent_pk": parent_product.pk},
         )
-        form = self.get(url).form
+        form = self.get(url).forms["create_update_product_form"]
         form.submit()
 
         self.assertEqual(Product.objects.count(), 2)

--- a/tests/functional/dashboard/test_catalogue_option.py
+++ b/tests/functional/dashboard/test_catalogue_option.py
@@ -43,7 +43,7 @@ class TestOptionCreateView(PopUpObjectCreateMixin, WebTestCase):
     object_check_str = "Test Option"
 
     def _get_create_obj_response(self):
-        form = self.get(self._get_url()).form
+        form = self.get(self._get_url()).forms["create_update_option_form"]
         form["name"] = self.object_check_str
         return form.submit()
 
@@ -68,7 +68,7 @@ class TestOptionUpdateView(PopUpObjectUpdateMixin, WebTestCase):
         return gettext("Update Option '%s'") % self.obj.name
 
     def _get_update_obj_response(self):
-        form = self.get(self._get_url()).form
+        form = self.get(self._get_url()).forms["create_update_option_form"]
         form["name"] = self.object_check_str
         return form.submit()
 
@@ -93,7 +93,7 @@ class TestOptionDeleteView(PopUpObjectDeleteMixin, WebTestCase):
         return gettext("Delete Option '%s'") % self.obj.name
 
     def _get_delete_obj_response(self):
-        form = self.get(self._get_url()).form
+        form = self.get(self._get_url()).forms["delete_option_form"]
         return form.submit()
 
     def _create_dissalowed_object_factory(self):

--- a/tests/functional/dashboard/test_catalogue_option_group.py
+++ b/tests/functional/dashboard/test_catalogue_option_group.py
@@ -72,7 +72,9 @@ class TestAttributeOptionGroupCreateView(PopUpObjectCreateMixin, WebTestCase):
         self.assertEqual(attribute_option.option, self.attribute_option_option)
 
     def _get_create_obj_response(self):
-        form = self.get(self._get_url()).form
+        form = self.get(self._get_url()).forms[
+            "create_update_attribute_option_group_form"
+        ]
         form["name"] = self.object_check_str
         form["options-0-option"] = self.attribute_option_option
         return form.submit()
@@ -101,7 +103,9 @@ class TestAttributeOptionGroupUpdateView(PopUpObjectUpdateMixin, WebTestCase):
         return gettext("Update Attribute Option Group '%s'") % self.obj.name
 
     def _get_update_obj_response(self):
-        form = self.get(self._get_url()).form
+        form = self.get(self._get_url()).forms[
+            "create_update_attribute_option_group_form"
+        ]
         form["name"] = self.object_check_str
         form["options-0-option"] = self.attribute_option_option
         return form.submit()
@@ -147,7 +151,7 @@ class TestAttributeOptionGroupDeleteView(PopUpObjectDeleteMixin, WebTestCase):
         return gettext("Delete Attribute Option Group '%s'") % self.obj.name
 
     def _get_delete_obj_response(self):
-        form = self.get(self._get_url()).form
+        form = self.get(self._get_url()).forms["attribute_delete_form"]
         return form.submit()
 
     def _create_dissalowed_object_factory(self):

--- a/tests/functional/dashboard/test_category.py
+++ b/tests/functional/dashboard/test_category.py
@@ -20,7 +20,7 @@ class TestCategoryDashboard(WebTestCase):
         category_add = self.app.get(
             reverse("dashboard:catalogue-category-create"), user=self.staff
         )
-        form = category_add.form
+        form = category_add.forms["create_update_category_form"]
         form["name"] = "Top-level category"
         form["_position"] = "right"
         form["_ref_node_id"] = a.id
@@ -33,7 +33,7 @@ class TestCategoryDashboard(WebTestCase):
         category_add = self.app.get(
             reverse("dashboard:catalogue-category-create"), user=self.staff
         )
-        form = category_add.form
+        form = category_add.forms["create_update_category_form"]
         form["name"] = "Child category"
         form["_position"] = "left"
         form["_ref_node_id"] = c.id
@@ -46,5 +46,5 @@ class TestCategoryDashboard(WebTestCase):
         dashboard_index = self.app.get(reverse("dashboard:index"), user=self.staff)
         category_index = dashboard_index.click("Categories")
         category_add = category_index.click("Create new category")
-        response = category_add.form.submit()
+        response = category_add.forms["create_update_category_form"].submit()
         self.assertEqual(200, response.status_code)

--- a/tests/functional/dashboard/test_communication.py
+++ b/tests/functional/dashboard/test_communication.py
@@ -23,7 +23,7 @@ class TestAnAdmin(WebTestCase):
     def test_can_preview_an_email(self):
         list_page = self.app.get(reverse("dashboard:comms-list"), user=self.staff)
         update_page = list_page.click("Edit")
-        form = update_page.form
+        form = update_page.forms["update_communication_event_form"]
         form["email_subject_template"] = "Hello {{ user.username }}"
         form["email_body_template"] = "Hello {{ user.username }}"
         form["email_body_html_template"] = "Hello {{ user.username }}"
@@ -33,7 +33,7 @@ class TestAnAdmin(WebTestCase):
     def test_can_send_a_preview_email(self):
         list_page = self.app.get(reverse("dashboard:comms-list"), user=self.staff)
         update_page = list_page.click("Edit")
-        form = update_page.form
+        form = update_page.forms["update_communication_event_form"]
         form["email_subject_template"] = "Hello {{ user.username }}"
         form["email_body_template"] = "Hello {{ user.username }}"
         form["email_body_html_template"] = "Hello {{ user.username }}"

--- a/tests/functional/dashboard/test_offer.py
+++ b/tests/functional/dashboard/test_offer.py
@@ -24,24 +24,24 @@ class TestAnAdmin(testcases.WebTestCase):
         list_page = self.get(reverse("dashboard:offer-list"))
 
         metadata_page = list_page.click("Create new offer")
-        metadata_form = metadata_page.form
+        metadata_form = metadata_page.forms["create_update_offer_step_form"]
         metadata_form["name"] = "Test offer"
         metadata_form["offer_type"] = models.ConditionalOffer.SITE
 
         benefit_page = metadata_form.submit().follow()
-        benefit_form = benefit_page.form
+        benefit_form = benefit_page.forms["create_update_offer_step_form"]
         benefit_form["range"] = self.range.id
         benefit_form["type"] = "Percentage"
         benefit_form["value"] = "25"
 
         condition_page = benefit_form.submit().follow()
-        condition_form = condition_page.form
+        condition_form = condition_page.forms["create_update_offer_step_form"]
         condition_form["range"] = self.range.id
         condition_form["type"] = "Count"
         condition_form["value"] = "3"
 
         restrictions_page = condition_form.submit().follow()
-        restrictions_page.form.submit()
+        restrictions_page.forms["create_update_offer_step_form"].submit()
 
         offers = models.ConditionalOffer.objects.all()
         self.assertEqual(1, len(offers))
@@ -54,7 +54,7 @@ class TestAnAdmin(testcases.WebTestCase):
         offer = factories.create_offer(name="Offer A")
 
         list_page = self.get(reverse("dashboard:offer-list"))
-        form = list_page.forms[0]
+        form = list_page.forms["search_offers_form"]
         form["name"] = "I do not exist"
         res = form.submit()
         self.assertTrue("No offers found" in res.text)
@@ -94,18 +94,18 @@ class TestAnAdmin(testcases.WebTestCase):
         detail_page = list_page.click("Offer A")
 
         metadata_page = detail_page.click(linkid="edit_metadata")
-        metadata_form = metadata_page.form
+        metadata_form = metadata_page.forms["create_update_offer_step_form"]
         metadata_form["name"] = "Offer A+"
         metadata_form["offer_type"] = models.ConditionalOffer.SITE
 
         benefit_page = metadata_form.submit().follow()
-        benefit_form = benefit_page.form
+        benefit_form = benefit_page.forms["create_update_offer_step_form"]
 
         condition_page = benefit_form.submit().follow()
-        condition_form = condition_page.form
+        condition_form = condition_page.forms["create_update_offer_step_form"]
 
         restrictions_page = condition_form.submit().follow()
-        restrictions_page.form.submit()
+        restrictions_page.forms["create_update_offer_step_form"].submit()
 
         models.ConditionalOffer.objects.get(name="Offer A+")
 
@@ -116,7 +116,11 @@ class TestAnAdmin(testcases.WebTestCase):
         name_and_description_page = self.get(
             reverse("dashboard:offer-metadata", kwargs={"pk": offer.pk})
         )
-        res = name_and_description_page.form.submit("save").follow()
+        res = (
+            name_and_description_page.forms["create_update_offer_step_form"]
+            .submit("save")
+            .follow()
+        )
         self.assertEqual(200, res.status_code)
 
     def test_can_jump_to_intermediate_step_for_existing_offer(self):
@@ -167,8 +171,8 @@ class TestAnAdmin(testcases.WebTestCase):
         restrictions_page = self.get(
             reverse("dashboard:offer-restrictions", kwargs={"pk": offer.pk})
         )
-        restrictions_page.form["priority"] = "12"
-        restrictions_page.form.submit()
+        restrictions_page.forms["create_update_offer_step_form"]["priority"] = "12"
+        restrictions_page.forms["create_update_offer_step_form"].submit()
         offer.refresh_from_db()
 
         self.assertEqual(offer.priority, 12)
@@ -177,12 +181,12 @@ class TestAnAdmin(testcases.WebTestCase):
         list_page = self.get(reverse("dashboard:offer-list"))
 
         metadata_page = list_page.click("Create new offer")
-        metadata_form = metadata_page.form
+        metadata_form = metadata_page.forms["create_update_offer_step_form"]
         metadata_form["name"] = "Test offer"
         metadata_form["offer_type"] = models.ConditionalOffer.SITE
 
         benefit_page = metadata_form.submit().follow()
-        benefit_form = benefit_page.form
+        benefit_form = benefit_page.forms["create_update_offer_step_form"]
         benefit_form["range"] = self.range.id
         benefit_form["type"] = "Percentage"
         benefit_form["value"] = "25"
@@ -199,18 +203,18 @@ class TestAnAdmin(testcases.WebTestCase):
         list_page = self.get(reverse("dashboard:offer-list"))
 
         metadata_page = list_page.click("Create new offer")
-        metadata_form = metadata_page.form
+        metadata_form = metadata_page.forms["create_update_offer_step_form"]
         metadata_form["name"] = "Test offer"
         metadata_form["offer_type"] = models.ConditionalOffer.SITE
 
         benefit_page = metadata_form.submit().follow()
-        benefit_form = benefit_page.form
+        benefit_form = benefit_page.forms["create_update_offer_step_form"]
         benefit_form["range"] = self.range.id
         benefit_form["type"] = "Percentage"
         benefit_form["value"] = "25"
 
         condition_page = benefit_form.submit().follow()
-        condition_form = condition_page.form
+        condition_form = condition_page.forms["create_update_offer_step_form"]
         condition_form["range"] = self.range.id
         condition_form["type"] = "Count"
         condition_form["value"] = "3"
@@ -248,17 +252,19 @@ class TestAnAdmin(testcases.WebTestCase):
         restrictions_page = self.get(
             reverse("dashboard:offer-restrictions", kwargs={"pk": offer_a.pk})
         )
-        restrictions_page.form["exclusive"] = False
-        restrictions_page.form["combinations"] = [offer_b.id]
-        restrictions_page.form.submit()
+        restrictions_page.forms["create_update_offer_step_form"]["exclusive"] = False
+        restrictions_page.forms["create_update_offer_step_form"]["combinations"] = [
+            offer_b.id
+        ]
+        restrictions_page.forms["create_update_offer_step_form"].submit()
 
         self.assertIn(offer_a, offer_b.combinations.all())
 
         restrictions_page = self.get(
             reverse("dashboard:offer-restrictions", kwargs={"pk": offer_a.pk})
         )
-        restrictions_page.form["combinations"] = []
-        restrictions_page.form.submit()
+        restrictions_page.forms["create_update_offer_step_form"]["combinations"] = []
+        restrictions_page.forms["create_update_offer_step_form"].submit()
 
         self.assertNotIn(offer_a, offer_b.combinations.all())
 

--- a/tests/functional/dashboard/test_page.py
+++ b/tests/functional/dashboard/test_page.py
@@ -38,14 +38,14 @@ class TestPageDashboard(WebTestCase):
     def test_dashboard_delete_pages(self):
         page = self.get(reverse("dashboard:page-list"))
         delete_page = page.click(linkid="delete_page_%s" % self.flatpage_1.id)
-        response = delete_page.form.submit()
+        response = delete_page.forms["delete_page_form"].submit()
 
         self.assertIsRedirect(response)
         self.assertEqual(FlatPage.objects.count(), 1)
 
     def test_dashboard_create_page_with_slugified_url(self):
         page = self.get(reverse("dashboard:page-create"))
-        form = page.form
+        form = page.forms["create_update_page_form"]
         form["title"] = "test"
         form["content"] = "my content here"
         response = form.submit()
@@ -54,7 +54,7 @@ class TestPageDashboard(WebTestCase):
 
     def test_dashboard_create_page_with_duplicate_slugified_url_fails(self):
         page = self.get(reverse("dashboard:page-create"))
-        form = page.form
+        form = page.forms["create_update_page_form"]
         form["title"] = "url1"  # This will slugify to url1
         form["content"] = "my content here"
         response = form.submit()
@@ -63,7 +63,7 @@ class TestPageDashboard(WebTestCase):
 
     def test_default_site_added_for_new_pages(self):
         page = self.get(reverse("dashboard:page-create"))
-        form = page.form
+        form = page.forms["create_update_page_form"]
         form["title"] = "test"
         form["url"] = "/hello-world/"
         form.submit()

--- a/tests/functional/dashboard/test_partner.py
+++ b/tests/functional/dashboard/test_partner.py
@@ -18,7 +18,7 @@ class TestPartnerDashboard(WebTestCase):
         list_page = self.get(url)
         detail_page = list_page.click("Manage partner and users")
         user_page = detail_page.click("Link a new user")
-        form = user_page.form
+        form = user_page.forms["user_partner_form"]
         form["first_name"] = "Maik"
         form["last_name"] = "Hoepfel"
         form["email"] = "maik@gmail.com"

--- a/tests/functional/dashboard/test_product.py
+++ b/tests/functional/dashboard/test_product.py
@@ -82,7 +82,7 @@ class TestCreateParentProduct(ProductWebTest):
             kwargs={"product_class_slug": self.pclass.slug},
         )
 
-        product_form = self.get(url).form
+        product_form = self.get(url).forms["create_update_product_form"]
 
         product_form["title"] = title
         product_form["upc"] = upc
@@ -137,7 +137,7 @@ class TestCreateChildProduct(ProductWebTest):
         )
         page = self.get(url)
 
-        product_form = page.form
+        product_form = page.forms["create_update_product_form"]
         product_form["title"] = expected_title = "Nice T-Shirt"
         product_form.submit()
 
@@ -156,7 +156,7 @@ class TestProductUpdate(ProductWebTest):
         url = reverse("dashboard:catalogue-product", kwargs={"pk": self.product.id})
 
         page = self.get(url)
-        product_form = page.form
+        product_form = page.forms["create_update_product_form"]
         product_form["title"] = expected_title = "Nice T-Shirt"
         page = product_form.submit()
 
@@ -194,7 +194,7 @@ class TestProductClass(ProductWebTest):
 
     def test_product_update_attribute_values(self):
         page = self.get(self.url)
-        product_form = page.form
+        product_form = page.forms["create_update_product_form"]
         # Send string field values due to an error
         # in the Webtest during multipart form encode.
         product_form["attr_text"] = "test1"
@@ -231,7 +231,7 @@ class TestProductClass(ProductWebTest):
             self.assertEqual(image1_file.read(), image1.content)
 
         page = self.get(self.url)
-        product_form = page.form
+        product_form = page.forms["create_update_product_form"]
         product_form["attr_text"] = "test2"
         product_form["attr_integer"] = "2"
         product_form["attr_float"] = "5.2"
@@ -273,7 +273,7 @@ class TestProductImages(ProductWebTest):
 
     def test_product_images_upload(self):
         page = self.get(self.url)
-        product_form = page.form
+        product_form = page.forms["create_update_product_form"]
         image1 = Upload("image1.png", generate_test_image(), "image/png")
         image2 = Upload("image2.png", generate_test_image(), "image/png")
         image3 = Upload("image3.png", generate_test_image(), "image/png")
@@ -284,7 +284,7 @@ class TestProductImages(ProductWebTest):
         self.product = Product.objects.get(pk=self.product.id)
         self.assertEqual(self.product.images.count(), 2)
         page = self.get(self.url)
-        product_form = page.form
+        product_form = page.forms["create_update_product_form"]
         product_form["images-2-original"] = image3
         product_form.submit()
         self.product = Product.objects.get(pk=self.product.id)
@@ -319,7 +319,7 @@ class TestProductImages(ProductWebTest):
         )
 
         page = self.get(self.url)
-        product_form = page.form
+        product_form = page.forms["create_update_product_form"]
         product_form["images-1-display_order"] = "3"  # 1 is im2
         product_form["images-2-display_order"] = "4"  # 2 is im3
         product_form["images-0-display_order"] = "5"  # 0 is im1

--- a/tests/functional/dashboard/test_range.py
+++ b/tests/functional/dashboard/test_range.py
@@ -92,7 +92,7 @@ class RangeProductViewTest(WebTestCase):
 
     def test_upload_file_with_skus(self):
         range_products_page = self.get(self.url)
-        form = range_products_page.forms[0]
+        form = range_products_page.forms["add_products_range_form"]
         form["file_upload"] = Upload("new_skus.txt", b"456")
         form.submit().follow()
         all_products = self.range.all_products()
@@ -113,7 +113,7 @@ class RangeProductViewTest(WebTestCase):
 
         # Upload the product
         range_products_page = self.get(self.url)
-        form = range_products_page.forms[1]
+        form = range_products_page.forms["add_excluded_products_range_form"]
         form["file_upload"] = Upload("new_skus.txt", b"456")
         form.submit().follow()
 
@@ -137,7 +137,7 @@ class RangeProductViewTest(WebTestCase):
 
         # Upload the products
         range_products_page = self.get(self.url)
-        form = range_products_page.forms[1]
+        form = range_products_page.forms["add_excluded_products_range_form"]
         form["file_upload"] = Upload("new_skus.txt", b"456,789")
         form.submit().follow()
 
@@ -160,7 +160,7 @@ class RangeProductViewTest(WebTestCase):
         self.assertFalse(self.product3 in excluded_products)
 
         range_products_page = self.get(self.url)
-        form = range_products_page.forms[1]
+        form = range_products_page.forms["add_excluded_products_range_form"]
         form["query"] = "456"
         form.submit().follow()
 
@@ -175,7 +175,7 @@ class RangeProductViewTest(WebTestCase):
         self.assertFalse(self.product4 in excluded_products)
 
         range_products_page = self.get(self.url)
-        form = range_products_page.forms[1]
+        form = range_products_page.forms["add_excluded_products_range_form"]
         form["query"] = "456,789"
         form.submit().follow()
 
@@ -187,7 +187,7 @@ class RangeProductViewTest(WebTestCase):
     def test_dupe_skus_warning(self):
         self.range.add_product(self.product3)
         range_products_page = self.get(self.url)
-        form = range_products_page.forms[0]
+        form = range_products_page.forms["add_products_range_form"]
         form["query"] = "456"
         response = form.submit()
         self.assertEqual(list(response.context["messages"]), [])
@@ -198,7 +198,7 @@ class RangeProductViewTest(WebTestCase):
             ],
         )
 
-        form = response.forms[0]
+        form = response.forms["add_products_range_form"]
         form["query"] = "456, 789"
         response = form.submit().follow()
         messages = list(response.context["messages"])
@@ -216,7 +216,7 @@ class RangeProductViewTest(WebTestCase):
         self.range.add_product(self.product4)
         self.range.excluded_products.add(self.product3)
         range_products_page = self.get(self.url)
-        form = range_products_page.forms[2]
+        form = range_products_page.forms["add_excluded_products_range_form"]
         form["query"] = "456"
         response = form.submit()
         self.assertEqual(list(response.context["messages"]), [])
@@ -227,7 +227,7 @@ class RangeProductViewTest(WebTestCase):
             ],
         )
 
-        form = response.forms[2]
+        form = response.forms["add_excluded_products_range_form"]
         form["query"] = "456, 789"
         response = form.submit().follow()
         messages = list(response.context["messages"])
@@ -244,7 +244,7 @@ class RangeProductViewTest(WebTestCase):
 
     def test_missing_skus_warning(self):
         range_products_page = self.get(self.url)
-        form = range_products_page.forms[0]
+        form = range_products_page.forms["add_products_range_form"]
         form["query"] = "321"
         response = form.submit()
         self.assertEqual(list(response.context["messages"]), [])
@@ -252,7 +252,7 @@ class RangeProductViewTest(WebTestCase):
             response.context["form"].errors["query"],
             ["No products exist with a SKU or UPC matching 321"],
         )
-        form = range_products_page.forms[0]
+        form = range_products_page.forms["add_products_range_form"]
         form["query"] = "456, 321"
         response = form.submit().follow()
         messages = list(response.context["messages"])
@@ -266,7 +266,7 @@ class RangeProductViewTest(WebTestCase):
 
     def test_same_skus_within_different_products_warning_query(self):
         range_products_page = self.get(self.url)
-        form = range_products_page.forms[0]
+        form = range_products_page.forms["add_products_range_form"]
         form["query"] = "123123"
         response = form.submit().follow()
         messages = list(response.context["messages"])
@@ -278,7 +278,7 @@ class RangeProductViewTest(WebTestCase):
 
     def test_same_skus_within_different_products_warning_file_upload(self):
         range_products_page = self.get(self.url)
-        form = range_products_page.forms[0]
+        form = range_products_page.forms["add_products_range_form"]
         form["file_upload"] = Upload("skus.txt", b"123123")
         response = form.submit().follow()
         messages = list(response.context["messages"])
@@ -290,7 +290,7 @@ class RangeProductViewTest(WebTestCase):
 
     def test_adding_child_does_not_add_parent(self):
         range_products_page = self.get(self.url)
-        form = range_products_page.forms[0]
+        form = range_products_page.forms["add_products_range_form"]
         form["query"] = "1234.345"
         form.submit().follow()
         all_products = self.range.all_products()
@@ -299,7 +299,7 @@ class RangeProductViewTest(WebTestCase):
         self.assertTrue(self.range.contains_product(self.child1))
         self.assertFalse(self.range.contains_product(self.child2))
 
-        form = range_products_page.forms[0]
+        form = range_products_page.forms["add_products_range_form"]
         form["query"] = "1234-345"
         form.submit().follow()
         all_products = self.range.all_products()
@@ -310,7 +310,7 @@ class RangeProductViewTest(WebTestCase):
 
     def test_adding_multiple_children_does_not_add_parent(self):
         range_products_page = self.get(self.url)
-        form = range_products_page.forms[0]
+        form = range_products_page.forms["add_products_range_form"]
         form["query"] = "1234.345 1234-345"
         form.submit().follow()
         all_products = self.range.all_products()
@@ -321,7 +321,7 @@ class RangeProductViewTest(WebTestCase):
 
     def test_adding_multiple_comma_separated_children_does_not_add_parent(self):
         range_products_page = self.get(self.url)
-        form = range_products_page.forms[0]
+        form = range_products_page.forms["add_products_range_form"]
         form["query"] = "1234.345, 1234-345"
         form.submit().follow()
         all_products = self.range.all_products()
@@ -333,7 +333,7 @@ class RangeProductViewTest(WebTestCase):
     def test_remove_selected_product(self):
         self.range.add_product(self.product3)
         range_products_page = self.get(self.url)
-        form = range_products_page.forms[1]
+        form = range_products_page.forms["update_products_range_form"]
         form["selected_product"] = "456"
         response = form.submit().follow()
         messages = list(response.context["messages"])
@@ -350,7 +350,7 @@ class RangeProductViewTest(WebTestCase):
 
         # Remove the product from exclusion form
         range_products_page = self.get(self.url)
-        form = range_products_page.forms[2]
+        form = range_products_page.forms["remove_excluded_products_range_form"]
         form["selected_product"] = "456"
         response = form.submit().follow()
 
@@ -366,7 +366,7 @@ class RangeProductViewTest(WebTestCase):
         self.assertIn(self.product4, self.range.excluded_products.all())
 
         range_products_page = self.get(self.url)
-        form = range_products_page.forms[2]
+        form = range_products_page.forms["remove_excluded_products_range_form"]
         form["selected_product"] = [self.product3.pk, self.product4.pk]
         response = form.submit().follow()
 

--- a/tests/functional/dashboard/test_reports.py
+++ b/tests/functional/dashboard/test_reports.py
@@ -19,27 +19,27 @@ class ReportsDashboardTests(WebTestCase):
         url = reverse("dashboard:reports-index")
         response = self.get(url)
 
-        response.form["report_type"] = "conditional-offers"
-        response.form.submit()
+        response.forms["generate_report_form"]["report_type"] = "conditional-offers"
+        response.forms["generate_report_form"].submit()
         self.assertIsOk(response)
 
     def test_conditional_offers_with_date_range(self):
         url = reverse("dashboard:reports-index")
         response = self.get(url)
 
-        response.form["report_type"] = "conditional-offers"
-        response.form["date_from"] = "2017-01-01"
-        response.form["date_to"] = "2017-12-31"
-        response.form.submit()
+        response.forms["generate_report_form"]["report_type"] = "conditional-offers"
+        response.forms["generate_report_form"]["date_from"] = "2017-01-01"
+        response.forms["generate_report_form"]["date_to"] = "2017-12-31"
+        response.forms["generate_report_form"].submit()
         self.assertIsOk(response)
 
     def test_conditional_offers_with_date_range_download(self):
         url = reverse("dashboard:reports-index")
         response = self.get(url)
 
-        response.form["report_type"] = "conditional-offers"
-        response.form["date_from"] = "2017-01-01"
-        response.form["date_to"] = "2017-12-31"
-        response.form["download"] = "true"
-        response.form.submit()
+        response.forms["generate_report_form"]["report_type"] = "conditional-offers"
+        response.forms["generate_report_form"]["date_from"] = "2017-01-01"
+        response.forms["generate_report_form"]["date_to"] = "2017-12-31"
+        response.forms["generate_report_form"]["download"] = "true"
+        response.forms["generate_report_form"].submit()
         self.assertIsOk(response)

--- a/tests/functional/dashboard/test_review.py
+++ b/tests/functional/dashboard/test_review.py
@@ -33,7 +33,7 @@ class ReviewsDashboardTests(WebTestCase):
         assert ProductReview.objects.count() == 3
 
         list_page = self.get(reverse("dashboard:reviews-list"))
-        form = list_page.forms[1]
+        form = list_page.forms["update_reviews_form"]
         form["selected_review"] = [3, 2]
         form.submit("update")
 

--- a/tests/functional/dashboard/test_shipping.py
+++ b/tests/functional/dashboard/test_shipping.py
@@ -18,30 +18,38 @@ class TestShippingMethodDashboard(WebTestCase):
 
         # Create a shipping method
         create_page = list_page.click(linkid="create_new_shipping_method")
-        create_page.form["name"] = "My method"
-        detail_page = create_page.form.submit().follow()
+        create_page.forms["create_update_weight_based_form"]["name"] = "My method"
+        detail_page = (
+            create_page.forms["create_update_weight_based_form"].submit().follow()
+        )
         self.assertInContext(detail_page, "method")
         self.assertEqual(1, models.WeightBased.objects.all().count())
         method = models.WeightBased.objects.all()[0]
 
         # Edit shipping method
         edit_page = detail_page.click(linkid="edit_method")
-        edit_page.form["name"] = "My new method"
-        reloaded_detail_page = edit_page.form.submit().follow()
+        edit_page.forms["create_update_weight_based_form"]["name"] = "My new method"
+        reloaded_detail_page = (
+            edit_page.forms["create_update_weight_based_form"].submit().follow()
+        )
         reloaded_method = models.WeightBased.objects.get(id=method.id)
         self.assertEqual("My new method", reloaded_method.name)
 
         # Add a weight band
-        reloaded_detail_page.form["upper_limit"] = "0.1"
-        reloaded_detail_page.form["charge"] = "2.99"
-        reloaded_detail_page = reloaded_detail_page.form.submit().follow()
+        reloaded_detail_page.forms["add_new_weight_band_form"]["upper_limit"] = "0.1"
+        reloaded_detail_page.forms["add_new_weight_band_form"]["charge"] = "2.99"
+        reloaded_detail_page = (
+            reloaded_detail_page.forms["add_new_weight_band_form"].submit().follow()
+        )
         self.assertEqual(1, method.bands.all().count())
         band = method.bands.all()[0]
 
         # Edit weight band
         edit_band_page = reloaded_detail_page.click(linkid="edit_band_%s" % band.id)
-        edit_band_page.form["charge"] = "3.99"
-        reloaded_detail_page = edit_band_page.form.submit().follow()
+        edit_band_page.forms["create_update_weight_band_form"]["charge"] = "3.99"
+        reloaded_detail_page = (
+            edit_band_page.forms["create_update_weight_band_form"].submit().follow()
+        )
         reloaded_band = method.bands.get(id=band.id)
         self.assertEqual(D("3.99"), reloaded_band.charge)
 
@@ -49,10 +57,12 @@ class TestShippingMethodDashboard(WebTestCase):
         delete_band_page = reloaded_detail_page.click(
             linkid="delete_band_%s" % reloaded_band.id
         )
-        reloaded_detail_page = delete_band_page.form.submit().follow()
+        reloaded_detail_page = (
+            delete_band_page.forms["delete_weight_band_form"].submit().follow()
+        )
         self.assertEqual(0, method.bands.all().count())
 
         # Delete shipping method
         delete_page = reloaded_detail_page.click(linkid="delete_method")
-        delete_page.form.submit().follow()
+        delete_page.forms["delete_weight_based_form"].submit().follow()
         self.assertEqual(0, models.WeightBased.objects.all().count())

--- a/tests/functional/dashboard/test_user.py
+++ b/tests/functional/dashboard/test_user.py
@@ -135,7 +135,7 @@ class SearchTests(WebTestCase):
 
     def _search_by_form_args(self, form_args):
         response = self.get(self.url)
-        search_form = response.forms[0]
+        search_form = response.forms["search_users_form"]
         for field_name, val in form_args.items():
             search_form[field_name] = val
         search_response = search_form.submit("search")


### PR DESCRIPTION
Django 5 removed support for logging out users through a GET request.

The frontend uses a custom logout view, which we might need to deprecate too. But this should be done gracefully as it could break existing sites.

So this should be done in another PR.

It's not really a security risk, as an attacker could only logout the user and that's it. But it's best to do it the django way.