### PR TITLE
Update CDN version of jQuery to 3.7.1

### DIFF
--- a/src/oscar/templates/oscar/base.html
+++ b/src/oscar/templates/oscar/base.html
@@ -35,7 +35,7 @@
         {# Scripts loaded from a CDN. #}
         {% block cdn_scripts %}
             <!-- jQuery -->
-            <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+            <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
             <script>window.jQuery || document.write('<script src="{% static "oscar/js/jquery/jquery.min.js" %}"><\/script>')</script>
         {% endblock %}
 


### PR DESCRIPTION
Hey,

the local jQuery version is set to ^3.7.1 in the package.json but the CDN version in the template is still at 3.6.0.

This bumps the template version to 3.7.1 so both are in sync again.



Or should we just remove the CDN version altogether?
Not using a CDN seems like a more reasonable/modern default to me.