### PR TITLE
deps: compatibility with django-treebeard 5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     # Search support
     "django-haystack>=3.0b1",
     # Treebeard is used for categories
-    "django-treebeard>=4.3.0",
+    "django-treebeard>=4.7.0",
     # Babel is used for currency formatting
     "Babel>=1.0,<3.0",
     # For manipulating search URLs

--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -264,8 +264,8 @@ class AbstractCategory(MP_Node):
         return children.filter(is_public=True)
 
     @classmethod
-    def fix_tree(cls, destructive=False, fix_paths=False):
-        super().fix_tree(destructive, fix_paths)
+    def fix_tree(cls, fix_paths=False, **kwargs):  # pylint: disable=W0221
+        super().fix_tree(fix_paths=fix_paths, **kwargs)
         for node in cls.get_root_nodes():
             # ancestors_are_public *must* be True for root nodes, or all trees
             # will become non-public
@@ -333,10 +333,10 @@ class AbstractCategory(MP_Node):
         verbose_name_plural = _("Categories")
 
     def has_children(self):
-        return self.get_num_children() > 0
+        return self.get_children().exists()
 
     def get_num_children(self):
-        return self.get_children().count()
+        return self.get_children_count()
 
 
 class AbstractProductCategory(models.Model):

--- a/tests/functional/dashboard/test_category.py
+++ b/tests/functional/dashboard/test_category.py
@@ -5,6 +5,8 @@ from oscar.apps.catalogue.models import Category
 from oscar.core.loading import get_class
 from oscar.test.testcases import WebTestCase
 
+from treebeard import __version__ as treebeard_version
+
 DashboardPermission = get_class("dashboard.permissions", "DashboardPermission")
 
 
@@ -17,6 +19,12 @@ class TestCategoryDashboard(WebTestCase):
         "view_category",
         "delete_category",
         "add_category",
+    )
+    TREEBEARD_POS_FIELD = (
+        "treebeard_position" if treebeard_version >= "5" else "_position"
+    )
+    TREEBEARD_REF_FIELD = (
+        "treebeard_ref_node" if treebeard_version >= "5" else "_ref_node_id"
     )
 
     def setUp(self):
@@ -31,8 +39,8 @@ class TestCategoryDashboard(WebTestCase):
         )
         form = category_add.forms["create_update_category_form"]
         form["name"] = "Top-level category"
-        form["_position"] = "right"
-        form["_ref_node_id"] = a.id
+        form[self.TREEBEARD_POS_FIELD] = "right"
+        form[self.TREEBEARD_REF_FIELD] = a.id
         response = form.submit()
         self.assertRedirects(response, reverse("dashboard:catalogue-category-list"))
 
@@ -44,8 +52,8 @@ class TestCategoryDashboard(WebTestCase):
         )
         form = category_add.forms["create_update_category_form"]
         form["name"] = "Child category"
-        form["_position"] = "left"
-        form["_ref_node_id"] = c.id
+        form[self.TREEBEARD_POS_FIELD] = "left"
+        form[self.TREEBEARD_REF_FIELD] = c.id
         response = form.submit()
         self.assertRedirects(
             response, reverse("dashboard:catalogue-category-detail-list", args=(b.pk,))


### PR DESCRIPTION
Treebeard v5 is now available. This PR:

- Adds compatibility for Treebeard 5.0
- Raises minimum version of Treebeard to 4.7 (earliest version to declare support for Django 4.2)

Note that the tests on the main branch will fail until this is applied, because Oscar doesn't impose an upper limit on the version dependency for treebeard.