### PR TITLE
Avoid crash when Benefit.range is None

### DIFF
--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -82,7 +82,10 @@ class BaseOfferMixin(models.Model):
         A description of the benefit/condition.
         Defaults to the name. May contain HTML.
         """
-        return self.name
+        try:
+            return self.name
+        except AttributeError:
+            pass
 
 
 class AbstractConditionalOffer(models.Model):

--- a/tests/functional/test_offer.py
+++ b/tests/functional/test_offer.py
@@ -35,3 +35,13 @@ class TestRangeDetailsPageWithUnicodeSlug(TestCase):
     def test_url_with_unicode_characters(self):
         response = self.client.get(f"/catalogue/ranges/{self.slug}/")
         self.assertEqual(200, response.status_code)
+
+
+class TestBenefitDescription(TestCase):
+    """
+    Tests Benefit description fallback for missing value.
+    """
+
+    def test_description_returns_fallback_if_range_is_none(self):
+        benefit = BenefitFactory(type="Percentage", value=10, range=None)
+        self.assertIsNone(benefit.description)


### PR DESCRIPTION
## Description
This PR resolves: https://github.com/django-oscar/django-oscar/issues/4482

When saving an edited Incentive offer form without providing a "Range" value, a 500 Internal Server Error is raised. This happens because the name property in the PercentageDiscountBenefit class tries to access:
`self._description % {"value": self.value, "range": self.range.name}`

If self.range is None, this raises an AttributeError, since None has no .name.
The error originates from the `description` property in `BaseOfferMixin`, which calls self.name. Because of the missing range, it fails before validation logic (like clean()) can run and display a user-friendly error.

## Fix
Update the `description` property in `BaseOfferMixin` to safely handle attribute errors by wrapping the call in a try block. This allows `clean()` to execute and return a proper validation error message instead of a server error:

## Result
<img width="1384" alt="Screenshot 2025-07-08 at 1 59 55 PM" src="https://github.com/user-attachments/assets/3243bd9f-2b2c-4e62-8671-75e0e4fe69c2" />
