### PR TITLE
Remove broken Transifex link from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ Docs status:
 .. _`Twitter account for news and updates`: https://twitter.com/#!/django_oscar
 .. _`django-oscar group`: https://groups.google.com/forum/?fromgroups#!forum/django-oscar
 .. _`PyPI page`: https://pypi.python.org/pypi/django-oscar/
-.. _`Transifex project`: https://www.transifex.com/projects/p/django-oscar/
+.. _`Transifex project`: https://explore.transifex.com/codeinthehole/django-oscar/
 .. _`Discord`: https://discord.gg/NMwfZuJnJZ
 
 Core team:


### PR DESCRIPTION
The Transifex project link (https://www.transifex.com/projects/p/django-oscar/) 
returns 404. Removed the broken link and its reference from README.rst.

Fixes #4527