### PR TITLE
fix: Sanitize HTML in description fields to prevent stored XSS ( GHSA-rvcc-4w2x-g7xv)

### DIFF
--- a/src/oscar/apps/dashboard/catalogue/forms.py
+++ b/src/oscar/apps/dashboard/catalogue/forms.py
@@ -6,6 +6,8 @@ from treebeard.forms import movenodeform_factory
 from oscar.core.loading import get_class, get_classes, get_model
 from oscar.core.utils import slugify
 from oscar.forms.widgets import DateTimePickerInput, ImageInput
+import nh3
+
 
 Product = get_model("catalogue", "Product")
 ProductClass = get_model("catalogue", "ProductClass")
@@ -67,6 +69,9 @@ class CategoryForm(SEOFormMixin, BaseCategoryForm):
             self.fields["slug"].help_text = _(
                 "Leave blank to generate from category name"
             )
+
+    def clean_description(self):
+        return nh3.clean(self.cleaned_data.get("description") or "")
 
 
 class ProductClassSelectForm(forms.Form):
@@ -316,6 +321,9 @@ class ProductForm(SEOFormMixin, forms.ModelForm):
         for field_name in ["description", "is_discountable"]:
             if field_name in self.fields:
                 del self.fields[field_name]
+
+    def clean_description(self):
+        return nh3.clean(self.cleaned_data.get("description") or "")
 
     def _post_clean(self):
         """

--- a/tests/integration/dashboard/catalogue/test_forms_xss.py
+++ b/tests/integration/dashboard/catalogue/test_forms_xss.py
@@ -1,0 +1,25 @@
+from django.test import SimpleTestCase
+from oscar.apps.dashboard.catalogue.forms import ProductForm, CategoryForm
+
+class TestProductFormXSS(SimpleTestCase):
+    def test_script_tag_sanitized_in_description(self):
+        """Fails if clean_description() is removed from ProductForm"""
+        form = ProductForm.__new__(ProductForm)
+        form.cleaned_data = {"description": "<script>alert(1)</script>"}
+        result = form.clean_description()
+        assert "<script>" not in result
+
+    def test_safe_html_allowed_in_description(self):
+        """Safe HTML must survive sanitization"""
+        form = ProductForm.__new__(ProductForm)
+        form.cleaned_data = {"description": "<p><b>Bold</b></p>"}
+        result = form.clean_description()
+        assert "<p>" in result
+
+class TestCategoryFormXSS(SimpleTestCase):
+    def test_script_tag_sanitized_in_description(self):
+        """Fails if clean_description() is removed from CategoryForm"""
+        form = CategoryForm.__new__(CategoryForm)
+        form.cleaned_data = {"description": "<script>alert(1)</script>"}
+        result = form.clean_description()
+        assert "<script>" not in result


### PR DESCRIPTION
## Summary
This PR fixes a stored XSS vulnerability in the dashboard by sanitizing 
HTML input in description fields using the `nh3` library.

## Problem
An authenticated staff user could inject arbitrary JavaScript into the 
`description` field of Products and Categories. The payload was persisted 
and executed in the browser of every user viewing the affected page.

## Solution
Added `clean_description()` methods to `ProductForm` and `CategoryForm` 
that sanitize HTML input using `nh3`. Safe HTML tags like `<p>`, `<b>`, 
`<a>` etc. are preserved so rich text content continues to work as expected.

## Changes
- `src/oscar/apps/dashboard/catalogue/forms.py`: Added `clean_description()` 
  to `ProductForm` and `CategoryForm`
- `tests/integration/dashboard/catalogue/test_forms_xss.py`: Added tests 
  to verify XSS payloads are stripped and safe HTML is preserved

## Testing
- Verified `<script>alert(1)</script>` is stripped after fix
- Verified `<p><b>Bold</b></p>` is preserved
- All tests passing

Fixes  GHSA-rvcc-4w2x-g7xv