### PR TITLE
Add custom granular permission checks for dashboards

### DIFF
--- a/src/oscar/apps/dashboard/catalogue/apps.py
+++ b/src/oscar/apps/dashboard/catalogue/apps.py
@@ -18,54 +18,82 @@ class CatalogueDashboardConfig(OscarDashboardConfig):
         DashboardPermission = get_class("dashboard.permissions", "DashboardPermission")
 
         self.permissions_map = {
+            # Product views
             "catalogue-product": (
-                DashboardPermission.get("product"),
+                DashboardPermission.get("view-product"),
                 DashboardPermission.partner_dashboard_access,
             ),
             "catalogue-product-create": (
-                DashboardPermission.get("product"),
+                DashboardPermission.get("view-product", "add-product"),
                 DashboardPermission.partner_dashboard_access,
             ),
             "catalogue-product-list": (
-                DashboardPermission.get("product"),
+                DashboardPermission.get("view-product"),
                 DashboardPermission.partner_dashboard_access,
             ),
             "catalogue-product-delete": (
-                DashboardPermission.get("product"),
+                DashboardPermission.get("delete-product"),
                 DashboardPermission.partner_dashboard_access,
             ),
             "catalogue-product-lookup": (
-                DashboardPermission.get("product"),
+                DashboardPermission.get("view-product"),
                 DashboardPermission.partner_dashboard_access,
             ),
-            "catalogue-product-create-child": DashboardPermission.get("product"),
-            "stock-alert-list": DashboardPermission.get("stockalert"),
-            "catalogue-category-list": DashboardPermission.get("category"),
-            "catalogue-category-detail-list": DashboardPermission.get("category"),
-            "catalogue-category-create": DashboardPermission.get("category"),
-            "catalogue-category-create-child": DashboardPermission.get("category"),
-            "catalogue-category-update": DashboardPermission.get("category"),
-            "catalogue-category-delete": DashboardPermission.get("category"),
-            "catalogue-class-create": DashboardPermission.get("product_class"),
-            "catalogue-class-list": DashboardPermission.get("product_class"),
-            "catalogue-class-update": DashboardPermission.get("product_class"),
-            "catalogue-class-delete": DashboardPermission.get("product_class"),
-            "catalogue-attribute-option-group-create": DashboardPermission.get(
-                "attribute_option_group"
+            "catalogue-product-create-child": DashboardPermission.get(
+                "view-product", "add-product"
             ),
+            # Stock alerts
+            "stock-alert-list": DashboardPermission.get("view-stockalert"),
+            # Category views
+            "catalogue-category-list": DashboardPermission.get("view-category"),
+            "catalogue-category-detail-list": DashboardPermission.get("view-category"),
+            "catalogue-category-create": DashboardPermission.get("add-category"),
+            "catalogue-category-create-child": DashboardPermission.get("add-category"),
+            "catalogue-category-update": DashboardPermission.get("change-category"),
+            "catalogue-category-delete": DashboardPermission.get("delete-category"),
+            # Product class views
+            "catalogue-class-create": DashboardPermission.get("add-productclass"),
+            "catalogue-class-list": DashboardPermission.get("view-productclass"),
+            "catalogue-class-update": DashboardPermission.get("change-productclass"),
+            "catalogue-class-delete": DashboardPermission.get("delete-productclass"),
+            # Attribute option group views
             "catalogue-attribute-option-group-list": DashboardPermission.get(
-                "attribute_option_group"
+                "view-attributeoptiongroup"
+            ),
+            "catalogue-attribute-option-group-create": DashboardPermission.get(
+                "view-attributeoptiongroup", "add-attributeoptiongroup"
             ),
             "catalogue-attribute-option-group-update": DashboardPermission.get(
-                "attribute_option_group"
+                "view-attributeoptiongroup", "change-attributeoptiongroup"
             ),
             "catalogue-attribute-option-group-delete": DashboardPermission.get(
-                "attribute_option_group"
+                "view-attributeoptiongroup", "delete-attributeoptiongroup"
             ),
-            "catalogue-option-list": DashboardPermission.get("option"),
-            "catalogue-option-create": DashboardPermission.get("option"),
-            "catalogue-option-update": DashboardPermission.get("option"),
-            "catalogue-option-delete": DashboardPermission.get("option"),
+            # Option views
+            "catalogue-option-list": DashboardPermission.get("view-option"),
+            "catalogue-option-create": DashboardPermission.get(
+                "view-option", "add-option"
+            ),
+            "catalogue-option-update": DashboardPermission.get(
+                "view-option", "change-option"
+            ),
+            "catalogue-option-delete": DashboardPermission.get(
+                "view-option", "delete-option"
+            ),
+            # Offer views
+            "offer-list": DashboardPermission.get("view-offer"),
+            "offer-metadata": DashboardPermission.get("add-offer", "change-offer"),
+            "offer-condition": DashboardPermission.get("add-offer", "change-offer"),
+            "offer-benefit": DashboardPermission.get("add-offer", "change-offer"),
+            "offer-restrictions": DashboardPermission.get("add-offer", "change-offer"),
+            "offer-delete": DashboardPermission.get("delete-offer"),
+            "offer-detail": DashboardPermission.get("view-offer"),
+            # Range views
+            "range-list": DashboardPermission.get("view-range"),
+            "range-create": DashboardPermission.get("add-range"),
+            "range-update": DashboardPermission.get("change-range"),
+            "range-delete": DashboardPermission.get("delete-range"),
+            "range-products": DashboardPermission.get("change-range"),
         }
 
     # pylint: disable=attribute-defined-outside-init

--- a/src/oscar/apps/dashboard/communications/apps.py
+++ b/src/oscar/apps/dashboard/communications/apps.py
@@ -18,8 +18,8 @@ class CommunicationsDashboardConfig(OscarDashboardConfig):
         DashboardPermission = get_class("dashboard.permissions", "DashboardPermission")
 
         self.permissions_map = {
-            "comms-list": DashboardPermission.get("communication_event_type"),
-            "comms-update": DashboardPermission.get("communication_event_type"),
+            "comms-list": DashboardPermission.get("view-communication_event_type"),
+            "comms-update": DashboardPermission.get("change-communication_event_type"),
         }
 
     # pylint: disable=attribute-defined-outside-init

--- a/src/oscar/apps/dashboard/offers/apps.py
+++ b/src/oscar/apps/dashboard/offers/apps.py
@@ -18,13 +18,13 @@ class OffersDashboardConfig(OscarDashboardConfig):
         DashboardPermission = get_class("dashboard.permissions", "DashboardPermission")
 
         self.permissions_map = {
-            "offer-list": DashboardPermission.get("offer"),
-            "offer-metadata": DashboardPermission.get("offer"),
-            "offer-condition": DashboardPermission.get("offer"),
-            "offer-benefit": DashboardPermission.get("offer"),
-            "offer-restrictions": DashboardPermission.get("offer"),
-            "offer-delete": DashboardPermission.get("offer"),
-            "offer-detail": DashboardPermission.get("offer"),
+            "offer-list": DashboardPermission.get("view-offer"),
+            "offer-metadata": DashboardPermission.get("add-offer", "change-offer"),
+            "offer-condition": DashboardPermission.get("add-offer", "change-offer"),
+            "offer-benefit": DashboardPermission.get("add-offer", "change-offer"),
+            "offer-restrictions": DashboardPermission.get("add-offer", "change-offer"),
+            "offer-delete": DashboardPermission.get("delete-offer"),
+            "offer-detail": DashboardPermission.get("view-offer"),
         }
 
     # pylint: disable=attribute-defined-outside-init

--- a/src/oscar/apps/dashboard/orders/apps.py
+++ b/src/oscar/apps/dashboard/orders/apps.py
@@ -19,27 +19,27 @@ class OrdersDashboardConfig(OscarDashboardConfig):
 
         self.permissions_map = {
             "order-list": (
-                DashboardPermission.get("order"),
+                DashboardPermission.get("view-order"),
                 DashboardPermission.partner_dashboard_access,
             ),
             "order-stats": (
-                DashboardPermission.get("order"),
+                DashboardPermission.get("view-order"),
                 DashboardPermission.partner_dashboard_access,
             ),
             "order-detail": (
-                DashboardPermission.get("order"),
+                DashboardPermission.get("view-order"),
                 DashboardPermission.partner_dashboard_access,
             ),
             "order-detail-note": (
-                DashboardPermission.get("order"),
+                DashboardPermission.get("change-order"),
                 DashboardPermission.partner_dashboard_access,
             ),
             "order-line-detail": (
-                DashboardPermission.get("order"),
+                DashboardPermission.get("view-order"),
                 DashboardPermission.partner_dashboard_access,
             ),
             "order-shipping-address": (
-                DashboardPermission.get("order"),
+                DashboardPermission.get("view-order"),
                 DashboardPermission.partner_dashboard_access,
             ),
         }

--- a/src/oscar/apps/dashboard/pages/apps.py
+++ b/src/oscar/apps/dashboard/pages/apps.py
@@ -18,10 +18,10 @@ class PagesDashboardConfig(OscarDashboardConfig):
         DashboardPermission = get_class("dashboard.permissions", "DashboardPermission")
 
         self.permissions_map = {
-            "page-list": DashboardPermission.get("flat_page"),
-            "page-create": DashboardPermission.get("flat_page"),
-            "page-update": DashboardPermission.get("flat_page"),
-            "page-delete": DashboardPermission.get("flat_page"),
+            "page-list": DashboardPermission.get("view-flatpage"),
+            "page-create": DashboardPermission.get("add-flatpage"),
+            "page-update": DashboardPermission.get("change-flatpage"),
+            "page-delete": DashboardPermission.get("delete-flatpage"),
         }
 
     # pylint: disable=attribute-defined-outside-init

--- a/src/oscar/apps/dashboard/partners/apps.py
+++ b/src/oscar/apps/dashboard/partners/apps.py
@@ -18,15 +18,24 @@ class PartnersDashboardConfig(OscarDashboardConfig):
         DashboardPermission = get_class("dashboard.permissions", "DashboardPermission")
 
         self.permissions_map = {
-            "partner-list": DashboardPermission.get("partner"),
-            "partner-create": DashboardPermission.get("partner"),
-            "partner-manage": DashboardPermission.get("partner"),
-            "partner-delete": DashboardPermission.get("partner"),
-            "partner-user-create": DashboardPermission.get("partner"),
-            "partner-user-select": DashboardPermission.get("partner"),
-            "partner-user-link": DashboardPermission.get("partner"),
-            "partner-user-unlink": DashboardPermission.get("partner"),
-            "partner-user-update": DashboardPermission.get("partner"),
+            "partner-list": DashboardPermission.get("view-partner"),
+            "partner-create": DashboardPermission.get("add-partner"),
+            "partner-manage": (
+                DashboardPermission.get("view-partner"),
+                DashboardPermission.get("change-partner"),
+            ),
+            "partner-delete": DashboardPermission.get("delete-partner"),
+            "partner-user-create": (
+                DashboardPermission.get("change-partner"),
+                DashboardPermission.get("add-user"),
+            ),
+            "partner-user-select": DashboardPermission.get("change-partner"),
+            "partner-user-link": DashboardPermission.get("change-partner"),
+            "partner-user-unlink": DashboardPermission.get("change-partner"),
+            "partner-user-update": (
+                DashboardPermission.get("change-partner"),
+                DashboardPermission.get("change-user"),
+            ),
         }
 
     # pylint: disable=attribute-defined-outside-init

--- a/src/oscar/apps/dashboard/permissions.py
+++ b/src/oscar/apps/dashboard/permissions.py
@@ -10,136 +10,88 @@ class DashboardPermission:
 
     permissions = {
         # Catalogue
-        "product": [
-            "is_staff",
-            "catalogue.add_product",
-            "catalogue.change_product",
-            "catalogue.view_product",
-            "catalogue.delete_product",
-        ],
-        "category": [
-            "is_staff",
-            "catalogue.add_category",
-            "catalogue.change_category",
-            "catalogue.view_category",
-            "catalogue.delete_category",
-        ],
-        "product_class": [
-            "is_staff",
-            "catalogue.add_productclass",
-            "catalogue.change_productclass",
-            "catalogue.view_productclass",
-            "catalogue.delete_productclass",
-        ],
-        "attribute_option_group": [
-            "is_staff",
-            "catalogue.add_attributeoptiongroup",
-            "catalogue.change_attributeoptiongroup",
-            "catalogue.view_attributeoptiongroup",
-            "catalogue.delete_attributeoptiongroup",
-        ],
-        "option": [
-            "is_staff",
-            "catalogue.add_option",
-            "catalogue.change_option",
-            "catalogue.view_option",
-            "catalogue.delete_option",
-        ],
+        "view-product": ["catalogue.view_product"],
+        "add-product": ["catalogue.add_product"],
+        "change-product": ["catalogue.change_product"],
+        "delete-product": ["catalogue.delete_product"],
+        "view-category": ["catalogue.view_category"],
+        "add-category": ["catalogue.add_category"],
+        "change-category": ["catalogue.change_category"],
+        "delete-category": ["catalogue.delete_category"],
+        "view-productclass": ["catalogue.view_productclass"],
+        "add-productclass": ["catalogue.add_productclass"],
+        "change-productclass": ["catalogue.change_productclass"],
+        "delete-productclass": ["catalogue.delete_productclass"],
+        "view-attributeoptiongroup": ["catalogue.view_attributeoptiongroup"],
+        "add-attributeoptiongroup": ["catalogue.add_attributeoptiongroup"],
+        "change-attributeoptiongroup": ["catalogue.change_attributeoptiongroup"],
+        "delete-attributeoptiongroup": ["catalogue.delete_attributeoptiongroup"],
+        "view-option": ["catalogue.view_option"],
+        "add-option": ["catalogue.add_option"],
+        "change-option": ["catalogue.change_option"],
+        "delete-option": ["catalogue.delete_option"],
         # Communications
-        "communication_event_type": [
-            "is_staff",
-            "communication.add_communicationeventtype",
-            "communication.change_communicationeventtype",
-            "communication.view_communicationeventtype",
-            "communication.delete_communicationeventtype",
+        "view-communication_event_type": ["communication.view_communicationeventtype"],
+        "add-communication_event_type": ["communication.add_communicationeventtype"],
+        "change-communication_event_type": [
+            "communication.change_communicationeventtype"
+        ],
+        "delete-communication_event_type": [
+            "communication.delete_communicationeventtype"
         ],
         # Partners
-        "stockalert": [
-            "is_staff",
-            "partner.add_stockalert",
-            "partner.change_stockalert",
-            "partner.view_stockalert",
-            "partner.delete_stockalert",
-        ],
-        "partner": [
-            "is_staff",
-            "partner.add_partner",
-            "partner.change_partner",
-            "partner.view_partner",
-            "partner.delete_partner",
-        ],
+        "view-stockalert": ["partner.view_stockalert"],
+        "add-stockalert": ["partner.add_stockalert"],
+        "change-stockalert": ["partner.change_stockalert"],
+        "delete-stockalert": ["partner.delete_stockalert"],
+        "view-partner": ["partner.view_partner"],
+        "add-partner": ["partner.add_partner"],
+        "change-partner": ["partner.change_partner"],
+        "delete-partner": ["partner.delete_partner"],
         # Offers
-        "offer": [
-            "is_staff",
-            "offer.add_conditionaloffer",
-            "offer.change_conditionaloffer",
-            "offer.view_conditionaloffer",
-            "offer.delete_conditionaloffer",
-        ],
+        "view-offer": ["offer.view_conditionaloffer"],
+        "add-offer": ["offer.add_conditionaloffer"],
+        "change-offer": ["offer.change_conditionaloffer"],
+        "delete-offer": ["offer.delete_conditionaloffer"],
+        "view-range": ["offer.view_range"],
+        "add-range": ["offer.add_range"],
+        "change-range": ["offer.change_range"],
+        "delete-range": ["offer.delete_range"],
         # Orders
-        "order": [
-            "is_staff",
-            "order.add_order",
-            "order.change_order",
-            "order.view_order",
-            "order.delete_order",
-        ],
+        "view-order": ["order.view_order"],
+        "add-order": ["order.add_order"],
+        "change-order": ["order.change_order"],
+        "delete-order": ["order.delete_order"],
         # Flat Pages
-        "flat_page": [
-            "is_staff",
-            "flatpages.add_flatpage",
-            "flatpages.change_flatpage",
-            "flatpages.view_flatpage",
-            "flatpages.delete_flatpage",
-        ],
-        # Ranges
-        "range": [
-            "is_staff",
-            "offer.add_range",
-            "offer.change_range",
-            "offer.view_range",
-            "offer.delete_range",
-        ],
+        "view-flatpage": ["flatpages.view_flatpage"],
+        "add-flatpage": ["flatpages.add_flatpage"],
+        "change-flatpage": ["flatpages.change_flatpage"],
+        "delete-flatpage": ["flatpages.delete_flatpage"],
         # Analytics
-        "user_record": [
-            "is_staff",
-            "analytics.add_userrecord",
-            "analytics.change_userrecord",
-            "analytics.view_userrecord",
-            "analytics.delete_userrecord",
-        ],
+        "view-user_record": ["analytics.view_userrecord"],
+        "add-user_record": ["analytics.add_userrecord"],
+        "change-user_record": ["analytics.change_userrecord"],
+        "delete-user_record": ["analytics.delete_userrecord"],
         # Reviews
-        "product_review": [
-            "is_staff",
-            "reviews.add_productreview",
-            "reviews.change_productreview",
-            "reviews.view_productreview",
-            "reviews.delete_productreview",
-        ],
+        "view-product_review": ["reviews.view_productreview"],
+        "add-product_review": ["reviews.add_productreview"],
+        "change-product_review": ["reviews.change_productreview"],
+        "delete-product_review": ["reviews.delete_productreview"],
         # Shipping
-        "shipping_method": [
-            "is_staff",
-            "shipping.add_weightbased",
-            "shipping.change_weightbased",
-            "shipping.delete_weightbased",
-            "shipping.view_weightbased",
-        ],
+        "view-shipping_method": ["shipping.view_weightbased"],
+        "add-shipping_method": ["shipping.add_weightbased"],
+        "change-shipping_method": ["shipping.change_weightbased"],
+        "delete-shipping_method": ["shipping.delete_weightbased"],
         # Users
-        "user": [
-            "is_staff",
-            f"{User._meta.app_label}.add_user",
-            f"{User._meta.app_label}.change_user",
-            f"{User._meta.app_label}.view_user",
-            f"{User._meta.app_label}.delete_user",
-        ],
+        "view-user": [f"{User._meta.app_label}.view_user"],
+        "add-user": [f"{User._meta.app_label}.add_user"],
+        "change-user": [f"{User._meta.app_label}.change_user"],
+        "delete-user": [f"{User._meta.app_label}.delete_user"],
         # Vouchers
-        "voucher": [
-            "is_staff",
-            "voucher.add_voucher",
-            "voucher.change_voucher",
-            "voucher.view_voucher",
-            "voucher.delete_voucher",
-        ],
+        "view-voucher": ["voucher.view_voucher"],
+        "add-voucher": ["voucher.add_voucher"],
+        "change-voucher": ["voucher.change_voucher"],
+        "delete-voucher": ["voucher.delete_voucher"],
     }
     # Staff
     staff = ["is_staff"]
@@ -149,14 +101,14 @@ class DashboardPermission:
     @classmethod
     def get(cls, *args):
         """
-        DashboardPermission.get("product", "category", "stockalert")
+        Get combined permissions for given keys.
+        Example: DashboardPermission.get("view-product", "view-category")
 
         :return: list of permission codes
         """
         permissions = set()
         for arg in args:
             permissions.update(cls.permissions[arg])
-        permissions.remove("is_staff")
         return list(permissions)
 
     @classmethod

--- a/src/oscar/apps/dashboard/ranges/apps.py
+++ b/src/oscar/apps/dashboard/ranges/apps.py
@@ -18,12 +18,12 @@ class RangesDashboardConfig(OscarDashboardConfig):
         DashboardPermission = get_class("dashboard.permissions", "DashboardPermission")
 
         self.permissions_map = {
-            "range-list": DashboardPermission.get("range"),
-            "range-create": DashboardPermission.get("range"),
-            "range-update": DashboardPermission.get("range"),
-            "range-delete": DashboardPermission.get("range"),
-            "range-products": DashboardPermission.get("range"),
-            "range-reorder": DashboardPermission.get("range"),
+            "range-list": DashboardPermission.get("view-range"),
+            "range-create": DashboardPermission.get("add-range"),
+            "range-update": DashboardPermission.get("change-range"),
+            "range-delete": DashboardPermission.get("delete-range"),
+            "range-products": DashboardPermission.get("change-range"),
+            "range-reorder": DashboardPermission.get("change-range"),
         }
 
     # pylint: disable=attribute-defined-outside-init

--- a/src/oscar/apps/dashboard/reports/apps.py
+++ b/src/oscar/apps/dashboard/reports/apps.py
@@ -18,7 +18,7 @@ class ReportsDashboardConfig(OscarDashboardConfig):
         DashboardPermission = get_class("dashboard.permissions", "DashboardPermission")
 
         self.permissions_map = {
-            "reports-index": DashboardPermission.get("user_record"),
+            "reports-index": DashboardPermission.get("view-user_record"),
         }
 
     # pylint: disable=attribute-defined-outside-init

--- a/src/oscar/apps/dashboard/reviews/apps.py
+++ b/src/oscar/apps/dashboard/reviews/apps.py
@@ -18,9 +18,9 @@ class ReviewsDashboardConfig(OscarDashboardConfig):
         DashboardPermission = get_class("dashboard.permissions", "DashboardPermission")
 
         self.permissions_map = {
-            "reviews-list": DashboardPermission.get("product_review"),
-            "reviews-update": DashboardPermission.get("product_review"),
-            "reviews-delete": DashboardPermission.get("product_review"),
+            "reviews-list": DashboardPermission.get("view-product_review"),
+            "reviews-update": DashboardPermission.get("change-product_review"),
+            "reviews-delete": DashboardPermission.get("delete-product_review"),
         }
 
     # pylint: disable=attribute-defined-outside-init

--- a/src/oscar/apps/dashboard/shipping/apps.py
+++ b/src/oscar/apps/dashboard/shipping/apps.py
@@ -16,13 +16,17 @@ class ShippingDashboardConfig(OscarDashboardConfig):
         DashboardPermission = get_class("dashboard.permissions", "DashboardPermission")
 
         self.permissions_map = {
-            "shipping-method-list": DashboardPermission.get("shipping_method"),
-            "shipping-method-create": DashboardPermission.get("shipping_method"),
-            "shipping-method-detail": DashboardPermission.get("shipping_method"),
-            "shipping-method-edit": DashboardPermission.get("shipping_method"),
-            "shipping-method-delete": DashboardPermission.get("shipping_method"),
-            "shipping-method-band-edit": DashboardPermission.get("shipping_method"),
-            "shipping-method-band-delete": DashboardPermission.get("shipping_method"),
+            "shipping-method-list": DashboardPermission.get("view-shipping_method"),
+            "shipping-method-create": DashboardPermission.get("add-shipping_method"),
+            "shipping-method-detail": DashboardPermission.get("view-shipping_method"),
+            "shipping-method-edit": DashboardPermission.get("change-shipping_method"),
+            "shipping-method-delete": DashboardPermission.get("delete-shipping_method"),
+            "shipping-method-band-edit": DashboardPermission.get(
+                "change-shipping_method"
+            ),
+            "shipping-method-band-delete": DashboardPermission.get(
+                "delete-shipping_method"
+            ),
         }
 
     # pylint: disable=attribute-defined-outside-init
@@ -39,7 +43,6 @@ class ShippingDashboardConfig(OscarDashboardConfig):
         self.weight_method_delete_view = get_class(
             "dashboard.shipping.views", "WeightBasedDeleteView"
         )
-        # This doubles as the weight_band create view
         self.weight_method_detail_view = get_class(
             "dashboard.shipping.views", "WeightBasedDetailView"
         )

--- a/src/oscar/apps/dashboard/users/apps.py
+++ b/src/oscar/apps/dashboard/users/apps.py
@@ -18,12 +18,12 @@ class UsersDashboardConfig(OscarDashboardConfig):
         DashboardPermission = get_class("dashboard.permissions", "DashboardPermission")
 
         self.permissions_map = {
-            "users-index": DashboardPermission.get("user"),
-            "user-detail": DashboardPermission.get("user"),
-            "user-password-reset": DashboardPermission.get("user"),
-            "user-alert-list": DashboardPermission.get("user"),
-            "user-alert-delete": DashboardPermission.get("user"),
-            "user-alert-update": DashboardPermission.get("user"),
+            "users-index": DashboardPermission.get("view-user"),
+            "user-detail": DashboardPermission.get("view-user"),
+            "user-password-reset": DashboardPermission.get("view-user", "change-user"),
+            "user-alert-list": DashboardPermission.get("view-user"),
+            "user-alert-delete": DashboardPermission.get("delete-user"),
+            "user-alert-update": DashboardPermission.get("change-user"),
         }
 
     # pylint: disable=attribute-defined-outside-init

--- a/src/oscar/apps/dashboard/vouchers/apps.py
+++ b/src/oscar/apps/dashboard/vouchers/apps.py
@@ -18,17 +18,17 @@ class VouchersDashboardConfig(OscarDashboardConfig):
         DashboardPermission = get_class("dashboard.permissions", "DashboardPermission")
 
         self.permissions_map = {
-            "voucher-list": DashboardPermission.get("voucher"),
-            "voucher-create": DashboardPermission.get("voucher"),
-            "voucher-update": DashboardPermission.get("voucher"),
-            "voucher-delete": DashboardPermission.get("voucher"),
-            "voucher-stats": DashboardPermission.get("voucher"),
-            "voucher-set-list": DashboardPermission.get("voucher"),
-            "voucher-set-create": DashboardPermission.get("voucher"),
-            "voucher-set-update": DashboardPermission.get("voucher"),
-            "voucher-set-detail": DashboardPermission.get("voucher"),
-            "voucher-set-download": DashboardPermission.get("voucher"),
-            "voucher-set-delete": DashboardPermission.get("voucher"),
+            "voucher-list": DashboardPermission.get("view-voucher"),
+            "voucher-create": DashboardPermission.get("add-voucher"),
+            "voucher-update": DashboardPermission.get("change-voucher"),
+            "voucher-delete": DashboardPermission.get("delete-voucher"),
+            "voucher-stats": DashboardPermission.get("view-voucher"),
+            "voucher-set-list": DashboardPermission.get("view-voucher"),
+            "voucher-set-create": DashboardPermission.get("add-voucher"),
+            "voucher-set-update": DashboardPermission.get("change-voucher"),
+            "voucher-set-detail": DashboardPermission.get("view-voucher"),
+            "voucher-set-download": DashboardPermission.get("view-voucher"),
+            "voucher-set-delete": DashboardPermission.get("delete-voucher"),
         }
 
     # pylint: disable=attribute-defined-outside-init

--- a/src/oscar/templates/oscar/dashboard/index.html
+++ b/src/oscar/templates/oscar/dashboard/index.html
@@ -1,5 +1,6 @@
 {% extends 'oscar/dashboard/layout.html' %}
 {% load currency_filters %}
+{% load dashboard_permissions %}
 {% load i18n %}
 
 {% block body_class %}{{ block.super }} orders home{% endblock %}
@@ -17,6 +18,11 @@
 {% endblock %}
 
 {% block dashboard_content %}
+{% has_dashboard_permission "order-list" "orders_dashboard" as can_view_orders %}
+{% has_dashboard_permission "product-list" "catalogue_dashboard" as can_view_products %}
+{% has_dashboard_permission "stock-alert-list" "partners_dashboard" as can_view_stock %}
+{% has_dashboard_permission "offer-list" "offers_dashboard" as can_view_offers %}
+{% has_dashboard_permission "voucher-list" "vouchers_dashboard" as can_view_vouchers %}
 
 <div class="table-header">
     <i class="fas fa-signal"></i> {% trans "Your Store Statistics" %}
@@ -82,9 +88,11 @@
     <div class="col-md-4">
         <table class="table table-striped table-bordered table-hover">
             <caption>
-                <a href="{% url 'dashboard:order-list' %}" class="btn btn-secondary float-right">
-                    <i class="fas fa-shopping-cart"></i> {% trans "Manage" %}
-                </a>
+                {% if can_view_orders %}
+                    <a href="{% url 'dashboard:order-list' %}" class="btn btn-secondary float-right">
+                        <i class="fas fa-shopping-cart"></i> {% trans "Manage" %}
+                    </a>
+                {% endif %}
                 <i class="fas fa-shopping-cart"></i> {% trans "Orders - All Time" %}
             </caption>
             <tr>
@@ -130,16 +138,20 @@
         <table class="table table-striped table-bordered table-hover">
             <caption>
                 <div class="btn-toolbar float-right">
-                    <div class="btn-group">
-                        <a href="{% url 'dashboard:catalogue-product-list' %}" class="btn btn-secondary">
-                            <i class="fas fa-sitemap"></i> {% trans "Manage" %}
-                        </a>
-                    </div>
-                    <div class="btn-group ml-2">
-                        <a href="{% url 'dashboard:stock-alert-list' %}" class="btn btn-secondary">
-                            <i class="fas fa-sitemap"></i> {% trans "View Stock Alerts" %}
-                        </a>
-                    </div>
+                    {% if can_view_products %}
+                        <div class="btn-group">
+                            <a href="{% url 'dashboard:catalogue-product-list' %}" class="btn btn-secondary">
+                                <i class="fas fa-sitemap"></i> {% trans "Manage" %}
+                            </a>
+                        </div>
+                    {% endif %}
+                    {% if can_view_stock %}
+                        <div class="btn-group ml-2">
+                            <a href="{% url 'dashboard:stock-alert-list' %}" class="btn btn-secondary">
+                                <i class="fas fa-sitemap"></i> {% trans "View Stock Alerts" %}
+                            </a>
+                        </div>
+                    {% endif %}
                 </div>
                 <i class="fas fa-sitemap"></i> {% trans "Catalogue and stock" %}
             </caption>
@@ -158,7 +170,6 @@
         </table>
     </div>
     <div class="col-md-6">
-        {% if user.is_staff %}
         <table class="table table-striped table-bordered table-hover">
             <caption><i class="fas fa-gift"></i> {% trans "Offers, vouchers" %}</caption>
             {% for offer_map in offer_maps %}
@@ -172,7 +183,6 @@
                 <td class="col-md-2" >{{ total_vouchers }}</td>
             </tr>
         </table>
-        {% endif %}
     </div>
 </div>
 

--- a/src/oscar/templates/oscar/dashboard/offers/offer_detail.html
+++ b/src/oscar/templates/oscar/dashboard/offers/offer_detail.html
@@ -1,6 +1,7 @@
 {% extends 'oscar/dashboard/layout.html' %}
 {% load currency_filters %}
 {% load i18n %}
+{% load dashboard_permissions %}
 
 {% block title %}
     {% blocktrans with name=offer.name %}
@@ -19,24 +20,39 @@
 {% endblock %}
 
 {% block header %}
+    {% has_dashboard_permission "offer-delete" "offers_dashboard" as can_delete_offer %}
+    {% has_dashboard_permission "offer-metadata" "offers_dashboard" as can_change_offer %}
+
     <div class="page-header">
-        <form id="status_form" class="float-right" method="post">
-            {% csrf_token %}
-            {% if offer.is_suspended %}
-                <button type="submit" class="btn btn-success" name="unsuspend" data-loading-text="{% trans 'Reinstating...' %}">{% trans "Reinstate offer" %}</button>
-            {% else %}
-                <button type="submit" class="btn btn-secondary" name="suspend" data-loading-text="{% trans 'Suspending...' %}">{% trans "Suspend offer" %}</button>
-            {% endif %}
-            {% if not offer.vouchers.exists %}
-            <a class="btn btn-danger" href="{% url 'dashboard:offer-delete' pk=offer.pk %}">{% trans "Delete offer" %}</a>
-            {% endif %}
-        </form>
+        {% if can_change_offer or can_delete_offer %}
+            <form id="status_form" class="float-right" method="post">
+                {% csrf_token %}
+                {% if can_change_offer %}
+                    {% if offer.is_suspended %}
+                        <button type="submit" class="btn btn-success" name="unsuspend"
+                                data-loading-text="{% trans 'Reinstating...' %}">
+                            {% trans "Reinstate offer" %}
+                        </button>
+                    {% else %}
+                        <button type="submit" class="btn btn-secondary" name="suspend"
+                                data-loading-text="{% trans 'Suspending...' %}">
+                            {% trans "Suspend offer" %}
+                        </button>
+                    {% endif %}
+                {% endif %}
+                {% if can_delete_offer and not offer.vouchers.exists %}
+                    <a class="btn btn-danger" href="{% url 'dashboard:offer-delete' pk=offer.pk %}">
+                        {% trans "Delete offer" %}
+                    </a>
+                {% endif %}
+            </form>
+        {% endif %}
         <h1>{{ offer.name }}</h1>
     </div>
 {% endblock header %}
 
 {% block dashboard_content %}
-
+    {% has_dashboard_permission "offer-metadata" "offers_dashboard" as can_change_offer %}
     <table class="table table-bordered">
         <tr>
             <td>
@@ -61,7 +77,12 @@
             <tr>
                 <th>{% trans "Name" %}</th>
                 <td>{{ offer.name }}</td>
-                <td rowspan="3"><a id="edit_metadata" href="{% url 'dashboard:offer-metadata' pk=offer.pk %}" class="btn btn-secondary">{% trans "Edit" %}</a></td>
+                <td rowspan="3">
+                    {% if can_change_offer %}
+                        <a id="edit_metadata" href="{% url 'dashboard:offer-metadata' pk=offer.pk %}"
+                           class="btn btn-secondary">{% trans "Edit" %}</a>
+                    {% endif %}
+                </td>
             </tr>
             <tr>
                 <th>{% trans "Description" %}</th>
@@ -74,12 +95,22 @@
             <tr>
                 <th>{% trans "Incentive" %}</th>
                 <td>{{ offer.benefit.description|safe }}</td>
-                <td><a href="{% url 'dashboard:offer-benefit' pk=offer.pk %}" class="btn btn-secondary">{% trans "Edit" %}</a></td>
+                <td>
+                    {% if can_change_offer %}
+                        <a href="{% url 'dashboard:offer-benefit' pk=offer.pk %}"
+                           class="btn btn-secondary">{% trans "Edit" %}</a>
+                    {% endif %}
+                </td>
             </tr>
             <tr>
                 <th>{% trans "Condition" %}</th>
                 <td>{{ offer.condition.description|safe }}</td>
-                <td><a href="{% url 'dashboard:offer-condition' pk=offer.pk %}" class="btn btn-secondary">{% trans "Edit" %}</a></td>
+                <td>
+                    {% if can_change_offer %}
+                        <a href="{% url 'dashboard:offer-condition' pk=offer.pk %}"
+                           class="btn btn-secondary">{% trans "Edit" %}</a>
+                    {% endif %}
+                </td>
             </tr>
             <tr>
                 <th>{% trans "Restrictions" %}</th>
@@ -94,7 +125,12 @@
                         {% endif %}
                     {% endfor %}
                 </td>
-                <td><a href="{% url 'dashboard:offer-restrictions' pk=offer.pk %}" class="btn btn-secondary">{% trans "Edit" %}</a></td>
+                <td>
+                    {% if can_change_offer %}
+                        <a href="{% url 'dashboard:offer-restrictions' pk=offer.pk %}"
+                           class="btn btn-secondary">{% trans "Edit" %}</a>
+                    {% endif %}
+                </td>
             </tr>
             {% if offer.is_voucher_offer_type %}
             <tr>

--- a/src/oscar/templates/oscar/dashboard/offers/offer_list.html
+++ b/src/oscar/templates/oscar/dashboard/offers/offer_list.html
@@ -4,6 +4,7 @@
 {% load sorting_tags %}
 {% load i18n %}
 {% load widget_tweaks %}
+{% load dashboard_permissions %}
 
 {% block title %}
     {% trans "Offers" %} | {{ block.super }}
@@ -20,12 +21,17 @@
 
 {% block header %}
     <div class="page-header">
-        <a href="{% url 'dashboard:offer-metadata' %}" class="btn btn-primary float-right"><i class="fas fa-plus-circle"></i> {% trans "Create new offer" %}</a>
+        {% has_dashboard_permission "offer-metadata" "offers_dashboard" as can_add_offer %}
+        {% if can_add_offer %}
+            <a href="{% url 'dashboard:offer-metadata' %}" class="btn btn-primary float-right"><i class="fas fa-plus-circle"></i> {% trans "Create new offer" %}</a>
+        {% endif %}
         <h1>{% trans "Offers" %}</h1>
     </div>
 {% endblock header %}
 
 {% block dashboard_content %}
+{% has_dashboard_permission "offer-metadata" "offers_dashboard" as can_change_offer %}
+{% has_dashboard_permission "offer-delete" "offers_dashboard" as can_delete_offer %}
     <div class="table-header">
         <h3><i class="fas fa-search"></i> {% trans "Search" %}</h3>
     </div>
@@ -142,13 +148,17 @@
                                         <a class="dropdown-item" href="{% url 'dashboard:offer-detail' pk=offer.pk %}">
                                             {% trans "Stats" %}
                                         </a>
-                                        <a class="dropdown-item" href="{% url 'dashboard:offer-metadata' pk=offer.pk %}">
-                                            {% trans "Edit" %}
-                                        </a>
-                                        {% if not offer.voucher_count %}
-                                        <a class="dropdown-item" href="{% url 'dashboard:offer-delete' pk=offer.pk %}">
-                                            {% trans "Delete" %}
-                                        </a>
+                                        {% if can_change_offer %}
+                                            <a class="dropdown-item" href="{% url 'dashboard:offer-metadata' pk=offer.pk %}">
+                                                {% trans "Edit" %}
+                                            </a>
+                                        {% endif %}
+                                        {% if can_delete_offer %}
+                                            {% if not offer.voucher_count %}
+                                            <a class="dropdown-item" href="{% url 'dashboard:offer-delete' pk=offer.pk %}">
+                                                {% trans "Delete" %}
+                                            </a>
+                                            {% endif %}
                                         {% endif %}
                                     </div>
                                 </div>

--- a/src/oscar/templates/oscar/dashboard/offers/progress.html
+++ b/src/oscar/templates/oscar/dashboard/offers/progress.html
@@ -1,4 +1,9 @@
 {% load i18n %}
+{% load dashboard_permissions %}
+
+{% has_dashboard_permission "offer-metadata" "offers_dashboard" as can_offer_metadata %}
+{% has_dashboard_permission "offer-benefit" "offers_dashboard" as can_offer_benefit %}
+{% has_dashboard_permission "offer-condition" "offers_dashboard" as can_offer_condition %}
 
 <div class="tab-nav sticky-top">
     <div class="table-header">
@@ -7,9 +12,15 @@
     <ul class="nav flex-column bs-docs-sidenav">
         <li class="nav-item step1">
             {% if step == 2 or step == 3 or step == 4 %}
-            <a href="{% if session_offer.pk %}{% url 'dashboard:offer-metadata' pk=session_offer.pk %}{% else %}{% url 'dashboard:offer-metadata' %}{% endif %}" class="nav-link visited">
-                {% trans "1. Name, description and type" %}
-            </a>
+                {% if can_offer_metadata %}
+                <a href="{% if session_offer.pk %}{% url 'dashboard:offer-metadata' pk=session_offer.pk %}{% else %}{% url 'dashboard:offer-metadata' %}{% endif %}" class="nav-link visited">
+                    {% trans "1. Name, description and type" %}
+                </a>
+                {% else %}
+                <a class="nav-link disabled text-reset">
+                    {% trans "1. Name, description and type" %}
+                </a>
+                {% endif %}
             {% else %}
             <a class="nav-link {% if step == 1 %}active{% else %}disabled text-reset{% endif %}">
                 {% trans "1. Name, description and type" %}
@@ -18,9 +29,15 @@
         </li>
         <li class="nav-item step2">
             {% if step == 3 or step == 4 %}
-            <a href="{% if session_offer.pk %}{% url 'dashboard:offer-benefit' pk=session_offer.pk %}{% else %}{% url 'dashboard:offer-benefit' %}{% endif %}" class="nav-link visited">
-                {% trans "2. Incentive" %}
-            </a>
+                {% if can_offer_benefit %}
+                <a href="{% if session_offer.pk %}{% url 'dashboard:offer-benefit' pk=session_offer.pk %}{% else %}{% url 'dashboard:offer-benefit' %}{% endif %}" class="nav-link visited">
+                    {% trans "2. Incentive" %}
+                </a>
+                {% else %}
+                <a class="nav-link disabled text-reset">
+                    {% trans "2. Incentive" %}
+                </a>
+                {% endif %}
             {% else %}
             <a class="nav-link {% if step == 2 %}active{% else %}disabled text-reset{% endif %}">
                 {% trans "2. Incentive" %}
@@ -29,9 +46,15 @@
         </li>
         <li class="nav-item step3">
             {% if step == 4 %}
-            <a href="{% if session_offer.pk %}{% url 'dashboard:offer-condition' pk=session_offer.pk %}{% else %}{% url 'dashboard:offer-condition' %}{% endif %}" class="nav-link visited">
-                {% trans "3. Condition" %}
-            </a>
+                {% if can_offer_condition %}
+                <a href="{% if session_offer.pk %}{% url 'dashboard:offer-condition' pk=session_offer.pk %}{% else %}{% url 'dashboard:offer-condition' %}{% endif %}" class="nav-link visited">
+                    {% trans "3. Condition" %}
+                </a>
+                {% else %}
+                <a class="nav-link disabled text-reset">
+                    {% trans "3. Condition" %}
+                </a>
+                {% endif %}
             {% else %}
             <a class="nav-link {% if step == 3 %}active{% else %}disabled text-reset{% endif %}">
                 {% trans "3. Condition" %}

--- a/src/oscar/templates/oscar/dashboard/offers/step_form.html
+++ b/src/oscar/templates/oscar/dashboard/offers/step_form.html
@@ -3,6 +3,7 @@
 {% load currency_filters %}
 
 {% load i18n %}
+{% load dashboard_permissions %}
 
 {% block body_class %}{{ block.super }} create-page{% endblock %}
 
@@ -61,18 +62,23 @@
                 </div>
 
                 {% block form_actions %}
+                    {% has_dashboard_permission "offer-change" "offers_dashboard" as can_change_offer %}
 
                     <div class="fixed-actions-group">
                         <div class="form-actions">
                             <div class="float-right">
-                            {% block form_actions_buttons %}
-                                <button class="btn btn-primary" type="submit" data-loading-text="{% trans 'Submitting...' %}">{% block submittext %}{% trans "Continue" %}{% endblock %}</button>
-                                {% if offer %}{# When editing offer, show saving button #}
-                                    <button class="btn btn-secondary" name="save" type="submit" data-loading-text="{% trans 'Saving...' %}">{% trans "Save changes" %}</button>
-                                {% endif %}
-                            {% endblock %}
+                                {% block form_actions_buttons %}
+                                    {% if offer.pk and can_change_offer %}
+                                        <button class="btn btn-primary" type="submit" data-loading-text="{% trans 'Submitting...' %}">
+                                            {% block submittext %}{% trans "Continue" %}{% endblock %}
+                                        </button>
+                                        <button class="btn btn-secondary" name="save" type="submit" data-loading-text="{% trans 'Saving...' %}">
+                                            {% trans "Save changes" %}
+                                        </button>
+                                    {% endif %}
+                                {% endblock %}
                             </div>
-                            <a class="btn btn-secondary" href="{% url 'dashboard:offer-list' %}">{% trans "cancel" %}</a>
+                            <a class="btn btn-secondary" href="{% url 'dashboard:offer-list' %}">{% trans "Cancel" %}</a>
                         </div>
                     </div>
 

--- a/src/oscar/templates/oscar/dashboard/offers/summary.html
+++ b/src/oscar/templates/oscar/dashboard/offers/summary.html
@@ -1,4 +1,10 @@
 {% load i18n %}
+{% load dashboard_permissions %}
+
+{% has_dashboard_permission "offer-metadata" "offers_dashboard" as can_edit_metadata %}
+{% has_dashboard_permission "offer-benefit" "offers_dashboard" as can_edit_benefit %}
+{% has_dashboard_permission "offer-condition" "offers_dashboard" as can_edit_condition %}
+{% has_dashboard_permission "offer-restrictions" "offers_dashboard" as can_edit_restrictions %}
 
 <div class="table-header">
     <h3>{% trans "Offer summary" %}</h3>
@@ -7,7 +13,9 @@
     {% if session_offer.name %}
         <div class="card card-body">
             <div class="d-flex">
-                <a href="{% if session_offer.pk %}{% url 'dashboard:offer-metadata' pk=session_offer.pk %}{% else %}{% url 'dashboard:offer-metadata' %}{% endif %}" class="btn btn-secondary ml-auto">{% trans "Edit" %}</a>
+                {% if can_edit_metadata %}
+                    <a href="{% if session_offer.pk %}{% url 'dashboard:offer-metadata' pk=session_offer.pk %}{% else %}{% url 'dashboard:offer-metadata' %}{% endif %}" class="btn btn-secondary ml-auto">{% trans "Edit" %}</a>
+                {% endif %}
             </div>
             <p><strong>{% trans "Name" %}:</strong><br /> {{ session_offer.name }}</p>
             {% if session_offer.description %}
@@ -19,7 +27,9 @@
     {% if session_offer.benefit %}
         <div class="card card-body">
             <div class="d-flex">
-                <a href="{% if session_offer.pk %}{% url 'dashboard:offer-benefit' pk=session_offer.pk %}{% else %}{% url 'dashboard:offer-benefit' %}{% endif %}" class="btn btn-secondary ml-auto">{% trans "Edit" %}</a>
+                {% if can_edit_benefit %}
+                    <a href="{% if session_offer.pk %}{% url 'dashboard:offer-benefit' pk=session_offer.pk %}{% else %}{% url 'dashboard:offer-benefit' %}{% endif %}" class="btn btn-secondary ml-auto">{% trans "Edit" %}</a>
+                {% endif %}
             </div>
             <p><strong>{% trans "Incentive" %}:</strong><br /> {{ session_offer.benefit.description|safe }}</p>
         </div>
@@ -27,7 +37,9 @@
     {% if session_offer.condition %}
         <div class="card card-body">
             <div class="d-flex">
-              <a href="{% if session_offer.pk %}{% url 'dashboard:offer-condition' pk=session_offer.pk %}{% else %}{% url 'dashboard:offer-condition' %}{% endif %}" class="btn btn-secondary ml-auto">{% trans "Edit" %}</a>
+                {% if can_edit_condition %}
+                    <a href="{% if session_offer.pk %}{% url 'dashboard:offer-condition' pk=session_offer.pk %}{% else %}{% url 'dashboard:offer-condition' %}{% endif %}" class="btn btn-secondary ml-auto">{% trans "Edit" %}</a>
+                {% endif %}
             </div>
             <p><strong>{% trans "Condition" %}:</strong><br />{{ session_offer.condition.description|safe }}</p>
         </div>
@@ -35,7 +47,9 @@
     {% if session_offer.pk %}
         <div class="card card-body">
             <div class="d-flex">
-                <a href="{% if session_offer.pk %}{% url 'dashboard:offer-restrictions' pk=session_offer.pk %}{% else %}{% url 'dashboard:offer-restrictions' %}{% endif %}" class="btn btn-secondary ml-auto">{% trans "Edit" %}</a>
+                {% if can_edit_restrictions %}
+                    <a href="{% if session_offer.pk %}{% url 'dashboard:offer-restrictions' pk=session_offer.pk %}{% else %}{% url 'dashboard:offer-restrictions' %}{% endif %}" class="btn btn-secondary ml-auto">{% trans "Edit" %}</a>
+                {% endif %}
             </div>
             <p><strong>{% trans "Restrictions" %}:</strong></p>
             {% if offer.availability_restrictions %}

--- a/src/oscar/templates/oscar/dashboard/orders/order_detail.html
+++ b/src/oscar/templates/oscar/dashboard/orders/order_detail.html
@@ -1,6 +1,7 @@
 {% extends 'oscar/dashboard/layout.html' %}
 {% load i18n %}
 {% load currency_filters %}
+{% load dashboard_permissions %}
 
 {% block body_class %}{{ block.super }} orders{% endblock %}
 
@@ -23,6 +24,9 @@
 {% endblock  %}
 
 {% block dashboard_content %}
+    {% has_dashboard_permission "order-detail-note" "orders_dashboard" as can_edit_order_note %}
+    {% has_dashboard_permission "delete-order" "orders_dashboard" as can_delete_order %}
+    
     {% block customer_information %}
     <table class="table table-bordered table-hover">
         <caption><i class="fas fa-user"></i> {% trans "Customer Information" %}</caption>
@@ -101,11 +105,13 @@
                         {% trans "Discounts" %}
                     </a>
                 </li>
+                {% if can_edit_order_note %}
                 <li class="nav-item">
                     <a class="nav-link {% if active_tab == 'notes' %}active{% endif %}" href="#notes" data-toggle="tab">
                         {% trans "Notes" %}
                     </a>
                 </li>
+                {% endif %}
             {% endblock nav_tabs %}
         </ul>
 
@@ -137,11 +143,17 @@
                             <tbody>
                                 {% for line in lines %}
                                     <tr>
+                                        {% if can_edit_order_note %}
                                         <td>
                                             <input type="checkbox" name="selected_line" value="{{ line.id }}" />
                                         </td>
+                                        {% endif %}
                                         <td>
+                                            {% if can_edit_order_note %}
                                             <input type="text" name="selected_line_qty_{{ line.id }}" value="{{ line.quantity }}" size="2" style="width:40px" />
+                                            {% else %}
+                                            {{ line.quantity }}
+                                            {% endif %}
                                         </td>
                                         <td><a href="{% url 'dashboard:order-line-detail' number=order.number line_id=line.id %}">#{{ line.id }}</a></td>
                                         <td>{{ line.quantity }}</td>
@@ -278,11 +290,7 @@
                         </table>
                     {% endblock order_lines %}
 
-                    {% comment %}
-                        This is the important block within this template: you will almost certainly want to
-                        override this block to provide your own form widgets that suit your order processing
-                        flow.  The default contents shows a range of widgets - more than is sensible really.
-                    {% endcomment %}
+                    {% if can_edit_order_note %}
                     {% block line_actions %}
                         <div class="card card-body bg-light">
                             <h3>{% trans "With selected lines" %}:</h3>
@@ -350,8 +358,10 @@
                             </div>
                         </div>
                     {% endblock line_actions %}
+                    {% endif %}
                 </form>
 
+                {% if can_edit_order_note %}
                 <form method="post" id="order_status_form">
                     {% csrf_token %}
                     {% block order_actions %}
@@ -369,6 +379,7 @@
                         </div>
                     {% endblock %}
                 </form>
+                {% endif %}
 
                 {% block order_status_changes %}
                     <div class="table-header">
@@ -522,7 +533,7 @@
                                     {% for field in order.shipping_address.active_address_fields %}
                                         {{ field }}<br/>
                                     {% endfor %}
-                                    {% if order.shipping_address %}
+                                    {% if order.shipping_address and can_edit_order_note %}
                                         <a class="btn btn-secondary" href="{% url 'dashboard:order-shipping-address' order.number %}">
                                             {% trans "Update" %}
                                         </a>
@@ -625,6 +636,7 @@
 
             <div class="tab-pane fade {% if active_tab == 'discounts' %}show active{% endif %}" id="discounts" role="tabpanel">
                 {% block tab_discounts %}
+                    {% has_dashboard_permission "view-offer" "offers_dashboard" as can_view_offer %}
 
                     {% with discounts=order.discounts.all %}
                         <div class="table-header">
@@ -650,7 +662,7 @@
                                                 {{ discount.voucher.code|default:"-" }}
                                             </td>
                                             <td>
-                                                {% if discount.offer %}
+                                                {% if discount.offer and can_view_offer %}
                                                     <a href="{% url 'dashboard:offer-detail' pk=discount.offer.id %}">{{ discount.offer.name }}</a>
                                                 {% else %}
                                                     {{ discount.offer_name }}
@@ -673,6 +685,7 @@
                 {% endblock %}
             </div>
 
+            {% if can_edit_order_note %}
             <div class="tab-pane fade {% if active_tab == 'notes' %}show active{% endif %}" id="notes" role="tabpanel">
                 {% block tab_notes %}
                     <div class="table-header">
@@ -697,12 +710,14 @@
                                         <td>
                                             {% if note.is_editable %}
                                                 <a href="{% url 'dashboard:order-detail-note' number=order.number note_id=note.id %}#notes" class="btn btn-info">{% trans "Edit" %}</a>
+                                                {% if can_delete_order %}
                                                 <form id="delete_order_note_form" method="post" class="float-left m-0">
                                                     {% csrf_token %}
                                                     <input type="hidden" name="order_action" value="delete_note" />
                                                     <input type="hidden" name="note_id" value="{{ note.id }}" />
                                                     <input type="submit" value="{% trans "Delete" %}" class="btn btn-danger" />
                                                 </form>
+                                                {% endif %}
                                             {% endif %}
                                         </td>
                                     </tr>
@@ -714,7 +729,8 @@
                             {% endif %}
                         </table>
                     {% endwith %}
-
+                    
+                    {% if can_edit_order_note %}
                     <form id="order_note_form" action=".?note={{ note_id }}" method="post" class="form-stacked">
                         {% csrf_token %}
                         <input type="hidden" value="save_note" name="order_action" />
@@ -724,12 +740,28 @@
                             {% trans "Notes are only editable for 5 minutes after being saved." %}
                         </div>
                     </form>
+                    {% endif %}
                 {% endblock %}
             </div>
+            {% endif %}
 
             {% block extra_tabs %}{% endblock %}
         </div>
     </div>
+    
+    {% if can_delete_order %}
+    <div class="card card-body bg-danger">
+        <h3><i class="fas fa-exclamation-triangle"></i> {% trans "Danger Zone" %}</h3>
+        <form id="order_delete_form" method="post" class="form-stacked">
+            {% csrf_token %}
+            <input type="hidden" name="order_action" value="delete_order" />
+            <p>{% trans "Deleting this order will remove all related information and cannot be undone." %}</p>
+            <button type="submit" class="btn btn-danger" data-loading-text="{% trans 'Deleting...' %}">
+                {% trans "Delete Order" %}
+            </button>
+        </form>
+    </div>
+    {% endif %}
 {% endblock dashboard_content %}
 
 {% block onbodyload %}

--- a/src/oscar/templates/oscar/dashboard/orders/order_list.html
+++ b/src/oscar/templates/oscar/dashboard/orders/order_list.html
@@ -1,5 +1,6 @@
 {% extends 'oscar/dashboard/layout.html' %}
 {% load currency_filters %}
+{% load dashboard_permissions %}
 {% load sorting_tags %}
 {% load i18n %}
 {% load widget_tweaks %}
@@ -26,6 +27,8 @@
 {% endblock header %}
 
 {% block dashboard_content %}
+    {% has_dashboard_permission "order-detail-note" "orders_dashboard" as can_edit_order_note %}
+
     <div class="table-header">
         <h3><i class="fas fa-search"></i> {% trans "Search" %}</h3>
     </div>
@@ -80,12 +83,14 @@
                         {% trans "All Orders" %}
                         {% endif %}
                     </h3>
+                    {% if can_edit_order_note %}
                     <div class="float-right">
                         <div class="form-inline">
                             <label>{% trans "Download selected orders as a CSV" %}</label>
                             <button type="submit" class="btn btn-primary" name="action" value="download_selected_orders" data-loading-text="{% trans 'Submitting...' %}">{% trans "Download" %}</button>
                         </div>
                     </div>
+                    {% endif %}
                 </caption>
 
                 <thead>
@@ -105,8 +110,12 @@
                 <tbody>
                 {% for order in orders %}
                     <tr>
+                        {% if can_edit_order_note %}
                         <td><input type="checkbox" name="selected_order" class="selected_order" value="{{ order.id }}"/></td>
-                        <td><a href="{% url 'dashboard:order-detail' number=order.number %}">{{ order.number }}</a></td>
+                        {% endif %}
+                        <td>
+                            <a href="{% url 'dashboard:order-detail' number=order.number %}">{{ order.number }}</a>
+                        </td>
                         <td>{{ order.total_incl_tax|currency:order.currency }}</td>
                         <td>{{ order.num_items }}</td>
                         <td>{{ order.status|default:"-" }}</td>
@@ -130,6 +139,8 @@
                 </tbody>
             </table>
             {% endblock order_list %}
+            
+            {% if can_edit_order_note %}   
             {% block order_actions %}
                 <div class="card card-body bg-light">
                     <h3><i class="fas fa-exclamation-circle"></i> {% trans "Change order status" %}:</h3>
@@ -154,7 +165,8 @@
                     {% endif %}
                 </div>
             {% endblock %}
-
+            {% endif %}
+            
             {% include "oscar/dashboard/partials/pagination.html" %}
         </form>
     {% else %}

--- a/src/oscar/templates/oscar/dashboard/vouchers/voucher_detail.html
+++ b/src/oscar/templates/oscar/dashboard/vouchers/voucher_detail.html
@@ -1,6 +1,9 @@
 {% extends 'oscar/dashboard/layout.html' %}
 {% load currency_filters %}
+{% load dashboard_permissions %}
 {% load i18n %}
+
+{% has_dashboard_permission "view-offer" "offers_dashboard" as can_view_offer %}
 
 {% block title %}
     {{ voucher }} | {% trans "Vouchers" %} | {{ block.super }}
@@ -27,6 +30,7 @@
     </div>
     {% include "oscar/dashboard/vouchers/partials/voucher_details_table.html" %}
 
+
     <div class="table-header">
         <h2>{% trans "Attached offers" %}</h2>
     </div>
@@ -48,7 +52,11 @@
             {% for offer in voucher.offers.all %}
             <tr>
                 <td>
-                    <a href="{% url 'dashboard:offer-detail' pk=offer.pk %}">{{ offer.name }}</a>
+                    {% if can_view_offer %}
+                        <a href="{% url 'dashboard:offer-detail' pk=offer.pk %}">{{ offer.name }}</a>
+                    {% else %}
+                        {{ offer.name }}
+                    {% endif %}
                 </td>
                 <td>{{ offer.start_datetime|default:"-" }}</td>
                 <td>{{ offer.end_datetime|default:"-" }}</td>

--- a/src/oscar/templates/oscar/dashboard/vouchers/voucher_set_detail.html
+++ b/src/oscar/templates/oscar/dashboard/vouchers/voucher_set_detail.html
@@ -1,7 +1,10 @@
 {% extends 'oscar/dashboard/layout.html' %}
 {% load currency_filters %}
+{% load dashboard_permissions %}
 {% load sorting_tags %}
 {% load i18n %}
+
+{% has_dashboard_permission "view-offer" "offers_dashboard" as can_view_offer %}
 
 {% block title %}
     {{ voucher_set.name }} | {{ block.super }}
@@ -122,7 +125,11 @@
         {% for offer in voucher_set.vouchers.first.offers.all %}
         <tr>
             <td>
-                <a href="{% url 'dashboard:offer-detail' pk=offer.pk %}">{{ offer.name }}</a>
+                {% if can_view_offer %}
+                    <a href="{% url 'dashboard:offer-detail' pk=offer.pk %}">{{ offer.name }}</a>
+                {% else %}
+                    {{ offer.name }}
+                {% endif %}
             </td>
             <td>{{ offer.start_datetime|default:"-" }}</td>
             <td>{{ offer.end_datetime|default:"-" }}</td>

--- a/src/oscar/templatetags/dashboard_permissions.py
+++ b/src/oscar/templatetags/dashboard_permissions.py
@@ -1,0 +1,35 @@
+import logging
+from django import template
+from django.apps import apps
+from oscar.core.loading import get_class
+
+register = template.Library()
+DashboardPermission = get_class("dashboard.permissions", "DashboardPermission")
+logger = logging.getLogger(__name__)
+
+
+@register.simple_tag(takes_context=True)
+def has_dashboard_permission(context, section, app_label):
+    """Check if the user has the required dashboard permissions."""
+    user = context["user"]
+
+    try:
+        app_config = apps.get_app_config(app_label)
+        getattr(app_config, "configure_permissions", lambda: None)()
+        required_perms = getattr(app_config, "permissions_map", {}).get(section, [])
+    except LookupError:
+        required_perms = []
+
+    if not required_perms:
+        return False
+
+    # Single list of permissions
+    if all(isinstance(perm, str) for perm in required_perms):
+        result = all(user.has_perm(perm) for perm in required_perms)
+    else:
+        # Tuple/list of lists: ANY group satisfied (partner_dashboard_access)
+        result = any(
+            all(user.has_perm(perm) for perm in perm_group)
+            for perm_group in required_perms
+        )
+    return result

--- a/tests/functional/dashboard/test_catalogue.py
+++ b/tests/functional/dashboard/test_catalogue.py
@@ -35,7 +35,9 @@ DashboardPermission = get_class("dashboard.permissions", "DashboardPermission")
 
 class TestCatalogueViews(WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("product", "category", "stockalert")
+    permissions = DashboardPermission.get(
+        "view-product", "view-category", "view-stockalert"
+    )
 
     def test_exist(self):
         urls = [
@@ -111,7 +113,9 @@ class TestCatalogueViews(WebTestCase):
 
 class TestAStaffUser(WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("product")
+    permissions = DashboardPermission.get(
+        "view-product", "change-product", "delete-product", "add-product"
+    )
 
     def setUp(self):
         super().setUp()
@@ -334,7 +338,9 @@ class TestProductCreatePageWithUnicodeSlug(TestCase):
         self.slug = "Ûul-wįth-weird-chars"
         ProductClass.objects.create(name="Book", slug=self.slug)
         self.user = User.objects.create(is_staff=True)
-        add_permissions(self.user, DashboardPermission.get("product"))
+        add_permissions(
+            self.user, DashboardPermission.get("view-product", "add-product")
+        )
         self.client.force_login(self.user)
 
     def test_url_with_unicode_characters(self):

--- a/tests/functional/dashboard/test_catalogue_option.py
+++ b/tests/functional/dashboard/test_catalogue_option.py
@@ -20,7 +20,7 @@ DashboardPermission = get_class("dashboard.permissions", "DashboardPermission")
 
 class TestOptionListView(ListViewMixin, WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("option")
+    permissions = DashboardPermission.get("view-option")
     url_name = "dashboard:catalogue-option-list"
 
     def _create_object(self, idx):
@@ -31,7 +31,7 @@ class TestOptionListView(ListViewMixin, WebTestCase):
 
 class TestOptionCreateView(PopUpObjectCreateMixin, WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("option")
+    permissions = DashboardPermission.get("view-option", "add-option")
     model = Option
     form = OptionForm
     page_title = gettext("Add a new Option")
@@ -50,7 +50,7 @@ class TestOptionCreateView(PopUpObjectCreateMixin, WebTestCase):
 
 class TestOptionUpdateView(PopUpObjectUpdateMixin, WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("option")
+    permissions = DashboardPermission.get("view-option", "change-option")
     model = Option
     form = OptionForm
     page_title = None
@@ -75,7 +75,7 @@ class TestOptionUpdateView(PopUpObjectUpdateMixin, WebTestCase):
 
 class TestOptionDeleteView(PopUpObjectDeleteMixin, WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("option")
+    permissions = DashboardPermission.get("view-option", "delete-option")
     model = Option
     page_title = None
     url_name = "dashboard:catalogue-option-delete"

--- a/tests/functional/dashboard/test_catalogue_option_group.py
+++ b/tests/functional/dashboard/test_catalogue_option_group.py
@@ -30,7 +30,7 @@ DashboardPermission = get_class("dashboard.permissions", "DashboardPermission")
 
 class TestAttributeOptionGroupListView(ListViewMixin, WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("attribute_option_group")
+    permissions = DashboardPermission.get("view-attributeoptiongroup")
     url_name = "dashboard:catalogue-attribute-option-group-list"
 
     def _create_object(self, idx):
@@ -40,7 +40,9 @@ class TestAttributeOptionGroupListView(ListViewMixin, WebTestCase):
 
 class TestAttributeOptionGroupCreateView(PopUpObjectCreateMixin, WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("attribute_option_group")
+    permissions = DashboardPermission.get(
+        "view-attributeoptiongroup", "add-attributeoptiongroup"
+    )
     model = AttributeOptionGroup
     form = AttributeOptionGroupForm
     page_title = gettext("Add a new Attribute Option Group")
@@ -82,7 +84,9 @@ class TestAttributeOptionGroupCreateView(PopUpObjectCreateMixin, WebTestCase):
 
 class TestAttributeOptionGroupUpdateView(PopUpObjectUpdateMixin, WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("attribute_option_group")
+    permissions = DashboardPermission.get(
+        "view-attributeoptiongroup", "change-attributeoptiongroup"
+    )
     model = AttributeOptionGroup
     form = AttributeOptionGroupForm
     page_title = None
@@ -131,7 +135,9 @@ class TestAttributeOptionGroupUpdateView(PopUpObjectUpdateMixin, WebTestCase):
 
 class TestAttributeOptionGroupDeleteView(PopUpObjectDeleteMixin, WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("attribute_option_group")
+    permissions = DashboardPermission.get(
+        "view-attributeoptiongroup", "delete-attributeoptiongroup"
+    )
     model = AttributeOptionGroup
     page_title = None
     url_name = "dashboard:catalogue-attribute-option-group-delete"

--- a/tests/functional/dashboard/test_category.py
+++ b/tests/functional/dashboard/test_category.py
@@ -12,7 +12,12 @@ DashboardPermission = get_class("dashboard.permissions", "DashboardPermission")
 class TestCategoryDashboard(WebTestCase):
     def setUp(self):
         self.staff = UserFactory(is_staff=True)
-        add_permissions(self.staff, DashboardPermission.get("category"))
+        add_permissions(
+            self.staff,
+            DashboardPermission.get(
+                "view-category", "change-category", "delete-category", "add-category"
+            ),
+        )
         create_from_breadcrumbs("A > B > C")
 
     def test_redirects_to_main_dashboard_after_creating_top_level_category(self):

--- a/tests/functional/dashboard/test_communication.py
+++ b/tests/functional/dashboard/test_communication.py
@@ -15,7 +15,12 @@ DashboardPermission = get_class("dashboard.permissions", "DashboardPermission")
 class TestAnAdmin(WebTestCase):
     def setUp(self):
         self.staff = UserFactory(is_staff=True, username="1234")
-        add_permissions(self.staff, DashboardPermission.get("communication_event_type"))
+        add_permissions(
+            self.staff,
+            DashboardPermission.get(
+                "view-communication_event_type", "change-communication_event_type"
+            ),
+        )
         self.commtype = CommunicationEventType.objects.create(
             name="Password reset", category=CommunicationEventType.USER_RELATED
         )
@@ -52,7 +57,9 @@ class TestCommsUpdatePageWithUnicodeSlug(TestCase):
             code="Ûul-wįth-weird-chars",
         )
         self.user = User.objects.create(is_staff=True)
-        add_permissions(self.user, DashboardPermission.get("communication_event_type"))
+        add_permissions(
+            self.user, DashboardPermission.get("change-communication_event_type")
+        )
         self.client.force_login(self.user)
 
     def test_url_with_unicode_characters(self):

--- a/tests/functional/dashboard/test_dashboard.py
+++ b/tests/functional/dashboard/test_dashboard.py
@@ -52,7 +52,7 @@ class TestDashboardIndexForAnonUser(WebTestCase):
 
 class TestDashboardIndexForStaffUser(WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("order", "user")
+    permissions = DashboardPermission.get("view-order", "view-user")
 
     def test_is_available(self):
         urls = (

--- a/tests/functional/dashboard/test_offer.py
+++ b/tests/functional/dashboard/test_offer.py
@@ -12,7 +12,9 @@ DashboardPermission = get_class("dashboard.permissions", "DashboardPermission")
 class TestAnAdmin(testcases.WebTestCase):
     # New version of offer tests buy using WebTest
     is_staff = True
-    permissions = DashboardPermission.get("offer")
+    permissions = DashboardPermission.get(
+        "view-offer", "add-offer", "change-offer", "delete-offer"
+    )
 
     def setUp(self):
         super().setUp()
@@ -22,6 +24,22 @@ class TestAnAdmin(testcases.WebTestCase):
 
     def test_can_create_an_offer(self):
         list_page = self.get(reverse("dashboard:offer-list"))
+        # Debug template context
+        print("Template context:", list_page.context.keys())
+        print("can_add_offer:--101", list_page.context.get("can_add_offer"))
+        print("user permissions:", list_page.context["user"].get_all_permissions())
+        print("wooalist_page.text", list_page.text)
+        # list_page.context.get('can_add_offer') = True
+        # Or check the permission tag directly
+        from oscar.templatetags.dashboard_permissions import has_dashboard_permission
+
+        context = {"user": self.user}
+        print(
+            "Permission check:",
+            has_dashboard_permission(
+                context, "offer-list", app_label="offers_dashboard"
+            ),
+        )
 
         metadata_page = list_page.click("Create new offer")
         metadata_form = metadata_page.forms["create_update_offer_step_form"]
@@ -288,7 +306,7 @@ class TestAnAdmin(testcases.WebTestCase):
 
 class TestOfferListSearch(testcases.WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("offer")
+    permissions = DashboardPermission.get("view-offer")
 
     TEST_CASES = [
         ({}, []),

--- a/tests/functional/dashboard/test_order.py
+++ b/tests/functional/dashboard/test_order.py
@@ -22,7 +22,7 @@ DashboardPermission = get_class("dashboard.permissions", "DashboardPermission")
 
 class TestOrderListDashboard(WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("order")
+    permissions = DashboardPermission.get("view-order", "change-order")
 
     def test_redirects_to_detail_page(self):
         order = create_order()
@@ -121,7 +121,7 @@ class PermissionBasedDashboardOrderTestsNoStaff(PermissionBasedDashboardOrderTes
 
 class PermissionBasedDashboardOrderTestsStaff(PermissionBasedDashboardOrderTestsBase):
     is_staff = True
-    permissions = DashboardPermission.get("order")
+    permissions = DashboardPermission.get("view-order")
 
     def test_staff_user_can_list_all_orders(self):
         orders = [self.order_in, self.order_out]
@@ -137,7 +137,7 @@ class PermissionBasedDashboardOrderTestsStaff(PermissionBasedDashboardOrderTests
 
 class TestOrderListSearch(WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("order")
+    permissions = DashboardPermission.get("view-order")
 
     TEST_CASES = [
         ({}, []),
@@ -207,7 +207,7 @@ class TestOrderListSearch(WebTestCase):
 
 class TestOrderDetailPage(WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("order")
+    permissions = DashboardPermission.get("view-order", "add-order", "change-order")
 
     def setUp(self):
         super().setUp()
@@ -264,7 +264,7 @@ class TestOrderDetailPage(WebTestCase):
 
 class TestChangingOrderStatus(WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("order")
+    permissions = DashboardPermission.get("view-order", "change-order")
 
     def setUp(self):
         super().setUp()
@@ -293,7 +293,7 @@ class TestChangingOrderStatus(WebTestCase):
 
 class TestChangingOrderStatusFromFormOnOrderListView(WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("order")
+    permissions = DashboardPermission.get("view-order", "change-order")
 
     def setUp(self):
         super().setUp()
@@ -324,7 +324,7 @@ class TestChangingOrderStatusFromFormOnOrderListView(WebTestCase):
 
 class LineDetailTests(WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("order")
+    permissions = DashboardPermission.get("view-order")
 
     def setUp(self):
         self.order = create_order()

--- a/tests/functional/dashboard/test_page.py
+++ b/tests/functional/dashboard/test_page.py
@@ -12,7 +12,9 @@ DashboardPermission = get_class("dashboard.permissions", "DashboardPermission")
 class TestPageDashboard(WebTestCase):
     is_anonymous = False
     is_staff = True
-    permissions = DashboardPermission.get("flat_page")
+    permissions = DashboardPermission.get(
+        "view-flatpage", "add-flatpage", "delete-flatpage"
+    )
 
     def setUp(self):
         self.flatpage_1 = FlatPage.objects.create(

--- a/tests/functional/dashboard/test_partner.py
+++ b/tests/functional/dashboard/test_partner.py
@@ -9,7 +9,9 @@ DashboardPermission = get_class("dashboard.permissions", "DashboardPermission")
 
 class TestPartnerDashboard(WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("partner")
+    permissions = DashboardPermission.get(
+        "view-partner", "add-partner", "change-partner"
+    )
 
     def test_allows_a_partner_user_to_be_created(self):
         partner = models.Partner.objects.create(name="Acme Ltd")

--- a/tests/functional/dashboard/test_product.py
+++ b/tests/functional/dashboard/test_product.py
@@ -38,7 +38,9 @@ def media_file_path(path):
 
 class ProductWebTest(WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("product")
+    permissions = DashboardPermission.get(
+        "view-product", "change-product", "delete-product", "add-product"
+    )
 
     def get(self, url, **kwargs):
         kwargs["user"] = self.user

--- a/tests/functional/dashboard/test_range.py
+++ b/tests/functional/dashboard/test_range.py
@@ -68,7 +68,9 @@ class RangeProductFormTests(TestCase):
 
 class RangeProductViewTest(WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("range")
+    permissions = DashboardPermission.get(
+        "view-range", "change-range", "add-range", "delete-range"
+    )
 
     def setUp(self):
         super().setUp()
@@ -381,7 +383,7 @@ class RangeProductViewTest(WebTestCase):
 class RangeReorderViewTest(WebTestCase):
     is_staff = True
     csrf_checks = False
-    permissions = DashboardPermission.get("range")
+    permissions = DashboardPermission.get("change-range")
 
     def setUp(self):
         super().setUp()

--- a/tests/functional/dashboard/test_reports.py
+++ b/tests/functional/dashboard/test_reports.py
@@ -8,7 +8,7 @@ DashboardPermission = get_class("dashboard.permissions", "DashboardPermission")
 
 class ReportsDashboardTests(WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("user_record")
+    permissions = DashboardPermission.get("view-user_record")
 
     def test_dashboard_is_accessible_to_staff(self):
         url = reverse("dashboard:reports-index")

--- a/tests/functional/dashboard/test_review.py
+++ b/tests/functional/dashboard/test_review.py
@@ -15,7 +15,9 @@ DashboardPermission = get_class("dashboard.permissions", "DashboardPermission")
 
 class ReviewsDashboardTests(WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("product_review")
+    permissions = DashboardPermission.get(
+        "view-product_review", "change-product_review"
+    )
 
     def test_reviews_dashboard_is_accessible_to_staff(self):
         url = reverse("dashboard:reviews-list")

--- a/tests/functional/dashboard/test_shipping.py
+++ b/tests/functional/dashboard/test_shipping.py
@@ -11,7 +11,12 @@ DashboardPermission = get_class("dashboard.permissions", "DashboardPermission")
 
 class TestShippingMethodDashboard(WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("shipping_method")
+    permissions = DashboardPermission.get(
+        "view-shipping_method",
+        "change-shipping_method",
+        "add-shipping_method",
+        "delete-shipping_method",
+    )
 
     def test_for_smoke(self):
         list_page = self.get(reverse("dashboard:shipping-method-list"))

--- a/tests/functional/dashboard/test_user.py
+++ b/tests/functional/dashboard/test_user.py
@@ -17,7 +17,7 @@ class IndexViewTests(WebTestCase):
     is_staff = True
     active_users_ids = []
     inactive_users_ids = []
-    permissions = DashboardPermission.get("user")
+    permissions = DashboardPermission.get("view-user")
 
     csrf_checks = False
 
@@ -57,7 +57,7 @@ class IndexViewTests(WebTestCase):
 
 class DetailViewTests(WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("user")
+    permissions = DashboardPermission.get("view-user")
 
     def test_user_detail_view(self):
         response = self.get(
@@ -69,7 +69,7 @@ class DetailViewTests(WebTestCase):
 
 class TestDetailViewForStaffUser(WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("user")
+    permissions = DashboardPermission.get("view-user", "change-user")
 
     def setUp(self):
         self.customer = UserFactory(
@@ -110,7 +110,7 @@ class TestDetailViewForStaffUser(WebTestCase):
 class SearchTests(WebTestCase):
     is_staff = True
     url = reverse_lazy("dashboard:users-index")
-    permissions = DashboardPermission.get("user")
+    permissions = DashboardPermission.get("view-user")
 
     def setUp(self):
         UserFactory(
@@ -166,7 +166,7 @@ class SearchTests(WebTestCase):
 
 class ProductAlertListViewTestCase(WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("user")
+    permissions = DashboardPermission.get("view-user")
 
     def test_list_view_get_queryset_ordering(self):
         ProductAlertFactory.create_batch(3)

--- a/tests/functional/dashboard/test_voucher.py
+++ b/tests/functional/dashboard/test_voucher.py
@@ -8,7 +8,7 @@ DashboardPermission = get_class("dashboard.permissions", "DashboardPermission")
 
 class TestVoucherListSearch(WebTestCase):
     is_staff = True
-    permissions = DashboardPermission.get("voucher")
+    permissions = DashboardPermission.get("view-voucher")
 
     TEST_CASES = [
         ({}, ["Not in a set"]),

--- a/tests/integration/dashboard/test_permissions.py
+++ b/tests/integration/dashboard/test_permissions.py
@@ -45,7 +45,7 @@ class BaseViewPermissionTestCase(WebTestCase):
         Example view configuration:
         view_access_requirements = [{
             "name": "dashboard:offer-list",
-            "permissions": DashboardPermission.get("offer"),
+            "permissions": DashboardPermission.get("view-offer"),
         }]
 
         Test cases:
@@ -97,125 +97,131 @@ class CatalogueDashboardAccessTest(BaseViewPermissionTestCase):
             # Create Views
             {
                 "name": "dashboard:catalogue-product-create",
-                "permissions": DashboardPermission.get("product"),
+                "permissions": DashboardPermission.get("view-product", "add-product"),
             },
             {
                 "name": "dashboard:catalogue-product-create",
                 "kwargs": {"product_class_slug": product_class.slug},
-                "permissions": DashboardPermission.get("product"),
+                "permissions": DashboardPermission.get("view-product", "add-product"),
             },
             {
                 "name": "dashboard:catalogue-product-create-child",
                 "kwargs": {"parent_pk": parent_product.id},
-                "permissions": DashboardPermission.get("product"),
+                "permissions": DashboardPermission.get("view-product", "add-product"),
             },
             {
                 "name": "dashboard:catalogue-category-create",
-                "permissions": DashboardPermission.get("category"),
+                "permissions": DashboardPermission.get("add-category"),
             },
             {
                 "name": "dashboard:catalogue-category-create-child",
                 "kwargs": {"parent": category.id},
-                "permissions": DashboardPermission.get("category"),
+                "permissions": DashboardPermission.get("add-category"),
             },
             {
                 "name": "dashboard:catalogue-class-create",
-                "permissions": DashboardPermission.get("product_class"),
+                "permissions": DashboardPermission.get("add-productclass"),
             },
             {
                 "name": "dashboard:catalogue-attribute-option-group-create",
-                "permissions": DashboardPermission.get("attribute_option_group"),
+                "permissions": DashboardPermission.get(
+                    "view-attributeoptiongroup", "add-attributeoptiongroup"
+                ),
             },
             {
                 "name": "dashboard:catalogue-option-create",
-                "permissions": DashboardPermission.get("option"),
+                "permissions": DashboardPermission.get("view-option", "add-option"),
             },
             # Update Views
             {
                 "name": "dashboard:catalogue-category-update",
                 "kwargs": {"pk": category.id},
-                "permissions": DashboardPermission.get("category"),
+                "permissions": DashboardPermission.get("change-category"),
             },
             {
                 "name": "dashboard:catalogue-class-update",
                 "kwargs": {"pk": product_class.id},
-                "permissions": DashboardPermission.get("product_class"),
+                "permissions": DashboardPermission.get("change-productclass"),
             },
             {
                 "name": "dashboard:catalogue-attribute-option-group-update",
                 "kwargs": {"pk": attribute_option_group.id},
-                "permissions": DashboardPermission.get("attribute_option_group"),
+                "permissions": DashboardPermission.get(
+                    "view-attributeoptiongroup", "change-attributeoptiongroup"
+                ),
             },
             {
                 "name": "dashboard:catalogue-option-update",
                 "kwargs": {"pk": option.id},
-                "permissions": DashboardPermission.get("option"),
+                "permissions": DashboardPermission.get("view-option", "change-option"),
             },
             # List Views
             {
                 "name": "dashboard:catalogue-product-list",
-                "permissions": DashboardPermission.get("product"),
+                "permissions": DashboardPermission.get("view-product"),
             },
             {
                 "name": "dashboard:stock-alert-list",
-                "permissions": DashboardPermission.get("stockalert"),
+                "permissions": DashboardPermission.get("view-stockalert"),
             },
             {
                 "name": "dashboard:catalogue-category-list",
-                "permissions": DashboardPermission.get("category"),
+                "permissions": DashboardPermission.get("view-category"),
             },
             {
                 "name": "dashboard:catalogue-class-list",
-                "permissions": DashboardPermission.get("product_class"),
+                "permissions": DashboardPermission.get("view-productclass"),
             },
             {
                 "name": "dashboard:catalogue-attribute-option-group-list",
-                "permissions": DashboardPermission.get("attribute_option_group"),
+                "permissions": DashboardPermission.get("view-attributeoptiongroup"),
             },
             {
                 "name": "dashboard:catalogue-option-list",
-                "permissions": DashboardPermission.get("option"),
+                "permissions": DashboardPermission.get("view-option"),
             },
             # Detail Views
             {
                 "name": "dashboard:catalogue-product",
                 "kwargs": {"pk": product.id},
-                "permissions": DashboardPermission.get("product"),
+                "permissions": DashboardPermission.get("view-product"),
             },
             {
                 "name": "dashboard:catalogue-product-lookup",
-                "permissions": DashboardPermission.get("product"),
+                "permissions": DashboardPermission.get("view-product"),
             },
             {
                 "name": "dashboard:catalogue-category-detail-list",
                 "kwargs": {"pk": category.id},
-                "permissions": DashboardPermission.get("category"),
+                "permissions": DashboardPermission.get("view-category"),
             },
             # Delete Views
             {
                 "name": "dashboard:catalogue-product-delete",
                 "kwargs": {"pk": product.id},
-                "permissions": DashboardPermission.get("product"),
+                "permissions": DashboardPermission.get("delete-product"),
             },
             {
                 "name": "dashboard:catalogue-category-delete",
                 "kwargs": {"pk": category.id},
-                "permissions": DashboardPermission.get("category"),
+                "permissions": DashboardPermission.get("delete-category"),
             },
             {
                 "name": "dashboard:catalogue-class-delete",
                 "kwargs": {"pk": product_class.id},
-                "permissions": DashboardPermission.get("product_class"),
+                "permissions": DashboardPermission.get("delete-productclass"),
             },
             {
                 "name": "dashboard:catalogue-attribute-option-group-delete",
                 "kwargs": {"pk": attribute_option_group.id},
-                "permissions": DashboardPermission.get("attribute_option_group"),
+                "permissions": DashboardPermission.get(
+                    "view-attributeoptiongroup", "delete-attributeoptiongroup"
+                ),
             },
             {
                 "name": "dashboard:catalogue-option-delete",
                 "kwargs": {"pk": option.id},
-                "permissions": DashboardPermission.get("option"),
+                "permissions": DashboardPermission.get("view-option", "delete-option"),
             },
         ]
 
@@ -231,12 +237,14 @@ class CommunicationDashboardAccessTest(BaseViewPermissionTestCase):
         return [
             {
                 "name": "dashboard:comms-list",
-                "permissions": DashboardPermission.get("communication_event_type"),
+                "permissions": DashboardPermission.get("view-communication_event_type"),
             },
             {
                 "name": "dashboard:comms-update",
                 "kwargs": {"slug": communication_event_type.code},
-                "permissions": DashboardPermission.get("communication_event_type"),
+                "permissions": DashboardPermission.get(
+                    "change-communication_event_type"
+                ),
             },
         ]
 
@@ -245,60 +253,45 @@ class OfferDashboardAccessTest(BaseViewPermissionTestCase):
     def get_view_access_requirements(self):
         offer = ConditionalOfferFactory()
 
+        create_update_perm = DashboardPermission.get("add-offer", "change-offer")
+
         return [
             # List and Detail Views
             {
                 "name": "dashboard:offer-list",
-                "permissions": DashboardPermission.get("offer"),
+                "permissions": DashboardPermission.get("view-offer"),
             },
             {
                 "name": "dashboard:offer-detail",
                 "kwargs": {"pk": offer.id},
-                "permissions": DashboardPermission.get("offer"),
+                "permissions": DashboardPermission.get("view-offer"),
             },
-            # Create Views
+            # Create + Update Views
             {
                 "name": "dashboard:offer-metadata",
-                "permissions": DashboardPermission.get("offer"),
+                "permissions": create_update_perm,
+                "kwargs": {"pk": offer.id},
             },
             {
                 "name": "dashboard:offer-condition",
-                "permissions": DashboardPermission.get("offer"),
+                "permissions": create_update_perm,
+                "kwargs": {"pk": offer.id},
             },
             {
                 "name": "dashboard:offer-benefit",
-                "permissions": DashboardPermission.get("offer"),
+                "permissions": create_update_perm,
+                "kwargs": {"pk": offer.id},
             },
             {
                 "name": "dashboard:offer-restrictions",
-                "permissions": DashboardPermission.get("offer"),
-            },
-            # Update Views
-            {
-                "name": "dashboard:offer-metadata",
+                "permissions": create_update_perm,
                 "kwargs": {"pk": offer.id},
-                "permissions": DashboardPermission.get("offer"),
-            },
-            {
-                "name": "dashboard:offer-condition",
-                "kwargs": {"pk": offer.id},
-                "permissions": DashboardPermission.get("offer"),
-            },
-            {
-                "name": "dashboard:offer-benefit",
-                "kwargs": {"pk": offer.id},
-                "permissions": DashboardPermission.get("offer"),
-            },
-            {
-                "name": "dashboard:offer-restrictions",
-                "kwargs": {"pk": offer.id},
-                "permissions": DashboardPermission.get("offer"),
             },
             # Delete Views
             {
                 "name": "dashboard:offer-delete",
                 "kwargs": {"pk": offer.id},
-                "permissions": DashboardPermission.get("offer"),
+                "permissions": DashboardPermission.get("delete-offer"),
             },
         ]
 
@@ -312,31 +305,31 @@ class OrderDashboardAccessTest(BaseViewPermissionTestCase):
         return [
             {
                 "name": "dashboard:order-list",
-                "permissions": DashboardPermission.get("order"),
+                "permissions": DashboardPermission.get("view-order"),
             },
             {
                 "name": "dashboard:order-stats",
-                "permissions": DashboardPermission.get("order"),
+                "permissions": DashboardPermission.get("view-order"),
             },
             {
                 "name": "dashboard:order-detail",
                 "kwargs": {"number": order.number},
-                "permissions": DashboardPermission.get("order"),
+                "permissions": DashboardPermission.get("view-order"),
             },
             {
                 "name": "dashboard:order-detail-note",
                 "kwargs": {"number": order.number, "note_id": note.id},
-                "permissions": DashboardPermission.get("order"),
+                "permissions": DashboardPermission.get("change-order"),
             },
             {
                 "name": "dashboard:order-line-detail",
                 "kwargs": {"number": order.number, "line_id": line.id},
-                "permissions": DashboardPermission.get("order"),
+                "permissions": DashboardPermission.get("view-order"),
             },
             {
                 "name": "dashboard:order-shipping-address",
                 "kwargs": {"number": order.number},
-                "permissions": DashboardPermission.get("order"),
+                "permissions": DashboardPermission.get("view-order"),
             },
         ]
 
@@ -349,21 +342,21 @@ class PageDashboardAccessTest(BaseViewPermissionTestCase):
         return [
             {
                 "name": "dashboard:page-list",
-                "permissions": DashboardPermission.get("flat_page"),
+                "permissions": DashboardPermission.get("view-flatpage"),
             },
             {
                 "name": "dashboard:page-create",
-                "permissions": DashboardPermission.get("flat_page"),
+                "permissions": DashboardPermission.get("add-flatpage"),
             },
             {
                 "name": "dashboard:page-update",
                 "kwargs": {"pk": flatpage.id},
-                "permissions": DashboardPermission.get("flat_page"),
+                "permissions": DashboardPermission.get("change-flatpage"),
             },
             {
                 "name": "dashboard:page-delete",
                 "kwargs": {"pk": flatpage.id},
-                "permissions": DashboardPermission.get("flat_page"),
+                "permissions": DashboardPermission.get("delete-flatpage"),
             },
         ]
 
@@ -376,47 +369,49 @@ class PartnerDashboardAccessTest(BaseViewPermissionTestCase):
         return [
             {
                 "name": "dashboard:partner-list",
-                "permissions": DashboardPermission.get("partner"),
+                "permissions": DashboardPermission.get("view-partner"),
             },
             {
                 "name": "dashboard:partner-create",
-                "permissions": DashboardPermission.get("partner"),
+                "permissions": DashboardPermission.get("add-partner"),
             },
             {
                 "name": "dashboard:partner-manage",
                 "kwargs": {"pk": partner.id},
-                "permissions": DashboardPermission.get("partner"),
+                "permissions": DashboardPermission.get(
+                    "view-partner", "change-partner"
+                ),
             },
             {
                 "name": "dashboard:partner-user-create",
                 "kwargs": {"partner_pk": partner.id},
-                "permissions": DashboardPermission.get("partner"),
+                "permissions": DashboardPermission.get("add-user", "change-partner"),
             },
             {
                 "name": "dashboard:partner-user-select",
                 "kwargs": {"partner_pk": partner.id},
-                "permissions": DashboardPermission.get("partner"),
+                "permissions": DashboardPermission.get("change-partner"),
             },
             {
                 "name": "dashboard:partner-user-link",
                 "kwargs": {"partner_pk": partner.id, "user_pk": self.user.id},
-                "permissions": DashboardPermission.get("partner"),
+                "permissions": DashboardPermission.get("change-partner"),
             },
             {
                 "name": "dashboard:partner-user-update",
                 "kwargs": {"partner_pk": partner.id, "user_pk": self.user.id},
-                "permissions": DashboardPermission.get("partner"),
+                "permissions": DashboardPermission.get("change-partner", "change-user"),
             },
             {
                 "name": "dashboard:partner-user-unlink",
                 "kwargs": {"partner_pk": partner.id, "user_pk": self.user.id},
-                "permissions": DashboardPermission.get("partner"),
+                "permissions": DashboardPermission.get("change-partner"),
                 "method": "post",
             },
             {
                 "name": "dashboard:partner-delete",
                 "kwargs": {"pk": partner.id},
-                "permissions": DashboardPermission.get("partner"),
+                "permissions": DashboardPermission.get("delete-partner"),
             },
         ]
 
@@ -428,32 +423,32 @@ class RangeDashboardAccessTest(BaseViewPermissionTestCase):
         return [
             {
                 "name": "dashboard:range-list",
-                "permissions": DashboardPermission.get("range"),
+                "permissions": DashboardPermission.get("view-range"),
             },
             {
                 "name": "dashboard:range-create",
-                "permissions": DashboardPermission.get("range"),
+                "permissions": DashboardPermission.get("add-range"),
             },
             {
                 "name": "dashboard:range-update",
                 "kwargs": {"pk": offer_range.id},
-                "permissions": DashboardPermission.get("range"),
+                "permissions": DashboardPermission.get("change-range"),
             },
             {
                 "name": "dashboard:range-products",
                 "kwargs": {"pk": offer_range.id},
-                "permissions": DashboardPermission.get("range"),
+                "permissions": DashboardPermission.get("change-range"),
             },
             {
                 "name": "dashboard:range-reorder",
                 "kwargs": {"pk": offer_range.id},
-                "permissions": DashboardPermission.get("range"),
+                "permissions": DashboardPermission.get("change-range"),
                 "method": "post",
             },
             {
                 "name": "dashboard:range-delete",
                 "kwargs": {"pk": offer_range.id},
-                "permissions": DashboardPermission.get("range"),
+                "permissions": DashboardPermission.get("delete-range"),
             },
         ]
 
@@ -462,7 +457,7 @@ class ReportDashboardAccessTest(BaseViewPermissionTestCase):
     view_access_requirements = [
         {
             "name": "dashboard:reports-index",
-            "permissions": DashboardPermission.get("user_record"),
+            "permissions": DashboardPermission.get("view-user_record"),
         },
     ]
 
@@ -474,17 +469,17 @@ class ReviewDashboardAccessTest(BaseViewPermissionTestCase):
         return [
             {
                 "name": "dashboard:reviews-list",
-                "permissions": DashboardPermission.get("product_review"),
+                "permissions": DashboardPermission.get("view-product_review"),
             },
             {
                 "name": "dashboard:reviews-update",
                 "kwargs": {"pk": review.id},
-                "permissions": DashboardPermission.get("product_review"),
+                "permissions": DashboardPermission.get("change-product_review"),
             },
             {
                 "name": "dashboard:reviews-delete",
                 "kwargs": {"pk": review.id},
-                "permissions": DashboardPermission.get("product_review"),
+                "permissions": DashboardPermission.get("delete-product_review"),
             },
         ]
 
@@ -499,36 +494,36 @@ class ShippingDashboardAccessTest(BaseViewPermissionTestCase):
         return [
             {
                 "name": "dashboard:shipping-method-list",
-                "permissions": DashboardPermission.get("shipping_method"),
+                "permissions": DashboardPermission.get("view-shipping_method"),
             },
             {
                 "name": "dashboard:shipping-method-create",
-                "permissions": DashboardPermission.get("shipping_method"),
+                "permissions": DashboardPermission.get("add-shipping_method"),
             },
             {
                 "name": "dashboard:shipping-method-detail",
                 "kwargs": {"pk": weight_based.id},
-                "permissions": DashboardPermission.get("shipping_method"),
+                "permissions": DashboardPermission.get("view-shipping_method"),
             },
             {
                 "name": "dashboard:shipping-method-edit",
                 "kwargs": {"pk": weight_based.id},
-                "permissions": DashboardPermission.get("shipping_method"),
+                "permissions": DashboardPermission.get("change-shipping_method"),
             },
             {
                 "name": "dashboard:shipping-method-delete",
                 "kwargs": {"pk": weight_based.id},
-                "permissions": DashboardPermission.get("shipping_method"),
+                "permissions": DashboardPermission.get("delete-shipping_method"),
             },
             {
                 "name": "dashboard:shipping-method-band-edit",
                 "kwargs": {"pk": weight_band.id, "method_pk": weight_based.id},
-                "permissions": DashboardPermission.get("shipping_method"),
+                "permissions": DashboardPermission.get("change-shipping_method"),
             },
             {
                 "name": "dashboard:shipping-method-band-delete",
                 "kwargs": {"pk": weight_band.id, "method_pk": weight_based.id},
-                "permissions": DashboardPermission.get("shipping_method"),
+                "permissions": DashboardPermission.get("delete-shipping_method"),
             },
         ]
 
@@ -540,33 +535,33 @@ class UserDashboardAccessTest(BaseViewPermissionTestCase):
         return [
             {
                 "name": "dashboard:users-index",
-                "permissions": DashboardPermission.get("user"),
+                "permissions": DashboardPermission.get("view-user"),
             },
             {
                 "name": "dashboard:user-detail",
                 "kwargs": {"pk": self.user.id},
-                "permissions": DashboardPermission.get("user"),
+                "permissions": DashboardPermission.get("view-user"),
             },
             {
                 "name": "dashboard:user-password-reset",
                 "kwargs": {"pk": self.user.id},
-                "permissions": DashboardPermission.get("user"),
+                "permissions": DashboardPermission.get("view-user", "change-user"),
                 "method": "post",
             },
             # Alerts
             {
                 "name": "dashboard:user-alert-list",
-                "permissions": DashboardPermission.get("user"),
+                "permissions": DashboardPermission.get("view-user"),
             },
             {
                 "name": "dashboard:user-alert-update",
                 "kwargs": {"pk": alert.id},
-                "permissions": DashboardPermission.get("user"),
+                "permissions": DashboardPermission.get("change-user"),
             },
             {
                 "name": "dashboard:user-alert-delete",
                 "kwargs": {"pk": alert.id},
-                "permissions": DashboardPermission.get("user"),
+                "permissions": DashboardPermission.get("delete-user"),
             },
         ]
 
@@ -580,54 +575,54 @@ class VoucherDashboardAccessTest(BaseViewPermissionTestCase):
             # Vouchers
             {
                 "name": "dashboard:voucher-list",
-                "permissions": DashboardPermission.get("voucher"),
+                "permissions": DashboardPermission.get("view-voucher"),
             },
             {
                 "name": "dashboard:voucher-stats",
                 "kwargs": {"pk": voucher.id},
-                "permissions": DashboardPermission.get("voucher"),
+                "permissions": DashboardPermission.get("view-voucher"),
             },
             {
                 "name": "dashboard:voucher-create",
-                "permissions": DashboardPermission.get("voucher"),
+                "permissions": DashboardPermission.get("add-voucher"),
             },
             {
                 "name": "dashboard:voucher-update",
                 "kwargs": {"pk": voucher.id},
-                "permissions": DashboardPermission.get("voucher"),
+                "permissions": DashboardPermission.get("change-voucher"),
             },
             {
                 "name": "dashboard:voucher-delete",
                 "kwargs": {"pk": voucher.id},
-                "permissions": DashboardPermission.get("voucher"),
+                "permissions": DashboardPermission.get("delete-voucher"),
             },
             # Voucher Sets
             {
                 "name": "dashboard:voucher-set-list",
-                "permissions": DashboardPermission.get("voucher"),
+                "permissions": DashboardPermission.get("view-voucher"),
             },
             {
                 "name": "dashboard:voucher-set-create",
-                "permissions": DashboardPermission.get("voucher"),
+                "permissions": DashboardPermission.get("add-voucher"),
             },
             {
                 "name": "dashboard:voucher-set-update",
                 "kwargs": {"pk": voucher_set.id},
-                "permissions": DashboardPermission.get("voucher"),
+                "permissions": DashboardPermission.get("change-voucher"),
             },
             {
                 "name": "dashboard:voucher-set-detail",
                 "kwargs": {"pk": voucher_set.id},
-                "permissions": DashboardPermission.get("voucher"),
+                "permissions": DashboardPermission.get("view-voucher"),
             },
             {
                 "name": "dashboard:voucher-set-download",
                 "kwargs": {"pk": voucher_set.id},
-                "permissions": DashboardPermission.get("voucher"),
+                "permissions": DashboardPermission.get("view-voucher"),
             },
             {
                 "name": "dashboard:voucher-set-delete",
                 "kwargs": {"pk": voucher_set.id},
-                "permissions": DashboardPermission.get("voucher"),
+                "permissions": DashboardPermission.get("delete-voucher"),
             },
         ]

--- a/tests/integration/templatetags/test_dashboard_permissions.py
+++ b/tests/integration/templatetags/test_dashboard_permissions.py
@@ -1,0 +1,89 @@
+from django.test import TestCase, RequestFactory
+from django.contrib.auth.models import Permission
+from oscar.core.compat import get_user_model
+from django.template import Context, Template
+from oscar.core.loading import get_class
+
+User = get_user_model()
+DashboardPermission = get_class("dashboard.permissions", "DashboardPermission")
+
+
+class HasDashboardPermissionTagTests(TestCase):
+    """
+    Tests for the has_dashboard_permission template tag.
+    Covers:
+    - Tuple-of-lists (OR-of-ANDs) permission checks
+    - Single-list (all permissions required) checks
+    - Missing permissions returns False
+    - No section in permissions_map returns False
+    """
+
+    def setUp(self):
+        """
+        Create a test user and give them the 'view-order' and 'view-offer' permissions.
+        """
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(
+            email="testuser@example.com", username="testuser", password="pass"
+        )
+
+        permission_codes = DashboardPermission.get("view-order", "view-offer")
+        for perm in permission_codes:
+            app_label, codename = perm.split(".", 1)
+            permission = Permission.objects.filter(
+                content_type__app_label=app_label, codename=codename
+            ).first()
+            self.user.user_permissions.add(permission)
+
+    def test_order_list_permissions_tuple_of_lists(self):
+        """
+        order-list should match tuple-of-lists required permissions.
+        """
+        template = Template(
+            "{% load dashboard_permissions %}"
+            '{% has_dashboard_permission "order-list" "orders_dashboard" as can_view_order %}'
+            "{{ can_view_order }}"
+        )
+        context = Context({"request": self.factory.get("/"), "user": self.user})
+        rendered = template.render(context).strip()
+        self.assertEqual(rendered, "True")
+
+    def test_offer_list_permissions_single_list(self):
+        """
+        offer-list should match single list of required permissions.
+        """
+        template = Template(
+            "{% load dashboard_permissions %}"
+            '{% has_dashboard_permission "offer-list" "offers_dashboard" as can_view_offer %}'
+            "{{ can_view_offer }}"
+        )
+        context = Context({"request": self.factory.get("/"), "user": self.user})
+        rendered = template.render(context).strip()
+        self.assertEqual(rendered, "True")
+
+    def test_returns_false_if_user_missing_permission(self):
+        """
+        Should return False when user lacks the required permissions.
+        """
+        self.user.user_permissions.clear()
+        template = Template(
+            "{% load dashboard_permissions %}"
+            '{% has_dashboard_permission "order-list" "orders_dashboard" as can_view_order %}'
+            "{{ can_view_order }}"
+        )
+        context = Context({"request": self.factory.get("/"), "user": self.user})
+        rendered = template.render(context).strip()
+        self.assertEqual(rendered, "False")
+
+    def test_returns_false_if_section_not_in_permissions_map(self):
+        """
+        Should return False if section is not present in the app's permissions_map.
+        """
+        template = Template(
+            "{% load dashboard_permissions %}"
+            '{% has_dashboard_permission "nonexistent-section" "orders_dashboard" as can_view %}'
+            "{{ can_view }}"
+        )
+        context = Context({"request": self.factory.get("/"), "user": self.user})
+        rendered = template.render(context).strip()
+        self.assertEqual(rendered, "False")

--- a/tests/unit/dashboard/test_permissions.py
+++ b/tests/unit/dashboard/test_permissions.py
@@ -17,5 +17,5 @@ class DashboardPermissionCheckTestCase(TestCase):
 
         # reloading user to purge the _perm_cache
         user = User._default_manager.get(pk=user.pk)
-        add_permissions(user, DashboardPermission.permissions["product"])
+        add_permissions(user, DashboardPermission.get("view-product"))
         self.assertTrue(DashboardPermission.has_dashboard_perms(user))


### PR DESCRIPTION
### Description

This PR introduces the has_dashboard_permission tag for fine-grained dashboard access control.

### Changes

- Added custom template tag leveraging app view permissions (e.g., offer-list).
- Updated templates to use granular checks (offer-list, add-offer, change-offer, delete-offer, etc.).
- Navigation and actions (e.g., Delete) now only render if the user has the required permission.
- Updated unit tests to validate behavior with the new permission checks.