### PR TITLE
Fix/get applicable lines null range check

### DIFF
--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -3,6 +3,7 @@ import csv
 import operator
 from decimal import ROUND_DOWN
 from decimal import Decimal as D
+from django.core.exceptions import ImproperlyConfigured
 
 from django.conf import settings
 from django.core import exceptions
@@ -794,6 +795,11 @@ class AbstractBenefit(BaseOfferMixin, models.Model):
         """
         if range is None:
             range = self.range
+        if range is None:
+            raise ImproperlyConfigured(
+                "Benefit '%s' has no range set. A range is required "
+                "for get_applicable_lines to work." % self.__class__.__name__
+            )    
         line_tuples = []
         for line in basket.all_lines():
             product = line.product


### PR DESCRIPTION
When a custom benefit class is used without a range, `get_applicable_lines` 
crashes with `'NoneType' object has no attribute 'contains_product'`.

This fix adds a null check after `range = self.range` and raises 
`ImproperlyConfigured` with a clear error message instead of crashing silently.

Fixes #4506