### PR TITLE
fix: bulk actions discarding a returned HttpResponse

### DIFF
--- a/src/oscar/views/generic.py
+++ b/src/oscar/views/generic.py
@@ -2,7 +2,7 @@ import hashlib
 import time
 
 from django.contrib import messages
-from django.http import JsonResponse
+from django.http import HttpResponseBase, JsonResponse
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.utils.encoding import smart_str
@@ -164,9 +164,12 @@ class BulkEditMixin:
         action_handler = actions[action]
 
         if hasattr(action_handler, "execute"):
-            action_handler.execute(request, objects)
+            response = action_handler.execute(request, objects)
         else:
-            getattr(self, action)(request, objects)
+            response = getattr(self, action)(request, objects)
+
+        if isinstance(response, HttpResponseBase):
+            return response
 
         return redirect(self.get_success_url(request))
 

--- a/tests/functional/dashboard/test_order.py
+++ b/tests/functional/dashboard/test_order.py
@@ -38,7 +38,10 @@ class TestOrderListDashboard(WebTestCase):
         page = self.get(reverse("dashboard:order-list"))
         form = page.forms["orders_form"]
         form["selected_order"].checked = True
-        form.submit("download_selected")
+        response = form.submit(name="action", value="download_selected_orders")
+        self.assertEqual(http_client.OK, response.status_code)
+        self.assertEqual(response.headers["Content-Type"], "text/csv")
+        self.assertIn("orders.csv", response.headers["Content-Disposition"])
 
     def test_allows_order_number_search(self):
         page = self.get(reverse("dashboard:order-list"))

--- a/tests/functional/dashboard/test_review.py
+++ b/tests/functional/dashboard/test_review.py
@@ -1,4 +1,5 @@
 from datetime import timedelta, timezone as datetime_timezone
+from http import client as http_client
 
 from django.urls import reverse
 from django.utils import timezone
@@ -39,8 +40,10 @@ class ReviewsDashboardTests(WebTestCase):
         list_page = self.get(reverse("dashboard:reviews-list"))
         form = list_page.forms["update_reviews_form"]
         form["selected_review"] = [3, 2]
-        form.submit("update")
+        response = form.submit("update")
 
+        self.assertEqual(http_client.FOUND, response.status_code)
+        self.assertIn(reverse("dashboard:reviews-list"), response.headers["Location"])
         self.assertEqual(ProductReview.objects.get(pk=1).status, 0)
         self.assertEqual(ProductReview.objects.get(pk=2).status, 1)
         self.assertEqual(ProductReview.objects.get(pk=3).status, 1)


### PR DESCRIPTION
Fixes #4613

Fix is simple: if the `BulkEditMixin.post()` action hands back an `HttpResponseBase`, return that instead of redirecting. Otherwise the behaviour is unchanged.

Tests

`test_order.py::test_downloads_to_csv_without_error` now actually checks we get a CSV back 
`test_review.py::test_bulk_editing_review_status` checks the normal redirect flow still works fine

Before fix with the broken 302:

```shell
[2026-08-13 19:28:48,971] "GET /en-gb/dashboard/orders/ HTTP/1.1" 200 36947
[2026-08-13 19:28:56,365] "POST /en-gb/dashboard/orders/ HTTP/1.1" 302 0
```

After fix with the 200 CSV returned correctly

```shell
[2026-08-13 19:30:51,968] "GET /en-gb/dashboard/orders/ HTTP/1.1" 200 36947
[2026-08-13 19:30:55,339] "POST /en-gb/dashboard/orders/ HTTP/1.1" 200 263
```