### PR TITLE
Bump minimum Django version to 4.2.26 (CVE-2025-64459)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 keywords = ["E-commerce", "Django", "domain-driven"]
 dependencies = [
-    "django>=4.2,<5.3",
+    "django>=4.2.26,<5.3",
     # PIL is required for image fields, Pillow is the "friendly" PIL fork
     "pillow>=6.0",
     # We use the ModelFormSetView from django-extra-views for the basket page


### PR DESCRIPTION
Django versions below 4.2.26 are affected by CVE-2025-64459 (CVSS 9.1), a SQL injection vulnerability in the ORM. When a developer passes user-controlled dictionary keys directly to `filter(**kwargs)`, attackers can inject `_connector=OR` or `_negated=True` to manipulate the WHERE clause logic.

The fix was released in Django 4.2.26, 5.1.14, and 5.2.8.

This PR bumps the minimum required Django version from `>=4.2` to `>=4.2.26` to ensure downstream projects installing django-oscar are protected against this vulnerability.

Reference: https://www.djangoproject.com/weblog/2025/may/07/security-releases/