### PR TITLE
fix: correct namespace for notifications-inbox

### DIFF
--- a/src/oscar/apps/communication/notifications/views.py
+++ b/src/oscar/apps/communication/notifications/views.py
@@ -78,7 +78,7 @@ class UpdateView(BulkEditMixin, generic.View):
         return self.model.objects.filter(recipient=self.request.user).in_bulk(ids)
 
     def get_success_response(self):
-        return redirect_to_referrer(self.request, "communication:notifications-inbox")
+        return redirect_to_referrer(self.request, "customer:notifications-inbox")
 
     def archive(self, request, notifications):
         for notification in notifications:


### PR DESCRIPTION
Hello,

I've noticed that the notification delete/archive actions trigger an exception. That seems to be because the success URL points to `communication:notifications-inbox` which does not exist. It should actually point to `customer:notifications-inbox` as the URL is defined in the customer app/namespace.

All other places seem to use the correct identifier (grep for 'notifications-inbox').

Thank you!