### PR TITLE
Fix voucher set usage sorting

### DIFF
--- a/src/oscar/apps/dashboard/vouchers/views.py
+++ b/src/oscar/apps/dashboard/vouchers/views.py
@@ -4,7 +4,7 @@ import csv
 from django.conf import settings
 from django.contrib import messages
 from django.db import transaction
-from django.db.models import Count
+from django.db.models import Count, Sum
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse, reverse_lazy
@@ -312,6 +312,10 @@ class VoucherSetListView(generic.ListView):
 
     def get_queryset(self):
         qs = self.model.objects.all().order_by("-date_created")
+        qs = qs.alias(
+            num_basket_additions=Sum("vouchers__num_basket_additions"),
+            num_orders=Sum("vouchers__num_orders"),
+        )
         qs = sort_queryset(
             qs,
             self.request,

--- a/tests/integration/dashboard/test_voucher_views.py
+++ b/tests/integration/dashboard/test_voucher_views.py
@@ -106,6 +106,26 @@ class TestDashboardVoucherSets:
         assert response.context_data["page_obj"]
         assert response.status_code == 200
 
+    @pytest.mark.parametrize(
+        ("sort", "first_total", "second_total"),
+        (
+            ("num_basket_additions", 1, 3),
+            ("num_orders", 2, 4),
+        ),
+    )
+    def test_voucher_set_list_view_sorts_by_usage_totals(
+        self, rf, sort, first_total, second_total
+    ):
+        first_set = voucher.VoucherSetFactory(count=1)
+        second_set = voucher.VoucherSetFactory(count=1)
+        first_set.vouchers.update(**{sort: first_total})
+        second_set.vouchers.update(**{sort: second_total})
+
+        request = rf.get("/", {"sort": sort, "dir": "desc"})
+        response = views.VoucherSetListView.as_view()(request)
+
+        assert list(response.context_data["voucher_sets"]) == [second_set, first_set]
+
     def test_voucher_set_detail_view(self, rf):
         voucher.VoucherSetFactory(count=10)
         vs2 = voucher.VoucherSetFactory(count=15)


### PR DESCRIPTION
## Summary

- add SQL aliases for voucher-set basket-addition and order totals before applying dashboard sorting
- keep the existing property names in the UI while avoiding an invalid `order_by()` on Python properties
- cover descending sorting for both usage totals

Fixes #3978

## Testing

- `venv/bin/pytest -q --sqlite tests/integration/dashboard/test_voucher_views.py::TestDashboardVoucherSets`
- `venv/bin/black --check src/oscar/apps/dashboard/vouchers/views.py tests/integration/dashboard/test_voucher_views.py`