### PR TITLE
[FEAT] Allow guest checkout for customers with an existing account

### DIFF
--- a/docs/source/ref/settings.rst
+++ b/docs/source/ref/settings.rst
@@ -222,6 +222,16 @@ Specifies if an anonymous user can buy products without creating an account
 first.  If set to ``False`` users are required to authenticate before they can
 checkout (using Oscar's default checkout views).
 
+``OSCAR_ALLOW_GUEST_CHECKOUT_WITH_ACCOUNT``
+-------------------------------------------
+
+Default: ``False``
+
+Specifies whether a customer who already has an account can check out as a
+guest.  By default, when a guest enters an email address that matches an
+existing account, Oscar forces them to sign in.  If set to ``True``, such
+customers are allowed to proceed as a guest instead.
+
 ``OSCAR_REQUIRED_ADDRESS_FIELDS``
 ---------------------------------
 

--- a/src/oscar/apps/checkout/forms.py
+++ b/src/oscar/apps/checkout/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.conf import settings
 from django.contrib.auth.forms import AuthenticationForm
 from django.utils.translation import gettext_lazy as _
 
@@ -79,7 +80,15 @@ class GatewayForm(AuthenticationForm):
         if self.is_guest_checkout() or self.is_new_account_checkout():
             if "password" in self.errors:
                 del self.errors["password"]
-            if "username" in self.cleaned_data:
+            # Guests with an existing account are normally forced to sign in.
+            # When OSCAR_ALLOW_GUEST_CHECKOUT_WITH_ACCOUNT is enabled, we let
+            # them proceed as a guest instead. The check is always enforced for
+            # new account checkout, where a duplicate email is invalid.
+            skip_existing_check = (
+                self.is_guest_checkout()
+                and settings.OSCAR_ALLOW_GUEST_CHECKOUT_WITH_ACCOUNT
+            )
+            if not skip_existing_check and "username" in self.cleaned_data:
                 email = normalise_email(self.cleaned_data["username"])
                 if User._default_manager.filter(email__iexact=email).exists():
                     msg = _("A user with that email address already exists")

--- a/src/oscar/defaults.py
+++ b/src/oscar/defaults.py
@@ -55,6 +55,9 @@ OSCAR_DASHBOARD_ITEMS_PER_PAGE = 20
 
 # Checkout
 OSCAR_ALLOW_ANON_CHECKOUT = False
+# Allow customers who already have an account to check out as a guest, instead
+# of forcing them to sign in when their email matches an existing account.
+OSCAR_ALLOW_GUEST_CHECKOUT_WITH_ACCOUNT = False
 
 # Reviews
 OSCAR_ALLOW_ANON_REVIEWS = True

--- a/tests/functional/checkout/test_guest_checkout.py
+++ b/tests/functional/checkout/test_guest_checkout.py
@@ -130,6 +130,25 @@ class TestIndexView(
             "be changed to existing, so the user can enter his password",
         )
 
+    @override_settings(OSCAR_ALLOW_GUEST_CHECKOUT_WITH_ACCOUNT=True)
+    def test_guest_checkout_allowed_for_existing_user(self):
+        email = "forgetfulguest@test.com"
+        self.create_user(email, email, self.password)
+
+        self.add_product_to_basket()
+
+        # select guest checkout with an email that already has an account
+        page = self.get(reverse("checkout:index"))
+        form = page.form
+        form["options"].select(GatewayForm.GUEST)
+        form["username"].value = email
+
+        response = form.submit()
+
+        # The customer is allowed to proceed as a guest rather than being
+        # forced to sign in.
+        self.assertRedirectsTo(response, "checkout:shipping-address")
+
 
 @override_settings(OSCAR_ALLOW_ANON_CHECKOUT=True)
 class TestShippingAddressView(


### PR DESCRIPTION
Previously, an anonymous customer who entered an email matching an existing
account at the checkout gateway was forced to sign in. This adds the
`OSCAR_ALLOW_GUEST_CHECKOUT_WITH_ACCOUNT` setting (default `False`) which lets
them proceed as a guest instead. The duplicate-email check still applies to
new-account checkout.