### PR TITLE
Fix excluded_categories not applied when includes_all_products=False

### DIFF
--- a/src/oscar/apps/dashboard/ranges/views.py
+++ b/src/oscar/apps/dashboard/ranges/views.py
@@ -137,6 +137,9 @@ class RangeProductListView(BulkEditMixin, ListView):
         ctx = super().get_context_data(**kwargs)
         product_range = self.get_product_range()
         ctx["range"] = product_range
+        ctx["products_effectively_excluded"] = (
+            product_range.get_products_effectively_excluded()
+        )
         if "form" not in ctx:
             ctx["form"] = self.form_class(
                 product_range,

--- a/src/oscar/apps/offer/abstract_models.py
+++ b/src/oscar/apps/offer/abstract_models.py
@@ -1195,13 +1195,71 @@ class AbstractRange(models.Model):
                 ):
                     _filter |= Q(parent__categories__in=expanded_range_categories)
 
+        # extend exclusion filter if excluded_categories exist
+        _exclude_filter = Q()
+        if self.excluded_categories.exists():
+            if use_productcategory_materialised_view():
+                excluded_product_ids = ProductCategoryHierarchy.objects.filter(
+                    category_id__in=self.excluded_categories.values_list(
+                        "id", flat=True
+                    )
+                ).values_list("product_id", flat=True)
+
+                _exclude_filter |= Q(id__in=excluded_product_ids)
+                _exclude_filter |= Q(parent__id__in=excluded_product_ids)
+
+            else:
+                expanded_excluded_categories = ExpandDownwardsCategoryQueryset(
+                    self.excluded_categories.values("id")
+                )
+                _exclude_filter |= Q(categories__in=expanded_excluded_categories)
+                if (
+                    Product.objects.exclude(parent=None)
+                    .filter(parent__categories__in=expanded_excluded_categories)
+                    .exists()
+                ):
+                    _exclude_filter |= Q(
+                        parent__categories__in=expanded_excluded_categories
+                    )
+
         qs = Product.objects.filter(_filter, ~Q(excludes=self))
+        if _exclude_filter:
+            qs = qs.exclude(_exclude_filter)
 
         if Product.objects.filter(parent__excludes=self).exists():
             qs = qs.filter(~Q(parent__excludes=self))
 
         # make sure to filter out duplicates originating from a join
         return qs.distinct()
+
+    def get_products_effectively_excluded(self):
+        if self.proxy:
+            return self.proxy.get_products_effectively_excluded()
+        return self.products_excluded
+
+    @cached_property
+    def products_excluded(self):
+        """
+        Returns a queryset of products that are effectively excluded by this
+        range's rules. Includes products explicitly in excluded_products and
+        products whose categories are in excluded_categories.
+        """
+        Product = self.excluded_products.model
+        explicitly_excluded_ids = self.excluded_products.values_list("id", flat=True)
+
+        category_excluded_q = Q()
+        if self.excluded_categories.exists():
+            expanded_excluded_categories = ExpandDownwardsCategoryQueryset(
+                self.excluded_categories.values("id")
+            )
+            category_excluded_q |= Q(categories__in=expanded_excluded_categories)
+            category_excluded_q |= Q(
+                parent__categories__in=expanded_excluded_categories
+            )
+
+        return Product.objects.filter(
+            Q(id__in=explicitly_excluded_ids) | category_excluded_q
+        ).distinct()
 
     @property
     def is_editable(self):

--- a/src/oscar/templates/oscar/dashboard/ranges/range_product_list.html
+++ b/src/oscar/templates/oscar/dashboard/ranges/range_product_list.html
@@ -212,7 +212,7 @@
           {% endif %}
           {% endwith %}
 
-          {% if range.excluded_products.count %}
+          {% if products_effectively_excluded %}
             <form id="remove_excluded_products_range_form" method="post">
               {% csrf_token %}
               <table class="table table-striped table-bordered table-hover">
@@ -235,7 +235,7 @@
                   </tr>
                 </thead>
                 <tbody class="product_list">
-                  {% for product in range.excluded_products.all %}
+                  {% for product in products_effectively_excluded %}
                     <tr id="product_{{ product.pk }}">
                       <td>
                         <input type="checkbox" name="selected_product" value="{{ product.id }}" />

--- a/tests/integration/offer/test_range.py
+++ b/tests/integration/offer/test_range.py
@@ -387,3 +387,88 @@ class TestRangeQuerySet(TestCase):
             0,
             "No ranges should contain child2 after explicitly removing it from the only range that contained it",
         )
+
+
+class TestExcludedCategoryInPartialRange(TestCase):
+    """
+    Tests for bug #4479 — excluded_categories should remove products from
+    all_products() even when includes_all_products=False.
+    """
+
+    def setUp(self):
+        self.range = models.Range.objects.create(
+            name="Partial range with excluded category",
+            includes_all_products=False,
+        )
+        self.included_category = catalogue_models.Category.add_root(name="Sneakers")
+        self.excluded_category = catalogue_models.Category.add_root(name="Nike")
+
+        self.product_included = create_product()
+        catalogue_models.ProductCategory.objects.create(
+            product=self.product_included, category=self.included_category
+        )
+
+        self.product_excluded = create_product()
+        catalogue_models.ProductCategory.objects.create(
+            product=self.product_excluded, category=self.excluded_category
+        )
+
+        self.range.included_categories.add(self.included_category)
+        self.range.excluded_categories.add(self.excluded_category)
+
+    def test_excluded_category_product_not_in_all_products(self):
+        all_products = self.range.all_products()
+        self.assertIn(self.product_included, all_products)
+        self.assertNotIn(self.product_excluded, all_products)
+
+    @override_settings(OSCAR_CATALOGUE_USE_POSTGRES_MATERIALISED_VIEWS=True)
+    def test_excluded_category_product_not_in_all_products_materialised(self):
+        self.product_included.categories.add(self.included_category)
+        self.product_excluded.categories.add(self.excluded_category)
+        all_products = self.range.all_products()
+        self.assertIn(self.product_included, all_products)
+        self.assertNotIn(self.product_excluded, all_products)
+
+
+class TestGetProductsEffectivelyExcluded(TestCase):
+    """
+    Tests for get_products_effectively_excluded() — powers the dashboard
+    excluded products table (bug #4479).
+    """
+
+    def setUp(self):
+        self.range = models.Range.objects.create(
+            name="Range for exclusion display",
+            includes_all_products=False,
+        )
+        self.included_category = catalogue_models.Category.add_root(name="Footwear")
+        self.excluded_category = catalogue_models.Category.add_root(name="Boots")
+
+        self.product_included = create_product()
+        catalogue_models.ProductCategory.objects.create(
+            product=self.product_included, category=self.included_category
+        )
+
+        self.product_excluded_by_category = create_product()
+        catalogue_models.ProductCategory.objects.create(
+            product=self.product_excluded_by_category, category=self.excluded_category
+        )
+
+        self.product_excluded_explicitly = create_product()
+
+        self.range.included_categories.add(self.included_category)
+        self.range.excluded_categories.add(self.excluded_category)
+        self.range.excluded_products.add(self.product_excluded_explicitly)
+
+    def test_category_derived_exclusions_appear(self):
+        excluded = self.range.get_products_effectively_excluded()
+        self.assertIn(self.product_excluded_by_category, excluded)
+
+    def test_explicit_exclusions_appear(self):
+        excluded = self.range.get_products_effectively_excluded()
+        self.assertIn(self.product_excluded_explicitly, excluded)
+
+    def test_included_products_do_not_appear(self):
+        excluded = self.range.get_products_effectively_excluded()
+        self.assertNotIn(self.product_included, excluded)
+


### PR DESCRIPTION
Fixes #4479

## What is the issue?

In the dashboard's Range section, when `includes_all_products=False` (a partial range), adding a category to the "excluded categories" did not effectively remove those products from the range's core queryset (`product_queryset`), and did not display them in the "Excluded Products" table. The table was only checking the raw `excluded_products` ManyToMany field, ignoring category-based exclusions entirely.

## What does this PR do?

This PR implements a fix to ensure that category-based exclusions work identically to category-based inclusions, both under the hood and in the dashboard.

**Specific changes:**

1. **Core queryset fix** (`src/oscar/apps/offer/abstract_models.py`)
   - Updated `AbstractRange.product_queryset` so that when `includes_all_products=False`, it now computes an `_exclude_filter` based on `excluded_categories` (expanding downwards to child categories/products) and applies it to the final queryset via `.exclude()`.
   - Added a new `products_excluded` cached property and `get_products_effectively_excluded()` method to `AbstractRange` to fetch all excluded products (combining explicit `excluded_products` and products in `excluded_categories`).

2. **Dashboard view update** (`src/oscar/apps/dashboard/ranges/views.py`)
   - Updated `RangeProductListView.get_context_data` to pass `products_effectively_excluded` into the template context.

3. **Dashboard template update** (`src/oscar/templates/oscar/dashboard/ranges/range_product_list.html`)
   - Replaced the raw `range.excluded_products.all` loop with `products_effectively_excluded`, so the table reflects both explicit and category-derived exclusions.

4. **Tests** (`tests/integration/offer/test_range.py`)
   - Added `TestExcludedCategoryInPartialRange` to verify `product_queryset` correctly filters out excluded categories.
   - Added `TestGetProductsEffectivelyExcluded` to verify explicit and category-based exclusions are aggregated correctly for the dashboard.

## Verification

Verified manually in the Django Oscar sandbox (before/after dashboard behavior) and with automated tests. Full existing test suite passes with no regressions.