### PR TITLE
[Fix] Preserve basket line order when creating order lines

### DIFF
--- a/src/oscar/apps/order/utils.py
+++ b/src/oscar/apps/order/utils.py
@@ -120,13 +120,17 @@ class OrderCreator(object):
             for voucher in basket.vouchers.all():
                 self.record_voucher_usage(order, voucher, user)
 
+            # Create the lines in basket order, so that the resulting line pks
+            # preserve the order the customer saw in their basket.
+            for line in basket.all_lines():
+                self.create_line_models(order, line)
+
             # Allocate stock in a deterministic (stock-record) order so that
             # concurrent placements take the row locks in the same order and
             # can't deadlock.
             for line in sorted(
                 basket.all_lines(), key=lambda line: line.stockrecord_id
             ):
-                self.create_line_models(order, line)
                 self.update_stock_records(line)
 
         # Send signal for analytics to pick up

--- a/tests/integration/order/test_creator.py
+++ b/tests/integration/order/test_creator.py
@@ -132,6 +132,26 @@ class TestSuccessfulOrderCreation(TestCase):
         lines = order.lines.all()
         self.assertEqual(1, len(lines))
 
+    def test_creates_lines_in_basket_order(self):
+        first = factories.create_product(title="First")
+        second = factories.create_product(title="Second")
+        factories.create_stockrecord(second, price=D("12.00"), num_in_stock=5)
+        factories.create_stockrecord(first, price=D("12.00"), num_in_stock=5)
+        self.assertGreater(first.stockrecords.get().pk, second.stockrecords.get().pk)
+
+        add_product(self.basket, product=first)
+        add_product(self.basket, product=second)
+
+        place_order(
+            self.creator,
+            surcharges=self.surcharges,
+            basket=self.basket,
+            order_number="1234",
+        )
+
+        order = Order.objects.get(number="1234")
+        self.assertEqual([line.product for line in order.lines.all()], [first, second])
+
     def test_sets_correct_order_status(self):
         add_product(self.basket, D("12.00"))
         place_order(


### PR DESCRIPTION
https://github.com/django-oscar/django-oscar/pull/4594 fixed a deadlock by allocating stock in stockrecord order, but it sorted the combined loop — so create_line_models also ran in stockrecord order. Since Line.Meta.ordering = ["pk"] ("enforce sorting in order of creation"), order lines were displayed in stockrecord order rather than the order the customer saw in their basket, affecting order detail pages, invoices and emails.
This update splits the loop in two: create lines in basket order, allocate stock in stockrecord order.