### PR TITLE
Fix warning caused by Category manager not subclassing Treebeard's manager

### DIFF
--- a/src/oscar/apps/catalogue/abstract_models.py
+++ b/src/oscar/apps/catalogue/abstract_models.py
@@ -36,8 +36,8 @@ from oscar.models.fields import AutoSlugField, NullCharField
 from oscar.models.fields.slugfield import SlugField
 from oscar.utils.models import get_image_upload_path
 
-CategoryQuerySet, ProductQuerySet = get_classes(
-    "catalogue.managers", ["CategoryQuerySet", "ProductQuerySet"]
+CategoryQuerySet, CategoryManager, ProductQuerySet = get_classes(
+    "catalogue.managers", ["CategoryQuerySet", "CategoryManager", "ProductQuerySet"]
 )
 ProductAttributesContainer = get_class(
     "catalogue.product_attributes", "ProductAttributesContainer"
@@ -180,7 +180,7 @@ class AbstractCategory(MP_Node):
     _slug_separator = "/"
     _full_name_separator = " > "
 
-    objects = CategoryQuerySet.as_manager()
+    objects = CategoryManager.from_queryset(CategoryQuerySet)()
 
     def __str__(self):
         return self.full_name

--- a/src/oscar/apps/catalogue/managers.py
+++ b/src/oscar/apps/catalogue/managers.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from django.db import models
 from django.db.models import Exists, OuterRef, Prefetch, F, Q
 from django.db.models.constants import LOOKUP_SEP
-from treebeard.mp_tree import MP_NodeQuerySet
+from treebeard.mp_tree import MP_NodeQuerySet, MP_NodeManager
 
 from oscar.core.loading import get_model
 
@@ -264,3 +264,9 @@ class CategoryQuerySet(MP_NodeQuerySet):
                 condition |= Q(path__startswith=path)
             qs = qs.exclude(condition)
         return qs
+
+
+class CategoryManager(MP_NodeManager):
+    def get_queryset(self):
+        # Ignore the parent class method, which applies ordering, and use Django's default
+        return super(MP_NodeManager, self).get_queryset()


### PR DESCRIPTION
Treebeard 5.3.0 reports a [warning](https://github.com/django-treebeard/django-treebeard/blob/master/CHANGES.md#release-530-jun-24-2026) when the default manager for a tree model does not subclass the corresponding Treebeard manager class. This is because the next major release of Treebeard will move many table-level class methods from the model class into the manager.

This has always been a [documented requirement](https://django-treebeard.readthedocs.io/en/latest/caveats.html#overriding-the-default-manager), but is now being enforced.

This tweaks the instantiation of the manager on the Category model so that it subclasses the upstream manager.